### PR TITLE
Create pre-locked key range FT cursors for some index scans.

### DIFF
--- a/src/mongo/db/document_locking_context.h
+++ b/src/mongo/db/document_locking_context.h
@@ -1,0 +1,78 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona Server for MongoDB is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Affero General
+    Public License, version 3, as published by the Free Software
+    Foundation.
+
+    Percona Server for MongoDB is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with Percona Server for MongoDB.  If not, see
+    <http://www.gnu.org/licenses/>.
+======= */
+
+#pragma once
+
+#include "mongo/base/disallow_copying.h"
+
+namespace mongo {
+
+    class BSONObj;
+    class Ordering;
+
+/**
+ * This class/interface provides an API to set and probe the logical
+ * lock state for a set of documents and the operations on those
+ * documents.
+ */
+class DocumentLockingContext {
+    MONGO_DISALLOW_COPYING(DocumentLockingContext);
+
+public:
+    virtual ~DocumentLockingContext() {}
+
+    /**
+     * This method is used by storage engines to determine if the left
+     * and right bounds of a query or scan have been cached and can be
+     * used to create a ranged cursor.  
+     *
+     * NOTE: Derived classes should return true if the left and right
+     * BSON bounds have been set.
+    */
+    virtual bool HasBounds() const { return false; }
+
+    /**
+     * These two methods return pointers to cached left and right BSON
+     * keys, respectively.  Derived classes should return NULL if no
+     * key has been set.
+    */
+    virtual BSONObj *GetLeftBounds() { return NULL; }
+    virtual BSONObj *GetRightBounds() { return NULL; }
+
+    /**
+     * These two methods cache the given (i.e. not owned by THIS
+     * class) BSON key pointers for potential use by a storage engine
+     * cursor.
+    */
+    virtual void SetLeftBounds(BSONObj *left) {};
+    virtual void SetRightBounds(BSONObj *right) {};
+
+    /**
+     * Caches the cursor scan ordering, which may be needed by a
+     * storage engine at the time of cursor creation.
+    */
+    virtual const Ordering *GetCursorOrdering() const { return NULL; }
+    virtual void SetCursorOrdering(const Ordering *order) {};
+
+protected:
+    DocumentLockingContext() {}
+};
+
+}  // namespace mongo

--- a/src/mongo/db/document_range_operation_context.h
+++ b/src/mongo/db/document_range_operation_context.h
@@ -1,0 +1,76 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona Server for MongoDB is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Affero General
+    Public License, version 3, as published by the Free Software
+    Foundation.
+
+    Percona Server for MongoDB is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with Percona Server for MongoDB.  If not, see
+    <http://www.gnu.org/licenses/>.
+======= */
+
+#pragma once
+
+#include "mongo/db/document_locking_context.h"
+#include "mongo/db/operation_context.h"
+#include "mongo/db/storage/kv/slice.h"
+
+namespace mongo {
+
+/**
+ *  This class implements all the methods needed to help storage
+ *  engines optimize document level locking.
+ */
+class DocumentRangeOperationContext : public OperationContext {
+public:
+    DocumentRangeOperationContext() : _leftKeyIsSet(false), _rightKeyIsSet(false) {}
+    virtual ~DocumentRangeOperationContext() {}
+
+    virtual bool HasBounds() const {
+        return _leftKeyIsSet && _rightKeyIsSet;
+    }
+
+    virtual BSONObj *GetLeftBounds() {
+        return &_left;
+    }
+
+    virtual BSONObj *GetRightBounds() {
+        return &_right;
+    }
+
+    virtual void SetLeftBounds(BSONObj *left) {
+        _left = *left;
+        _leftKeyIsSet = true;
+    }
+
+    virtual void SetRightBounds(BSONObj *right) {
+        _right = *right;
+        _rightKeyIsSet = true;
+    }
+
+    virtual const Ordering *GetCursorOrdering() const {
+        return _ordering;
+    }
+
+    virtual void SetCursorOrdering(const Ordering *order) {
+        _ordering = order;
+    }
+
+private:
+    BSONObj _left;
+    BSONObj _right;
+    bool _leftKeyIsSet;
+    bool _rightKeyIsSet;
+    const Ordering *_ordering;
+};
+
+}  // namespace mongo

