### PR TITLE
tokuft storage engine renamed to PerconaFT.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -243,7 +243,7 @@ add_option( "ssl" , "Enable SSL" , 0 , True )
 add_option( "ssl-fips-capability", "Enable the ability to activate FIPS 140-2 mode", 0, True );
 add_option( "wiredtiger", "Enable wiredtiger", "?", True, "wiredtiger",
             type="choice", choices=["on", "off"], const="on", default="on")
-add_option( "tokuft" , "Enable TokuFT" , 0 , False )
+add_option( "PerconaFT" , "Enable PerconaFT" , 0 , False )
 
 # library choices
 js_engine_choices = ['v8-3.12', 'v8-3.25', 'none']

--- a/jstests/noPassthroughWithMongod/index_multi.js
+++ b/jstests/noPassthroughWithMongod/index_multi.js
@@ -1,4 +1,4 @@
-if (TestData.storageEngine == "tokuft") {
+if (TestData.storageEngine == "PerconaFT") {
     print("Skipping due to MSE-42");
 } else {
 

--- a/jstests/sharding/top_chunk_autosplit.js
+++ b/jstests/sharding/top_chunk_autosplit.js
@@ -312,7 +312,7 @@ var maxSizeTests = [
 
 // Execute all test objects
 // SERVER-17070 Auto split moves to shard node running WiredTiger, if exceeding maxSize
-var unsupported = ["wiredTiger", "rocksdb", "tokuft"];
+var unsupported = ["wiredTiger", "rocksdb", "PerconaFT"];
 if (unsupported.indexOf(st.d0.adminCommand({serverStatus : 1}).storageEngine.name) == -1 &&
     unsupported.indexOf(st.d1.adminCommand({serverStatus : 1}).storageEngine.name) == -1) {
     for (var i = 0; i < maxSizeTests.length; i++) {

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -1078,7 +1078,7 @@ serveronlyLibdeps = ["coreshard",
                      'elapsed_tracker',
                      '$BUILD_DIR/third_party/shim_snappy']
 
-if has_option("tokuft"):
+if has_option("PerconaFT"):
     serveronlyLibdeps.append( 'db/storage/tokuft/storage_tokuft' )
 
 if wiredtiger:

--- a/src/mongo/db/storage/tokuft/SConscript
+++ b/src/mongo/db/storage/tokuft/SConscript
@@ -6,7 +6,7 @@ env.Append(ARCHIVE_ADDITIONS = [env.File('scripts/tokumxse_stat.py')])
 env.Append(ARCHIVE_ADDITION_DIR_MAP = {'src/mongo/db/storage/tokuft/scripts': 'scripts'})
 env.Append(LIBPATH = ['$BUILD_DIR/third_party/tokuft/lib'])
 
-if has_option("tokuft"):
+if has_option("PerconaFT"):
 
     env.Library(
         target='storage_tokuft_options',

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary.cpp
@@ -212,7 +212,7 @@ namespace mongo {
     }
 
     bool TokuFTDictionary::appendCustomStats(OperationContext *opCtx, BSONObjBuilder* result, double scale ) const {
-        BSONObjBuilder b(result->subobjStart("tokuft"));
+        BSONObjBuilder b(result->subobjStart("PerconaFT"));
         KVDictionary::Stats stats = getStats();
         {
             BSONObjBuilder sizeBuilder(b.subobjStart("size"));

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary.h
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary.h
@@ -142,7 +142,7 @@ namespace mongo {
 
         virtual KVDictionary::Cursor *getCursor(OperationContext *opCtx, const int direction = 1) const;
 
-        virtual const char *name() const { return "tokuft"; }
+        virtual const char *name() const { return "PerconaFT"; }
 
         virtual KVDictionary::Stats getStats() const;
     

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary_options.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary_options.cpp
@@ -47,7 +47,7 @@ namespace mongo {
     }
 
     std::string TokuFTDictionaryOptions::optionName(const std::string& opt) const {
-        return str::stream() << "storage.tokuft." << _objectName << "Options." << opt;
+        return str::stream() << "storage.PerconaFT." << _objectName << "Options." << opt;
     }
 
     std::string TokuFTDictionaryOptions::shortOptionName(const std::string& opt) const {
@@ -129,7 +129,7 @@ namespace mongo {
 
     Status TokuFTDictionaryOptions::validateOptions(const BSONObj& options) {
         std::set<std::string> found;
-        BSONForEach(elem, options.getObjectField("tokuft")) {
+        BSONForEach(elem, options.getObjectField("PerconaFT")) {
             std::string name(elem.fieldName());
             if (found.find(name) != found.end()) {
                 StringBuilder sb;
@@ -186,7 +186,7 @@ namespace mongo {
     }
 
     TokuFTDictionaryOptions TokuFTDictionaryOptions::mergeOptions(const BSONObj& options) const {
-        BSONObj tokuftOptions = options.getObjectField("tokuft");
+        BSONObj tokuftOptions = options.getObjectField("PerconaFT");
         TokuFTDictionaryOptions merged(*this);
         if (tokuftOptions.hasField("pageSize")) {
             merged.pageSize = tokuftOptions["pageSize"].numberLong();

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary_test.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary_test.cpp
@@ -41,7 +41,7 @@ namespace mongo {
 	virtual KVDictionary* newKVDictionary() {
             std::auto_ptr<OperationContext> opCtx(new OperationContextNoop(newRecoveryUnit()));
 
-            const std::string ident = mongoutils::str::stream() << "TokuFTDictionary-" << _seq++;
+            const std::string ident = mongoutils::str::stream() << "PerconaFTDictionary-" << _seq++;
             Status status = _engine->createKVDictionary(opCtx.get(), ident, KVDictionary::Encoding(), BSONObj());
             invariant(status.isOK());
 

--- a/src/mongo/db/storage/tokuft/tokuft_engine.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_engine.cpp
@@ -270,10 +270,10 @@ namespace mongo {
 
         ftcxx::DBTxn txn(_env);
         _metadataDict.reset(
-            new TokuFTDictionary(_env, txn, "tokuft.metadata", KVDictionary::Encoding(),
+            new TokuFTDictionary(_env, txn, "perconaft.metadata", KVDictionary::Encoding(),
                                  tokuftGlobalOptions.collectionOptions));
         _internalMetadataDict.reset(
-            new TokuFTDictionary(_env, txn, "tokuft-internal.metadata", KVDictionary::Encoding(),
+            new TokuFTDictionary(_env, txn, "perconaft-internal.metadata", KVDictionary::Encoding(),
                                  tokuftGlobalOptions.collectionOptions));
         txn.commit();
 
@@ -359,7 +359,7 @@ namespace mongo {
         const int r = _env.env()->dbremove(_env.env(), _getDBTxn(opCtx).txn(), identStr.c_str(), NULL, 0);
         if (r != 0) {
             return Status(ErrorCodes::InternalError,
-                          str::stream() << "TokuFTEngine::dropKVDictionary - Not found "
+                          str::stream() << "PerconaFTEngine::dropKVDictionary - Not found "
                                         << ident);
         }
         invariant(r == 0);
@@ -417,10 +417,10 @@ namespace mongo {
                 filename = filename.substr(0, filename.size() - 1);
             }
 
-            if (filename == "tokuft.metadata") {
+            if (filename == "perconaft.metadata") {
                 continue;
             }
-            if (filename == "tokuft-internal.metadata") {
+            if (filename == "perconaft-internal.metadata") {
                 continue;
             }
 

--- a/src/mongo/db/storage/tokuft/tokuft_engine_global_accessor.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_engine_global_accessor.cpp
@@ -32,7 +32,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 namespace mongo {
 
     bool globalStorageEngineIsTokuFT() {
-        return storageGlobalParams.engine == "tokuft";
+        return storageGlobalParams.engine == "PerconaFT";
     }
 
     TokuFTEngine* tokuftGlobalEngine() {

--- a/src/mongo/db/storage/tokuft/tokuft_engine_options.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_engine_options.cpp
@@ -47,28 +47,28 @@ namespace mongo {
     Status TokuFTEngineOptions::add(moe::OptionSection* options) {
         moe::OptionSection tokuftOptions("PerconaFT engine options");
 
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.cacheSize",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.cacheSize",
                 "PerconaFTEngineCacheSize", moe::UnsignedLongLong, "PerconaFT engine cache size (bytes)");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.cleanerIterations",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.cleanerIterations",
                 "PerconaFTEngineCleanerIterations", moe::Int, "PerconaFT engine cleaner iterations");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.cleanerPeriod",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.cleanerPeriod",
                 "PerconaFTEngineCleanerPeriod", moe::Int, "PerconaFT engine cleaner period (s)");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.directio",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.directio",
                 "PerconaFTEngineDirectio", moe::Bool, "PerconaFT engine use Direct I/O");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.fsRedzone",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.fsRedzone",
                 "PerconaFTEngineFsRedzone", moe::Int, "PerconaFT engine filesystem redzone");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.journalCommitInterval",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.journalCommitInterval",
                 "PerconaFTEngineJournalCommitInterval", moe::Int, "PerconaFT engine journal commit interval (ms)");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.lockTimeout",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.lockTimeout",
                 "PerconaFTEngineLockTimeout", moe::Int, "PerconaFT engine lock wait timeout (ms)");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.locktreeMaxMemory",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.locktreeMaxMemory",
                 "PerconaFTEngineLocktreeMaxMemory", moe::UnsignedLongLong, "PerconaFT locktree size (bytes)");
         // TODO: MSE-39
-        //tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.directoryForIndexes",
+        //tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.directoryForIndexes",
         //        "PerconaFTEngineDirectoryForIndexes", moe::Bool, "PerconaFT use a separate directory for indexes");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.compressBuffersBeforeEviction",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.compressBuffersBeforeEviction",
                 "PerconaFTEngineCompressBuffersBeforeEviction", moe::Bool, "PerconaFT engine compress buffers before eviction");
-        tokuftOptions.addOptionChaining("storage.tokuft.engineOptions.numCachetableBucketMutexes",
+        tokuftOptions.addOptionChaining("storage.PerconaFT.engineOptions.numCachetableBucketMutexes",
                 "PerconaFTEngineNumCachetableBucketMutexes", moe::Int, "PerconaFT engine num cachetable bucket mutexes");
 
         return options->addSection(tokuftOptions);
@@ -80,8 +80,8 @@ namespace mongo {
 
     Status TokuFTEngineOptions::store(const moe::Environment& params,
                                  const std::vector<std::string>& args) {
-        if (params.count("storage.tokuft.engineOptions.cacheSize")) {
-            cacheSize = params["storage.tokuft.engineOptions.cacheSize"].as<unsigned long long>();
+        if (params.count("storage.PerconaFT.engineOptions.cacheSize")) {
+            cacheSize = params["storage.PerconaFT.engineOptions.cacheSize"].as<unsigned long long>();
             if (cacheSize < (1ULL<<30)) {
                 warning() << "PerconaFT: cacheSize is under 1GB, this is not recommended for production." << std::endl;
             }
@@ -95,69 +95,69 @@ namespace mongo {
                 return Status(ErrorCodes::BadValue, sb.str());
             }
         }
-        if (params.count("storage.tokuft.engineOptions.cleanerIterations")) {
-            cleanerIterations = params["storage.tokuft.engineOptions.cleanerIterations"].as<int>();
+        if (params.count("storage.PerconaFT.engineOptions.cleanerIterations")) {
+            cleanerIterations = params["storage.PerconaFT.engineOptions.cleanerIterations"].as<int>();
             if (cleanerIterations < 0) {
                 StringBuilder sb;
-                sb << "storage.tokuft.engineOptions.cleanerIterations must be >= 0, but attempted to set to: "
+                sb << "storage.PerconaFT.engineOptions.cleanerIterations must be >= 0, but attempted to set to: "
                    << cleanerIterations;
                 return Status(ErrorCodes::BadValue, sb.str());
             }
         }
-        if (params.count("storage.tokuft.engineOptions.cleanerPeriod")) {
-            cleanerPeriod = params["storage.tokuft.engineOptions.cleanerPeriod"].as<int>();
+        if (params.count("storage.PerconaFT.engineOptions.cleanerPeriod")) {
+            cleanerPeriod = params["storage.PerconaFT.engineOptions.cleanerPeriod"].as<int>();
             if (cleanerPeriod < 0) {
                 StringBuilder sb;
-                sb << "storage.tokuft.engineOptions.cleanerPeriod must be >= 0, but attempted to set to: "
+                sb << "storage.PerconaFT.engineOptions.cleanerPeriod must be >= 0, but attempted to set to: "
                    << cleanerPeriod;
                 return Status(ErrorCodes::BadValue, sb.str());
             }
         }
-        if (params.count("storage.tokuft.engineOptions.directio")) {
-            directio = params["storage.tokuft.engineOptions.directio"].as<bool>();
+        if (params.count("storage.PerconaFT.engineOptions.directio")) {
+            directio = params["storage.PerconaFT.engineOptions.directio"].as<bool>();
         }
-        if (params.count("storage.tokuft.engineOptions.fsRedzone")) {
-            fsRedzone = params["storage.tokuft.engineOptions.fsRedzone"].as<int>();
+        if (params.count("storage.PerconaFT.engineOptions.fsRedzone")) {
+            fsRedzone = params["storage.PerconaFT.engineOptions.fsRedzone"].as<int>();
             if (fsRedzone < 0 || fsRedzone > 100) {
                 StringBuilder sb;
-                sb << "storage.tokuft.engineOptions.fsRedzone must be between 0 and 100, but attempted to set to: "
+                sb << "storage.PerconaFT.engineOptions.fsRedzone must be between 0 and 100, but attempted to set to: "
                    << fsRedzone;
                 return Status(ErrorCodes::BadValue, sb.str());
             }
         }
-        if (params.count("storage.tokuft.engineOptions.journalCommitInterval")) {
-            journalCommitInterval = params["storage.tokuft.engineOptions.journalCommitInterval"].as<int>();
+        if (params.count("storage.PerconaFT.engineOptions.journalCommitInterval")) {
+            journalCommitInterval = params["storage.PerconaFT.engineOptions.journalCommitInterval"].as<int>();
             if (journalCommitInterval < 1 || journalCommitInterval > 300) {
                 StringBuilder sb;
-                sb << "storage.tokuft.engineOptions.journalCommitInterval must be between 1 and 300, but attempted to set to: "
+                sb << "storage.PerconaFT.engineOptions.journalCommitInterval must be between 1 and 300, but attempted to set to: "
                    << journalCommitInterval;
                 return Status(ErrorCodes::BadValue, sb.str());
             }
         }
-        if (params.count("storage.tokuft.engineOptions.lockTimeout")) {
-            lockTimeout = params["storage.tokuft.engineOptions.lockTimeout"].as<int>();
+        if (params.count("storage.PerconaFT.engineOptions.lockTimeout")) {
+            lockTimeout = params["storage.PerconaFT.engineOptions.lockTimeout"].as<int>();
             if (lockTimeout < 0 || lockTimeout > 60000) {
                 StringBuilder sb;
-                sb << "storage.tokuft.engineOptions.lockTimeout must be between 0 and 60000, but attempted to set to: "
+                sb << "storage.PerconaFT.engineOptions.lockTimeout must be between 0 and 60000, but attempted to set to: "
                    << lockTimeout;
                 return Status(ErrorCodes::BadValue, sb.str());
             }
         }
-        if (params.count("storage.tokuft.engineOptions.locktreeMaxMemory")) {
-            locktreeMaxMemory = params["storage.tokuft.engineOptions.locktreeMaxMemory"].as<unsigned long long>();
+        if (params.count("storage.PerconaFT.engineOptions.locktreeMaxMemory")) {
+            locktreeMaxMemory = params["storage.PerconaFT.engineOptions.locktreeMaxMemory"].as<unsigned long long>();
             if (lockTimeout < (100LL<<20)) {
                 warning() << "PerconaFT: locktreeMaxMemory is under 100MB, this is not recommended for production." << std::endl;
             }
         }
         // TODO: MSE-39
-        //if (params.count("storage.tokuft.engineOptions.directoryForIndexes")) {
-        //    directoryForIndexes = params["storage.tokuft.engineOptions.directoryForIndexes"].as<bool>();
+        //if (params.count("storage.PerconaFT.engineOptions.directoryForIndexes")) {
+        //    directoryForIndexes = params["storage.PerconaFT.engineOptions.directoryForIndexes"].as<bool>();
         //}
-        if (params.count("storage.tokuft.engineOptions.compressBuffersBeforeEviction")) {
-            compressBuffersBeforeEviction = params["storage.tokuft.engineOptions.compressBuffersBeforeEviction"].as<bool>();
+        if (params.count("storage.PerconaFT.engineOptions.compressBuffersBeforeEviction")) {
+            compressBuffersBeforeEviction = params["storage.PerconaFT.engineOptions.compressBuffersBeforeEviction"].as<bool>();
         }
-        if (params.count("storage.tokuft.engineOptions.numCachetableBucketMutexes")) {
-            numCachetableBucketMutexes = params["storage.tokuft.engineOptions.numCachetableBucketMutexes"].as<int>();
+        if (params.count("storage.PerconaFT.engineOptions.numCachetableBucketMutexes")) {
+            numCachetableBucketMutexes = params["storage.PerconaFT.engineOptions.numCachetableBucketMutexes"].as<int>();
         }
 
         return Status::OK();

--- a/src/mongo/db/storage/tokuft/tokuft_engine_server_status.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_engine_server_status.cpp
@@ -230,7 +230,7 @@ namespace mongo {
 
     class TokuFTServerStatusSection : public ServerStatusSection {
     public:
-        TokuFTServerStatusSection() : ServerStatusSection("tokuft") {}
+        TokuFTServerStatusSection() : ServerStatusSection("PerconaFT") {}
         virtual bool includeByDefault() const { return true; }
 
         BSONObj generateSection(OperationContext *opCtx, const BSONElement &configElement) const {

--- a/src/mongo/db/storage/tokuft/tokuft_engine_test.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_engine_test.cpp
@@ -33,7 +33,7 @@ namespace mongo {
 
     class TokuFTEngineHarnessHelper : public KVHarnessHelper {
     public:
-        TokuFTEngineHarnessHelper() : _dbpath("mongo-tokuft-engine-test") {
+        TokuFTEngineHarnessHelper() : _dbpath("mongo-perconaft-engine-test") {
             boost::filesystem::remove_all(_dbpath.path());
             boost::filesystem::create_directory(_dbpath.path());
             _engine.reset(new TokuFTEngine(_dbpath.path()));

--- a/src/mongo/db/storage/tokuft/tokuft_init.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_init.cpp
@@ -77,7 +77,7 @@ namespace mongo {
             return new TokuFTStorageEngine(params.dbpath, params.dur, options);
         }
         virtual StringData getCanonicalName() const {
-            return "tokuft";
+            return "PerconaFT";
         }
         virtual Status validateCollectionStorageOptions(const BSONObj& options) const {
             return TokuFTDictionaryOptions::validateOptions(options);
@@ -113,7 +113,7 @@ namespace mongo {
     MONGO_INITIALIZER_WITH_PREREQUISITES(TokuFTStorageEngineInit,
                                          ("SetGlobalEnvironment"))
                                          (InitializerContext *context) {
-        getGlobalEnvironment()->registerStorageEngine("tokuft", new TokuFTFactory());
+        getGlobalEnvironment()->registerStorageEngine("PerconaFT", new TokuFTFactory());
         return Status::OK();
     }
 

--- a/src/mongo/db/storage/tokuft/tokuft_record_store_test.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_record_store_test.cpp
@@ -45,7 +45,7 @@ namespace mongo {
         virtual RecordStore* newNonCappedRecordStore() {
             std::auto_ptr<OperationContext> opCtx(new OperationContextNoop(newRecoveryUnit()));
 
-            const std::string ident = mongoutils::str::stream() << "TokuFTRecordStore-" << _seq++;
+            const std::string ident = mongoutils::str::stream() << "PerconaFTRecordStore-" << _seq++;
             Status status = _engine->createRecordStore(opCtx.get(), "ns", ident, CollectionOptions());
             invariant(status.isOK());
 

--- a/src/mongo/db/storage/tokuft/tokuft_recovery_unit.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_recovery_unit.cpp
@@ -131,7 +131,7 @@ namespace mongo {
     //
     
     void *TokuFTRecoveryUnit::writingPtr(void *data, size_t len) {
-        log() << "tokuft-engine: writingPtr does nothing" << std::endl;
+        log() << "PerconaFT-engine: writingPtr does nothing" << std::endl;
         return data;
     }
 

--- a/src/mongo/db/storage/tokuft/tokuft_sorted_data_impl_test.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_sorted_data_impl_test.cpp
@@ -45,7 +45,7 @@ namespace mongo {
             // todo unique
             std::auto_ptr<OperationContext> opCtx(new OperationContextNoop(newRecoveryUnit()));
 
-            const std::string ident = mongoutils::str::stream() << "TokuFTSortedDataInterface-" << _seq++;
+            const std::string ident = mongoutils::str::stream() << "PerconaFTSortedDataInterface-" << _seq++;
             Status status = _engine->createSortedDataInterface(opCtx.get(), ident, NULL);
             invariant(status.isOK());
 


### PR DESCRIPTION
SCons option to build with FT support also renamed from --tokuft to --PerconaFT
The only place where I left tokuft name is src/mongo/db/storage/tokuft/tokuft_disk_format.cpp file. There are two constants:

    const Slice TokuFTDiskFormatVersion::versionInfoKey("tokuftDiskFormatVersionInfo");
    const BSONField<std::string> TokuFTDiskFormatVersion::tokuftGitField("tokuftGitVersion");

Those constants are read from file and then there is some logic to determine if file version is compatible with running version of MOngoDB. Thus if we will change these constants then our code will become incompatible with existing datafiles.

So to change these constants we also need to change logic in this file.