### PR TITLE
Organize src/third_party/install build dependencies

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -21,6 +21,7 @@ env.InjectMongoIncludePaths()
 
 # Add needed Percona dependencies
 env.InjectThirdPartyIncludePaths(libraries=['percona_incl'])
+env.Append(LIBPATH = ['#/src/third_party/install/lib'])
 
 env.SConscript(
     dirs=[

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -16,8 +16,11 @@ Import("use_system_version_of_library")
 
 # Boost we need everywhere. 's2' is spammed in all over the place by
 # db/geo unfortunately. pcre is also used many places.
-env.InjectThirdPartyIncludePaths(libraries=['boost', 's2', 'pcre', 'tokuft'])
+env.InjectThirdPartyIncludePaths(libraries=['boost', 's2', 'pcre'])
 env.InjectMongoIncludePaths()
+
+# Add needed Percona dependencies
+env.InjectThirdPartyIncludePaths(libraries=['percona_incl'])
 
 env.SConscript(
     dirs=[

--- a/src/mongo/db/storage/tokuft/SConscript
+++ b/src/mongo/db/storage/tokuft/SConscript
@@ -7,7 +7,6 @@ env.Append(ARCHIVE_ADDITIONS = [env.File('scripts/tokumxse_stat.py')])
 env.Append(ARCHIVE_ADDITION_DIR_MAP = {'src/mongo/db/storage/tokuft/scripts': 'scripts'})
 
 if has_option("PerconaFT"):
-    env.Append(LIBPATH = ['#/src/third_party/install/lib'])
     env.Library(
         target='storage_tokuft_options',
         source=[

--- a/src/third_party/SConscript
+++ b/src/third_party/SConscript
@@ -9,6 +9,7 @@ pcreSuffix = "-8.37"
 mozjsSuffix = '-38'
 
 thirdPartyIncludePathList = [
+    ('percona_incl', '#/src/third_party/install/include'),
     ('s2', '#/src/third_party/s2'),
     ('tz', '#/src/third_party/tz'),
 ]
@@ -71,9 +72,6 @@ if not use_system_version_of_library('yaml'):
 if not use_system_version_of_library('asio'):
     thirdPartyIncludePathList.append(
         ('asio', '#/src/third_party/asio-asio-1-11-0/asio/include'))
-
-thirdPartyIncludePathList.append(
-    ('tokuft', '#/src/third_party/install/include'))
 
 if not use_system_version_of_library('intel_decimal128'):
     thirdPartyIncludePathList.append(


### PR DESCRIPTION
1. Move Percona includes to better places
2. Fix build dependencies when PerconaFT is not being built

Read more in commit descriptions.