### PR TITLE
Remove skipPessimisticLocking flag from RecordStore interface

### DIFF
--- a/src/mongo/db/storage/devnull/devnull_kv_engine.cpp
+++ b/src/mongo/db/storage/devnull/devnull_kv_engine.cpp
@@ -90,7 +90,7 @@ public:
         return RecordData(_dummy.objdata(), _dummy.objsize());
     }
 
-    virtual bool findRecord( OperationContext* txn, const RecordId& loc, RecordData* rd, bool skipPessimisticLocking=false ) const {
+    virtual bool findRecord( OperationContext* txn, const RecordId& loc, RecordData* rd ) const {
         return false;
     }
 

--- a/src/mongo/db/storage/ephemeral_for_test/ephemeral_for_test_record_store.cpp
+++ b/src/mongo/db/storage/ephemeral_for_test/ephemeral_for_test_record_store.cpp
@@ -310,7 +310,7 @@ EphemeralForTestRecordStore::EphemeralForTestRecord* EphemeralForTestRecordStore
 
 bool EphemeralForTestRecordStore::findRecord(OperationContext* txn,
                                              const RecordId& loc,
-                                             RecordData* rd, bool skipPessimisticLocking) const {
+                                             RecordData* rd) const {
     Records::const_iterator it = _data->records.find(loc);
     if (it == _data->records.end()) {
         return false;

--- a/src/mongo/db/storage/ephemeral_for_test/ephemeral_for_test_record_store.h
+++ b/src/mongo/db/storage/ephemeral_for_test/ephemeral_for_test_record_store.h
@@ -56,7 +56,7 @@ public:
 
     virtual RecordData dataFor(OperationContext* txn, const RecordId& loc) const;
 
-    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* rd1, bool skipPessimisticLocking=false) const;
+    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* rd1) const;
 
     virtual void deleteRecord(OperationContext* txn, const RecordId& dl);
 

--- a/src/mongo/db/storage/kv/dictionary/kv_record_store.cpp
+++ b/src/mongo/db/storage/kv/dictionary/kv_record_store.cpp
@@ -201,8 +201,16 @@ namespace mongo {
         return rd;
     }
 
-    bool KVRecordStore::findRecord( OperationContext* txn,
-                                    const RecordId& loc, RecordData* out, bool skipPessimisticLocking ) const {
+    bool KVRecordStore::findRecordRelaxed(OperationContext* txn, const RecordId& loc, RecordData* out) const {
+        return _findRecord(txn, loc, out, true);
+    }
+
+    bool KVRecordStore::findRecord(OperationContext* txn, const RecordId& loc, RecordData* out) const {
+        return _findRecord(txn, loc, out, false);
+    }
+
+    bool KVRecordStore::_findRecord(OperationContext* txn, const RecordId& loc, RecordData* out,
+                                    bool skipPessimisticLocking) const {
         RecordData rd = _getDataFor(_db.get(), txn, loc, skipPessimisticLocking);
         if (rd.data() == NULL) {
             return false;

--- a/src/mongo/db/storage/kv/dictionary/kv_record_store.h
+++ b/src/mongo/db/storage/kv/dictionary/kv_record_store.h
@@ -91,10 +91,13 @@ namespace mongo {
 
         virtual RecordData dataFor( OperationContext* txn, const RecordId& loc ) const;
 
+        virtual bool findRecordRelaxed( OperationContext* txn,
+                                        const RecordId& loc,
+                                        RecordData* out ) const;
+
         virtual bool findRecord( OperationContext* txn,
                                  const RecordId& loc,
-                                 RecordData* out,
-                                 bool skipPessimisticLocking=false ) const;
+                                 RecordData* out ) const;
 
         virtual void deleteRecord( OperationContext* txn, const RecordId& dl );
 
@@ -245,6 +248,8 @@ namespace mongo {
         Status _insertRecord(OperationContext *txn, const RecordId &id, const Slice &value);
 
         void _updateStats(OperationContext *txn, long long nrDelta, long long dsDelta);
+
+        bool _findRecord(OperationContext* txn, const RecordId& loc, RecordData* out, bool skipPessimisticLocking) const;
 
         // Internal version of dataFor that takes a KVDictionary - used by
         // the RecordCursor to implement dataFor.

--- a/src/mongo/db/storage/kv/kv_catalog.cpp
+++ b/src/mongo/db/storage/kv/kv_catalog.cpp
@@ -224,7 +224,9 @@ BSONObj KVCatalog::_findEntry(OperationContext* opCtx, StringData ns, RecordId* 
 
     LOG(3) << "looking up metadata for: " << ns << " @ " << dl;
     RecordData data;
-    if (!_rs->findRecord(opCtx, dl, &data, skipPessimisticLocking)) {
+    const bool found = skipPessimisticLocking ? _rs->findRecordRelaxed(opCtx, dl, &data)
+                                              : _rs->findRecord(opCtx, dl, &data);
+    if (!found) {
         // since the in memory meta data isn't managed with mvcc
         // its possible for different transactions to see slightly
         // different things, which is ok via the locking above.

--- a/src/mongo/db/storage/kv/kv_catalog.cpp
+++ b/src/mongo/db/storage/kv/kv_catalog.cpp
@@ -224,9 +224,13 @@ BSONObj KVCatalog::_findEntry(OperationContext* opCtx, StringData ns, RecordId* 
 
     LOG(3) << "looking up metadata for: " << ns << " @ " << dl;
     RecordData data;
-    const bool found = skipPessimisticLocking ? _rs->findRecordRelaxed(opCtx, dl, &data)
-                                              : _rs->findRecord(opCtx, dl, &data);
-    if (!found) {
+    bool recordFound = false;
+    if (skipPessimisticLocking) {
+        recordFound = _rs->findRecordRelaxed(opCtx, dl, &data);
+    } else {
+        recordFound = _rs->findRecord(opCtx, dl, &data);
+    }
+    if (!recordFound) {
         // since the in memory meta data isn't managed with mvcc
         // its possible for different transactions to see slightly
         // different things, which is ok via the locking above.

--- a/src/mongo/db/storage/mmap_v1/heap_record_store_btree.cpp
+++ b/src/mongo/db/storage/mmap_v1/heap_record_store_btree.cpp
@@ -50,7 +50,7 @@ RecordData HeapRecordStoreBtree::dataFor(OperationContext* txn, const RecordId& 
 
 bool HeapRecordStoreBtree::findRecord(OperationContext* txn,
                                       const RecordId& loc,
-                                      RecordData* out, bool skipPessimisticLocking) const {
+                                      RecordData* out) const {
     Records::const_iterator it = _records.find(loc);
     if (it == _records.end())
         return false;

--- a/src/mongo/db/storage/mmap_v1/heap_record_store_btree.h
+++ b/src/mongo/db/storage/mmap_v1/heap_record_store_btree.h
@@ -51,7 +51,7 @@ public:
 
     virtual RecordData dataFor(OperationContext* txn, const RecordId& loc) const;
 
-    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* out, bool skipPessimisticLocking=false) const;
+    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* out) const;
 
     virtual void deleteRecord(OperationContext* txn, const RecordId& dl);
 

--- a/src/mongo/db/storage/mmap_v1/record_store_v1_base.cpp
+++ b/src/mongo/db/storage/mmap_v1/record_store_v1_base.cpp
@@ -175,7 +175,7 @@ RecordData RecordStoreV1Base::dataFor(OperationContext* txn, const RecordId& loc
 
 bool RecordStoreV1Base::findRecord(OperationContext* txn,
                                    const RecordId& loc,
-                                   RecordData* rd, bool skipPessimisticLocking) const {
+                                   RecordData* rd) const {
     // this is a bit odd, as the semantics of using the storage engine imply it _has_ to be.
     // And in fact we can't actually check.
     // So we assume the best.

--- a/src/mongo/db/storage/mmap_v1/record_store_v1_base.h
+++ b/src/mongo/db/storage/mmap_v1/record_store_v1_base.h
@@ -186,7 +186,7 @@ public:
 
     virtual RecordData dataFor(OperationContext* txn, const RecordId& loc) const;
 
-    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* rd, bool skipPessimisticLocking=false) const;
+    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* rd) const;
 
     void deleteRecord(OperationContext* txn, const RecordId& dl);
 

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -349,7 +349,7 @@ public:
      * potentially deleted RecordIds to seek methods if they know that MMAPv1 is not the current
      * storage engine. All new storage engines must support detecting the existence of Records.
      */
-    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* out, bool skipPessimisticLocking=false) const {
+    virtual bool findRecord(OperationContext* txn, const RecordId& loc, RecordData* out) const {
         auto cursor = getCursor(txn);
         auto record = cursor->seekExact(loc);
         if (!record)
@@ -358,6 +358,15 @@ public:
         record->data.makeOwned();  // Unowned data expires when cursor goes out of scope.
         *out = std::move(record->data);
         return true;
+    }
+
+    /**
+     * Relaxed version of findRecord which allows to implement optimistic locking strategy.
+     */
+    virtual bool findRecordRelaxed(OperationContext* txn,
+                                   const RecordId& loc,
+                                   RecordData* out) const {
+        return findRecord(txn, loc, out);
     }
 
     virtual void deleteRecord(OperationContext* txn, const RecordId& dl) = 0;

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -361,7 +361,8 @@ public:
     }
 
     /**
-     * Relaxed version of findRecord which allows to implement optimistic locking strategy.
+     * Relaxed version of findRecord which allows storage engines
+     * to skip a pessimistic locking strategy.
      */
     virtual bool findRecordRelaxed(OperationContext* txn,
                                    const RecordId& loc,

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
@@ -957,7 +957,7 @@ RecordData WiredTigerRecordStore::dataFor(OperationContext* txn, const RecordId&
 
 bool WiredTigerRecordStore::findRecord(OperationContext* txn,
                                        const RecordId& id,
-                                       RecordData* out, bool skipPessimisticLocking) const {
+                                       RecordData* out) const {
     WiredTigerCursor curwrap(_uri, _tableId, true, txn);
     WT_CURSOR* c = curwrap.get();
     invariant(c);

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
@@ -114,7 +114,7 @@ public:
 
     virtual RecordData dataFor(OperationContext* txn, const RecordId& id) const;
 
-    virtual bool findRecord(OperationContext* txn, const RecordId& id, RecordData* out, bool skipPessimisticLocking=false) const;
+    virtual bool findRecord(OperationContext* txn, const RecordId& id, RecordData* out) const;
 
     virtual void deleteRecord(OperationContext* txn, const RecordId& id);
 


### PR DESCRIPTION
Add method `findRecordRelaxed` that allows to implement optimistic locking strategy, and by default calls original `findRecord`.
The reason to add another method and not create overload with the same name is because overriding only one of the methods in derived classes causes gcc to issue warning because of `-Woverloaded-virtual` flag enabled. As we don't want to override both methods or add `using RecordStore::findRecord` to all SE layer implementations (that's what we want to avoid instead) it's simpler to add another method, and give it more reasonable name to improve readability.

Example of the similar problem with overriding one of several virtuals in derived class: http://stackoverflow.com/questions/9995421/gcc-woverloaded-virtual-warnings