### PR TITLE
fixed unquoted user in createUser line

### DIFF
--- a/docs/external_authentication/README.md
+++ b/docs/external_authentication/README.md
@@ -33,7 +33,7 @@ An authentication session in this environment moves from component to component 
 Use the following command to add an external user to the mongod server:
 
 ```
-$ db.getSiblingDB("$external").createUser( {user : christian, roles: [ {role: "read", db: "test"} ]} );
+$ db.getSiblingDB("$external").createUser( {user : "christian", roles: [ {role: "read", db: "test"} ]} );
 ```
 
 When running the `mongo` client, a user can authenticate against a given database by using the following command:

--- a/docs/external_authentication/client_and_server_setup.md
+++ b/docs/external_authentication/client_and_server_setup.md
@@ -81,7 +81,7 @@ This assumes that libsasl2 has been installed in the system as a dynamic library
 Use the following command to add an external user to the mongod server:
 
 ```
-$ db.getSiblingDB("$external").createUser( {user : christian, roles: [ {role: "read", db: "test"} ]} );
+$ db.getSiblingDB("$external").createUser( {user : "christian", roles: [ {role: "read", db: "test"} ]} );
 ```
 
 This example assumes that you have setup the server-wide admin user/role and have successfully locally authenticated as that admin user.


### PR DESCRIPTION
the user name should be quoted in createUser (or at least, the unquoted version does not work on my tests). 