--- a/src/mongo/db/exec/index_scan.cpp
+++ b/src/mongo/db/exec/index_scan.cpp
@@ -109,6 +109,8 @@ void IndexScan::initIndexScan() {
     /* NOTE: Had to move cursor creation AFTER setting of key bounds. */
 
     if (_params.bounds.isSimpleRange) {
+        _txn->SetLeftBounds(&_params.bounds.startKey);
+        _txn->SetRightBounds(&_params.bounds.endKey);
         this->createCursor(cursorOptions, &cursor);
 
         // Start at one key, end at another.

--- a/src/mongo/db/exec/index_scan.cpp
+++ b/src/mongo/db/exec/index_scan.cpp
@@ -129,6 +129,8 @@ void IndexScan::initIndexScan() {
         bool startKeyInclusive;
         if (IndexBoundsBuilder::isSingleInterval(
                 _params.bounds, &startKey, &startKeyInclusive, &_endKey, &_endKeyInclusive)) {
+            _txn->SetLeftBounds(&startKey);
+            _txn->SetRightBounds(&_endKey);
             this->createCursor(cursorOptions, &cursor);
             _btreeCursor = static_cast<BtreeIndexCursor*>(_indexCursor.get());
 

--- a/src/mongo/db/exec/index_scan.h
+++ b/src/mongo/db/exec/index_scan.h
@@ -133,6 +133,9 @@ private:
     /** See if the cursor is pointing at or past _endKey, if _endKey is non-empty. */
     void checkEnd();
 
+    /** Helper method for cursor creation. */
+    void createCursor(const CursorOptions& options, IndexCursor **cursor);
+
     // transactional context for read locks. Not owned by us
     OperationContext* _txn;
 

--- a/src/mongo/db/operation_context.h
+++ b/src/mongo/db/operation_context.h
@@ -30,6 +30,7 @@
 
 #include "mongo/base/disallow_copying.h"
 #include "mongo/base/status.h"
+#include "mongo/db/document_locking_context.h"
 #include "mongo/db/storage/recovery_unit.h"
 #include "mongo/db/concurrency/locker.h"
 #include "mongo/db/concurrency/d_concurrency.h"
@@ -52,7 +53,7 @@ class StringData;
  * destruction it deassociates itself. At any time a client can be associated with at most one
  * OperationContext.
  */
-class OperationContext {
+class OperationContext : public DocumentLockingContext {
     MONGO_DISALLOW_COPYING(OperationContext);
 
 public:

--- a/src/mongo/db/operation_context_impl.h
+++ b/src/mongo/db/operation_context_impl.h
@@ -29,13 +29,12 @@
 
 #include <boost/scoped_ptr.hpp>
 #include <string>
-
+#include "mongo/db/document_range_operation_context.h"
 #include "mongo/db/operation_context.h"
-
 
 namespace mongo {
 
-class OperationContextImpl : public OperationContext {
+class OperationContextImpl : public DocumentRangeOperationContext {
 public:
     OperationContextImpl();
 

--- a/src/mongo/db/storage/kv/dictionary/kv_dictionary.h
+++ b/src/mongo/db/storage/kv/dictionary/kv_dictionary.h
@@ -337,7 +337,9 @@ namespace mongo {
          */
         virtual Cursor *getCursor(OperationContext *opCtx, const Slice &key, const int direction = 1) const = 0;
 
-        virtual Cursor *getCursor(OperationContext *opCtx, const int direction = 1) const = 0;
+        virtual Cursor *getRangedCursor(OperationContext *opCtx, const Slice &key, const int direction = 1) const = 0;
+
+        virtual Cursor *getRangedCursor(OperationContext *opCtx, const int direction = 1) const = 0;
     };
 
 } // namespace mongo

--- a/src/mongo/db/storage/kv/dictionary/kv_dictionary_test_harness.cpp
+++ b/src/mongo/db/storage/kv/dictionary/kv_dictionary_test_harness.cpp
@@ -256,7 +256,7 @@ namespace mongo {
                 Slice value;
                 const int direction = 1;
                 unsigned char i = 0;
-                for (scoped_ptr<KVDictionary::Cursor> c(db->getCursor(opCtx.get(), direction));
+                for (scoped_ptr<KVDictionary::Cursor> c(db->getRangedCursor(opCtx.get(), direction));
                      c->ok(); c->advance(opCtx.get()), i++) {
                     ASSERT( c->currKey().as<unsigned char>() == i );
                     ASSERT( c->currVal().as<unsigned char>() == i );
@@ -270,7 +270,7 @@ namespace mongo {
                 Slice value;
                 const int direction = -1;
                 unsigned char i = nKeys - 1;
-                for (scoped_ptr<KVDictionary::Cursor> c(db->getCursor(opCtx.get(), direction));
+                for (scoped_ptr<KVDictionary::Cursor> c(db->getRangedCursor(opCtx.get(), direction));
                      c->ok(); c->advance(opCtx.get()), i--) {
                     ASSERT( c->currKey().as<unsigned char>() == i );
                     ASSERT( c->currVal().as<unsigned char>() == i );
@@ -332,7 +332,7 @@ namespace mongo {
             {
                 const int direction = 1;
                 unsigned char i = 0;
-                for (scoped_ptr<KVDictionary::Cursor> c(db->getCursor(opCtx.get(), direction));
+                for (scoped_ptr<KVDictionary::Cursor> c(db->getRangedCursor(opCtx.get(), direction));
                      c->ok(); c->advance(opCtx.get()), i++) {
                     unsigned char k = c->currKey().as<unsigned char>();
                     ASSERT( remainingKeys.count(k) == 1 );
@@ -386,7 +386,7 @@ namespace mongo {
         {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
-                scoped_ptr<KVDictionary::Cursor> cursor( db->getCursor( opCtx.get(), 1 ) );
+                scoped_ptr<KVDictionary::Cursor> cursor( db->getRangedCursor( opCtx.get(), 1 ) );
                 for (unsigned char i = 0; i < nKeys; i++) {
                     cursor->seek( opCtx.get(), Slice::of(keys[i]) );
                     if ( i % 2 == 0 ) {
@@ -397,7 +397,7 @@ namespace mongo {
                 }
             }
             {
-                scoped_ptr<KVDictionary::Cursor> cursor( db->getCursor( opCtx.get(), -1 ) );
+                scoped_ptr<KVDictionary::Cursor> cursor( db->getRangedCursor( opCtx.get(), -1 ) );
                 for (unsigned char i = 1; i < nKeys; i++) {
                     cursor->seek(opCtx.get(), Slice::of(keys[i]));
                     if ( i % 2 == 0 ) {

--- a/src/mongo/db/storage/kv/dictionary/kv_size_storer.cpp
+++ b/src/mongo/db/storage/kv/dictionary/kv_size_storer.cpp
@@ -146,7 +146,7 @@ namespace mongo {
 
         Map m;
         {
-            for (boost::scoped_ptr<KVDictionary::Cursor> cur(_metadataDict->getCursor(opCtx));
+            for (boost::scoped_ptr<KVDictionary::Cursor> cur(_metadataDict->getRangedCursor(opCtx));
                  cur->ok(); cur->advance(opCtx)) {
                 const std::string key(cur->currKey().data(), cur->currKey().size());
                 BSONObj data(cur->currVal().data());

--- a/src/mongo/db/storage/kv/dictionary/kv_sorted_data_impl.cpp
+++ b/src/mongo/db/storage/kv/dictionary/kv_sorted_data_impl.cpp
@@ -180,7 +180,7 @@ namespace mongo {
                                         BSONObjBuilder* output) const {
         if (numKeysOut) {
             *numKeysOut = 0;
-            for (boost::scoped_ptr<KVDictionary::Cursor> cursor(_db->getCursor(txn));
+            for (boost::scoped_ptr<KVDictionary::Cursor> cursor(_db->getRangedCursor(txn));
                  cursor->ok(); cursor->advance(txn)) {
                 ++(*numKeysOut);
             }
@@ -188,7 +188,7 @@ namespace mongo {
     }
 
     bool KVSortedDataImpl::isEmpty( OperationContext* txn ) {
-        boost::scoped_ptr<KVDictionary::Cursor> cursor(_db->getCursor(txn));
+        boost::scoped_ptr<KVDictionary::Cursor> cursor(_db->getRangedCursor(txn));
         return !cursor->ok();
     }
 
@@ -239,7 +239,7 @@ namespace mongo {
             if (_cursor) {
                 return;
             }
-            _cursor.reset(_db->getCursor(_txn, _dir));
+            _cursor.reset(_db->getRangedCursor(_txn, _dir));
         }
 
         void invalidateCache() {
@@ -280,7 +280,7 @@ namespace mongo {
 
         bool _locate(const KeyString &ks) {
             invalidateCache();
-            _cursor.reset(_db->getCursor(_txn, Slice::of(ks), _dir));
+            _cursor.reset(_db->getRangedCursor(_txn, Slice::of(ks), _dir));
             return !isEOF() &&
                     ks.getSize() == _cursor->currKey().size() &&
                     memcmp(ks.getBuffer(), _cursor->currKey().data(), ks.getSize()) == 0;

--- a/src/mongo/db/storage/kv/dictionary/kv_sorted_data_impl.cpp
+++ b/src/mongo/db/storage/kv/dictionary/kv_sorted_data_impl.cpp
@@ -304,7 +304,9 @@ namespace mongo {
               _typeBits(),
               _savedLoc(),
               _initialized(false)
-        {}
+        {
+            _txn->SetCursorOrdering(&_ordering);
+        }
 
         virtual ~KVSortedDataInterfaceCursor() {}
 

--- a/src/mongo/db/storage/kv_heap/kv_heap_dictionary.cpp
+++ b/src/mongo/db/storage/kv_heap/kv_heap_dictionary.cpp
@@ -167,7 +167,11 @@ namespace mongo {
         return new Cursor(_map, _cmp, key, direction);
     }
 
-    KVDictionary::Cursor *KVHeapDictionary::getCursor(OperationContext *opCtx, const int direction) const {
+    KVDictionary::Cursor *KVHeapDictionary::getRangedCursor(OperationContext *opCtx, const Slice &key, const int direction) const {
+        return new Cursor(_map, _cmp, key, direction);
+    }
+
+    KVDictionary::Cursor *KVHeapDictionary::getRangedCursor(OperationContext *opCtx, const int direction) const {
         return new Cursor(_map, _cmp, direction);
     }
 

--- a/src/mongo/db/storage/kv_heap/kv_heap_dictionary.h
+++ b/src/mongo/db/storage/kv_heap/kv_heap_dictionary.h
@@ -117,7 +117,9 @@ namespace mongo {
 
         KVDictionary::Cursor *getCursor(OperationContext *opCtx, const Slice &key, const int direction = 1) const;
 
-        KVDictionary::Cursor *getCursor(OperationContext *opCtx, const int direction = 1) const;
+        KVDictionary::Cursor *getRangedCursor(OperationContext *opCtx, const Slice &key, const int direction = 1) const;
+
+        KVDictionary::Cursor *getRangedCursor(OperationContext *opCtx, const int direction = 1) const;
     };
 
 } // namespace mongo

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary.cpp
@@ -192,6 +192,17 @@ namespace mongo {
 
     KVDictionary::Cursor *TokuFTDictionary::getCursor(OperationContext *opCtx, const Slice &key, const int direction) const {
         try {
+            return new Cursor(*this, opCtx, key, direction);
+        } catch (ftcxx::ft_exception &e) {
+            // Will throw WriteConflictException if needed, discard status
+            statusFromTokuFTException(e);
+            // otherwise rethrow
+            throw;
+        }
+    }
+
+    KVDictionary::Cursor *TokuFTDictionary::getRangedCursor(OperationContext *opCtx, const Slice &key, const int direction) const {
+        try {
             if (OperationShouldPrelockCursor(opCtx)) {
                 return this->CreatePrelockedCursorWithRetryAndStartKey(opCtx, key, direction);
             }
@@ -205,7 +216,7 @@ namespace mongo {
         }
     }
 
-    KVDictionary::Cursor *TokuFTDictionary::getCursor(OperationContext *opCtx, const int direction) const {
+    KVDictionary::Cursor *TokuFTDictionary::getRangedCursor(OperationContext *opCtx, const int direction) const {
         try {
             if (OperationShouldPrelockCursor(opCtx)) {
                 return this->CreatePrelockedCursorWithRetry(opCtx, direction);

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary.cpp
@@ -28,6 +28,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "mongo/base/error_codes.h"
 #include "mongo/base/status.h"
 #include "mongo/db/catalog/collection_options.h"
+#include "mongo/db/concurrency/write_conflict_exception.h"
 #include "mongo/db/index/index_descriptor.h"
 #include "mongo/db/storage/kv/dictionary/kv_sorted_data_impl.h"
 #include "mongo/db/storage/kv/slice.h"
@@ -180,8 +181,21 @@ namespace mongo {
         _rangeOptimizer->updateMaxDeleted(leftId, sizeSaved, docsRemoved);
     }
 
+    static bool OperationShouldPrelockCursor(OperationContext *opCtx) {
+        const bool is_read_only = _getDBTxn(opCtx).is_read_only();
+        if (!is_read_only && opCtx->HasBounds()) {
+            return true;
+        }
+
+        return false;
+    }
+
     KVDictionary::Cursor *TokuFTDictionary::getCursor(OperationContext *opCtx, const Slice &key, const int direction) const {
         try {
+            if (OperationShouldPrelockCursor(opCtx)) {
+                return this->CreatePrelockedCursorWithRetryAndStartKey(opCtx, key, direction);
+            }
+
             return new Cursor(*this, opCtx, key, direction);
         } catch (ftcxx::ft_exception &e) {
             // Will throw WriteConflictException if needed, discard status
@@ -193,6 +207,10 @@ namespace mongo {
 
     KVDictionary::Cursor *TokuFTDictionary::getCursor(OperationContext *opCtx, const int direction) const {
         try {
+            if (OperationShouldPrelockCursor(opCtx)) {
+                return this->CreatePrelockedCursorWithRetry(opCtx, direction);
+            }
+
             return new Cursor(*this, opCtx, direction);
         } catch (ftcxx::ft_exception &e) {
             // Will throw WriteConflictException if needed, discard status
@@ -200,6 +218,74 @@ namespace mongo {
             // otherwise rethrow
             throw;
         }
+    }
+
+    static bool IsATransientLockTreeError(ftcxx::ft_exception &e) {
+        return (e.code() == DB_LOCK_NOTGRANTED) || (e.code() == DB_LOCK_DEADLOCK);
+    }
+
+    KVDictionary::Cursor *TokuFTDictionary::CreatePrelockedCursorWithRetryAndStartKey(OperationContext *opCtx,
+                                                                                      const Slice &key,
+                                                                                      const int direction) const {
+        int attempt = 1;
+        do {
+            try {
+                return this->CreatePrelockedCursorWithStartKey(opCtx, key, direction);
+            } catch (ftcxx::ft_exception &e) {
+                if (IsATransientLockTreeError(e) && (attempt < MAX_WRITE_CONFLICT_RETRIES)) {
+                    WriteConflictException::logAndBackoff(attempt++, "CreatePrelockedCursorWithRetryAndStartKey", opCtx->getNS());
+                } else {
+                    throw;
+                }
+            }
+        } while (true);
+
+        return NULL;
+    }
+
+    KVDictionary::Cursor *TokuFTDictionary::CreatePrelockedCursorWithRetry(OperationContext *opCtx,
+                                                                           const int direction) const {
+        int attempt = 1;
+        do {
+            try {
+                return this->CreatePrelockedCursor(opCtx, direction);
+            } catch (ftcxx::ft_exception &e) {
+                if (IsATransientLockTreeError(e) && (attempt < MAX_WRITE_CONFLICT_RETRIES)) {
+                    WriteConflictException::logAndBackoff(attempt++, "CreatePrelockedCursorWithRetry", opCtx->getNS());
+                } else {
+                    throw;
+                }
+            }
+        } while (true);
+
+        return NULL;
+    }
+
+    KVDictionary::Cursor *TokuFTDictionary::CreatePrelockedCursorWithStartKey(OperationContext *opCtx,
+                                                                              const Slice &key,
+                                                                              const int direction) const {
+        const bool prelock = true;
+        return new Cursor(*this, opCtx, key, prelock, direction);
+    }
+
+    KVDictionary::Cursor *TokuFTDictionary::CreatePrelockedCursor(OperationContext *opCtx,
+                                                                  const int direction) const {
+        BSONObj left = *(opCtx->GetLeftBounds());
+        BSONObj right = *(opCtx->GetRightBounds());
+        const Ordering *ordering = opCtx->GetCursorOrdering();
+        if (direction == 1) {
+            return new Cursor(*this,
+                              opCtx,
+                              Slice::of(KeyString(left, *ordering, RecordId::min())),
+                              Slice::of(KeyString(right, *ordering, RecordId::max())),
+                              direction);
+        }
+
+        return new Cursor(*this,
+                          opCtx,
+                          Slice::of(KeyString(left, *ordering, RecordId::max())),
+                          Slice::of(KeyString(right, *ordering, RecordId::min())),
+                          direction);
     }
 
     KVDictionary::Stats TokuFTDictionary::getStats() const {
@@ -264,10 +350,50 @@ namespace mongo {
         advance(txn);
     }
 
+    TokuFTDictionary::Cursor::Cursor(const TokuFTDictionary &dict,
+                                     OperationContext *txn,
+                                     const Slice &key,
+                                     const bool prelock,
+                                     const int direction)
+        : _cur(dict.db().buffered_cursor(_getDBTxn(txn),
+                                         slice2ftslice(key),
+                                         dict.encoding(),
+                                         ftcxx::DB::NullFilter(),
+                                         0,
+                                         (direction == 1),
+                                         false,
+                                         prelock)),
+          _currKey(), _currVal(), _ok(false)
+    {
+        advance(txn);
+    }
+
     TokuFTDictionary::Cursor::Cursor(const TokuFTDictionary &dict, OperationContext *txn, const int direction)
         : _cur(dict.db().buffered_cursor(_getDBTxn(txn),
                                          dict.encoding(), ftcxx::DB::NullFilter(), 0, (direction == 1))),
           _currKey(), _currVal(), _ok(false)
+    {
+        advance(txn);
+    }
+
+    TokuFTDictionary::Cursor::Cursor(const TokuFTDictionary &dict,
+                                     OperationContext *txn,
+                                     const Slice &leftKey,
+                                     const Slice &rightKey,
+                                     const int direction)
+        // Call pre-locking cursor factory method:
+        : _cur(dict.db().buffered_cursor(_getDBTxn(txn),
+                                         slice2ftslice(leftKey),
+                                         slice2ftslice(rightKey),
+                                         dict.encoding(),
+                                         ftcxx::DB::NullFilter(),
+                                         0, // <- flags
+                                         (direction == 1),
+                                         false, // <-- end_exclusive (no idea)?
+                                         true)), // <-- prelocking),
+          _currKey(),
+          _currVal(),
+          _ok(false)
     {
         advance(txn);
     }

--- a/src/mongo/db/storage/tokuft/tokuft_dictionary.h
+++ b/src/mongo/db/storage/tokuft/tokuft_dictionary.h
@@ -150,7 +150,9 @@ namespace mongo {
 
         virtual KVDictionary::Cursor *getCursor(OperationContext *opCtx, const Slice &key, const int direction = 1) const;
 
-        virtual KVDictionary::Cursor *getCursor(OperationContext *opCtx, const int direction = 1) const;
+        virtual KVDictionary::Cursor *getRangedCursor(OperationContext *opCtx, const Slice &key, const int direction = 1) const;
+
+        virtual KVDictionary::Cursor *getRangedCursor(OperationContext *opCtx, const int direction = 1) const;
 
         virtual const char *name() const { return "PerconaFT"; }
 


### PR DESCRIPTION
These changes allow the fractal tree storage engine to create cursors that pre-lock a range of keys before they are used/consumed/altered by a write operation. In Read-Modify-Write workloads, like db.collection.update() operations, this will help reduce lock contention and improve concurrency.

The high level goal of pre-locking the cursor range is to lock and serialize write access to logical keys before descending deep into the fractal tree, where even more locks will be held. By avoiding this nested locking, other operations will be blocked less by a concurrent write operation.

Note: Changes to the MongoDB source code were required to enable pre-locking. These primarily include a minor refactoring of index scan initialization and some new key range caching methods added to the operation context classes.