### PR TITLE
Another fix for version string in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -408,7 +408,7 @@ except IOError as e:
         Exit(1)
 
     version_data = {
-        'version': utils.getGitDescribe()[1:],
+        'version': re.search(r'\d+\.\d+\.\d+.*', utils.getGitDescribe()).group(0),
         'githash': utils.getGitVersion(),
     }
 


### PR DESCRIPTION
SConstruct uses git describe for version string so it needs to be fixed for our git tags as well (it will skip psmdb- part of tag and just use the version part).