### PR TITLE
jstests/auth/auth1.js failure on debug build

### DIFF
--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -741,7 +741,10 @@ namespace audit {
                << "db" << username.getDB() 
                << "password" << password 
                << "customData" << (customData ? *customData : BSONObj());
-        appendRoles(params, *roles);
+        if (roles) {
+            appendRoles(params, *roles);
+        }
+
         _auditEvent(client, "updateUser", params.done());
     }
 


### PR DESCRIPTION
This is due to a null pointer exception in the method
mongo::audit::logUpdateUser when audit is enabled (it's always enabled
in debug builds). Calls to db.updateUser() that pass a (valid) null
roles parameter will throw SIGSEGV signal due to a null pointer
deference.

Resolves: Jira PSMDB-56