### PR TITLE
fixed KVSortedDataInterfaceCursor's behavior when there is no information if index is unique or not

### DIFF
--- a/src/mongo/db/storage/kv/dictionary/kv_sorted_data_impl.cpp
+++ b/src/mongo/db/storage/kv/dictionary/kv_sorted_data_impl.cpp
@@ -89,7 +89,7 @@ namespace mongo {
                                        const IndexDescriptor* desc)
         : _db(db),
           _ordering(Ordering::make(desc ? desc->keyPattern() : BSONObj())),
-          _dupsAllowed(false)
+          _dupsAllowed(true)
     {
         invariant(_db);
     }


### PR DESCRIPTION
The `KVSortedDataInterfaceCursor::restore` uses `_dupsAllowed` to decide which function to call to restore cursor position: `restoreRespectingDuplicates` or `restoreWithoutDuplicates`.

The problem was `KVSortedDataInterfaceCursor::_dupsAllowed` was set to `false` even though actual index was not unique and contained duplicate keys. Thus `restoreWithoutDuplicates` was called to restore position of cursor over index containing duplicates.

This happened because `KVSortedDataInterfaceCursor::_dupsAllowed` is assigned by `KVSortedDataImpl::newCursor` by assigning a copy of `KVSortedDataImpl::_dupsAllowed`.
`KVSortedDataImpl::_dupsAllowed` was initialized by the `KVSortedDataImpl`'s constructor to default value `false`.

`KVSortedDataImpl::_dupsAllowed` can be altered if `KVSortedDataBuilderImpl` is used with `KVSortedDataImpl`. But this is not the case for mapreduce operation. Thus `KVSortedDataImpl::_dupsAllowed` stays false during mapreduce and leads to `restoreWithoutDuplicates` on non-unique cursor.

To solve this issue i propose to change `KVSortedDataImpl::_dupsAllowed`'s default value assigned by the constructor from `false` to `true`. Thus when `KVSortedDataBuilderImpl` is not involved `restoreRespectingDuplicates` will be used for both unique and non-unique cursors.