### PR TITLE
Removed separate log backup and destination subdirectory logic.

### DIFF
--- a/src/mongo/db/storage/tokuft/backup/initiator.h
+++ b/src/mongo/db/storage/tokuft/backup/initiator.h
@@ -41,10 +41,9 @@ namespace mongo {
             bool UserWantsToCancelBackup() const;
             void HandleErrorFromBackupProcess(int i, const char *c);
         private:
-            bool SetupDestinationDirectories();
-            bool CreateDestinationSubdirectories();
+            bool SetupDestinationDirectory();
             void HandleFileError(const char *);
-            void ResolveFullPathOfSourceDirectories();
+            void ResolveFullPathOfSourceDirectory();
             int CreateBackup();
             void LogAnyErrors() const;
             inline bool IsOk() const {


### PR DESCRIPTION
In Hot Backup for the Fractal Tree Storage Engine, we do not need a
second directory in the destination directory.  This is because in 3.0
there is no user settable directory for the OpLog nor for the Fractal
Tree recovery log.  This fix only allows taking backups of the files
and directories in the current dbpath.