### PR TITLE
Implement correct link order for TokuBackup (take 2)

### DIFF
--- a/site_scons/libdeps.py
+++ b/site_scons/libdeps.py
@@ -135,7 +135,10 @@ def __get_syslibdeps(node):
                               "but no suitable library was found during configuration." %
                               (str(node), syslib[len(missing_syslibdep):]))
                         node.get_env().Exit(1)
-                    syslibdeps.append(syslib)
+                    if 'HotBackup' in str(syslib):
+                        syslibdeps.insert(0, syslib)
+                    else:
+                        syslibdeps.append(syslib)
         setattr(node.attributes, cached_var_name, syslibdeps)
     return getattr(node.attributes, cached_var_name)
 

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -257,6 +257,8 @@ mongodLibDeps = [
 
 if has_option('use-cpu-profiler'):
     mongodLibDeps.append('db/cpuprofiler')
+if has_option('tokubackup'):
+    mongodLibDeps.append('db/storage/tokuft/backup/tokubackup')
 
 mongod = env.Program(
     target="mongod",

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -258,10 +258,6 @@ mongodLibDeps = [
 if has_option('use-cpu-profiler'):
     mongodLibDeps.append('db/cpuprofiler')
 
-HotBackup = []
-if has_option("tokubackup"):
-    HotBackup = ['HotBackup']
-
 mongod = env.Program(
     target="mongod",
     source=[
@@ -269,7 +265,6 @@ mongod = env.Program(
         "db/mongod_options_init.cpp",
     ],
     LIBDEPS=mongodLibDeps,
-    SYSLIBDEPS=HotBackup,
 )
 
 env.Default(env.Install('#/', mongod))

--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -710,12 +710,8 @@ if wiredtiger:
 
 if has_option( "PerconaFT" ):
     serveronlyLibdeps.append('storage/tokuft/storage_tokuft')
-
-HotBackupSysLibs = []
 if has_option( "tokubackup" ):
     serveronlyLibdeps.append('storage/tokuft/backup/tokubackup')
-    HotBackupSysLibs = ['HotBackup']
-    
 
 serveronlyEnv.Library(
     target="serveronly",
@@ -733,7 +729,6 @@ env.Library(
         '$BUILD_DIR/mongo/util/net/network',
         'server_options',
     ],
-    SYSLIBDEPS=HotBackupSysLibs,
 )
 
 env.Library(

--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -710,8 +710,6 @@ if wiredtiger:
 
 if has_option( "PerconaFT" ):
     serveronlyLibdeps.append('storage/tokuft/storage_tokuft')
-if has_option( "tokubackup" ):
-    serveronlyLibdeps.append('storage/tokuft/backup/tokubackup')
 
 serveronlyEnv.Library(
     target="serveronly",

--- a/src/mongo/db/storage/tokuft/backup/SConscript
+++ b/src/mongo/db/storage/tokuft/backup/SConscript
@@ -8,4 +8,5 @@ env.Library(target='tokubackup',
                     'throttle_backup_command.cpp',
                     'initiator.cpp'],
             LIBDEPS=[],
+            SYSLIBDEPS=['HotBackup']
 )


### PR DESCRIPTION
1. Move TokuBackup linking directly to mongod LIBDEPS.
2. Make TokuBackup be the first library on the linker's command line by fixing site_scons/libdeps.py script.

Now libHotBackup.a only links into mongod, and everything builds and links fine.