### PR TITLE
PSMDB-59: fix calculation of cache size

### DIFF
--- a/src/mongo/db/storage/tokuft/tokuft_engine.cpp
+++ b/src/mongo/db/storage/tokuft/tokuft_engine.cpp
@@ -241,7 +241,7 @@ namespace mongo {
         }
 
         uint32_t cacheSizeGB = cacheSize >> 30;
-        uint32_t cacheSizeB = cacheSize & ~uint32_t(1<<30);
+        uint32_t cacheSizeB = cacheSize & (uint32_t(1<<30)-1);
 
         // TODO: Lock wait timeout callback, lock killed callback
         // TODO: logdir


### PR DESCRIPTION
This is to fix over allocating issue PSMDB-59. Actual issue is not doubling of specified memory but adding additional 2GB when specified cache size has bit 31 set. That is the issue appears when following expression is not zero:

```<specified-size> & (1<<31)```