### PR TITLE
Add auditAuthorized parameter

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -82,6 +82,21 @@ $ mongod                                \
 --auditFilter '{ "users.user" : "tim" }'
 ```
 
+###auditAuthorized parameter
+By default auditing in Percona Server for MongoDB logs only unauthorized operations.
+With auditAuthorized parameter set to ```true``` both authorized and unauthorized operations will be logged.
+
+To set auditAuthorized parameter at startup run server with following options:
+```
+mongod  --auditDestination=file --setParameter=auditAuthorized=true
+```
+
+You can also change auditAuthorized parameter at runtime with command:
+```
+db.adminCommand({ setParameter: 1, 'auditAuthorized': true });
+```
+
+**Note:** Setting this parameter to ```true``` may strongly affect performance.
 ## Testing
 
 There are dedicated audit JavaScript tests under the jstests/audit directory. To execute all of

--- a/jstests/audit/audit_authz_command.js
+++ b/jstests/audit/audit_authz_command.js
@@ -15,11 +15,24 @@ auditTest(
         var testDB = m.getDB(testDBName);
         var user = createNoPermissionUserForAudit(m, testDB);
 
+        // Admin user logs in
+        var adminDB = m.getDB('admin');
+        adminDB.auth('admin','admin');
+
+        // Admin tries to run a command with auditAuthorized=false and then
+        // with auditAuthorized=true. Only one event should be logged
+        assert.writeOK(testDB.foo.insert({'_id': 1}));
+        testDB.runCommand( {count : 'foo'} );
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        testDB.runCommand( {count : 'foo'} );
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
+        adminDB.logout();
+
         // User (tom) with no permissions logs in.
         var r = testDB.auth('tom', 'tom');
         assert(r);
 
-        // Tom tries to perfom a command.
+        // Tom tries to perform a command.
         testDB.runCommand( {count : 'foo'} );
 
         // Tom logs out.
@@ -28,6 +41,8 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom.
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
@@ -35,6 +50,16 @@ auditTest(
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'count',
             result: 13, // <-- Unauthorized error, see error_codes.err...
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.ns': testDBName + '.' + 'foo',
+            'params.command': 'count',
+            result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }

--- a/jstests/audit/audit_authz_current_op.js
+++ b/jstests/audit/audit_authz_current_op.js
@@ -15,12 +15,27 @@ auditTest(
         var testDB = m.getDB(testDBName);
         var user = createNoPermissionUserForAudit(m, testDB);
 
+        // Admin user logs in
+        var adminDB = m.getDB('admin');
+        adminDB.auth('admin','admin');
+
+        // Admin tries to get current operations first with
+        // auditAuthorized=false and then with auditAuthorized=true. Only
+        // one event should be logged
+        var operation = testDB.currentOp(true);
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        operation = testDB.currentOp(true);
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
+
+        // admin logout
+        adminDB.logout();
+
         // User (tom) with no permissions logs in.
         var r = testDB.auth('tom', 'tom');
         assert(r);
 
-        // Tom tries to get the curret operations..
-        var operation = testDB.currentOp(true);
+        // Tom tries to get the current operations..
+        operation = testDB.currentOp(true);
         // NOTE: This doesn't seem to set the error message on the current db!?!
 
         // Tom logs out.
@@ -29,12 +44,23 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.command': 'currentOp',
             result: 13, // <-- Unauthorized error, see error_codes.err...
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.command': 'currentOp',
+            result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }

--- a/jstests/audit/audit_authz_delete.js
+++ b/jstests/audit/audit_authz_delete.js
@@ -22,7 +22,14 @@ auditTest(
         adminDB.auth('admin','admin');
         assert.writeOK(testDB.foo.insert({'_id': 1}));
         assert.writeOK(testDB.foo.insert({'_id': 2}));
+        assert.writeOK(testDB.foo.insert({'_id': 3}));
+
+        // Admin tries to run an update with auditAuthorized=false and then
+        // with auditAuthorized=true. Only one event should be logged
         assert.writeOK(testDB.foo.remove({'_id': 2}));
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        assert.writeOK(testDB.foo.remove({'_id': 3}));
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
         adminDB.logout();
 
         // User with no permissions logs in.
@@ -37,6 +44,8 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom.
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
@@ -44,6 +53,16 @@ auditTest(
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'delete',
             result: 13, // <-- Unauthorized error, see error_codes.err...
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin.
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.ns': testDBName + '.' + 'foo',
+            'params.command': 'delete',
+            result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }

--- a/jstests/audit/audit_authz_find.js
+++ b/jstests/audit/audit_authz_find.js
@@ -21,6 +21,17 @@ auditTest(
         var adminDB = m.getDB('admin');
         adminDB.auth('admin','admin');
         assert.writeOK(testDB.foo.insert({'_id':1}));
+
+        // Admin tries to run a query with auditAuthorized=false and then
+        // with auditAuthorized=true. Only one event should be logged
+        var cursor = testDB.foo.find( {_id:1} );
+        assert.eq(null, testDB.getLastError());
+        cursor.next();
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        cursor = testDB.foo.find( {_id:1} );
+        assert.eq(null, testDB.getLastError());
+        cursor.next();
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
         adminDB.logout();
 
         // User (tom) with no permissions logs in.
@@ -28,10 +39,10 @@ auditTest(
         assert(r);
 
         // Tom tries to perform a query, but will only
-        // fail when he accecsses the document in the
+        // fail when he accesses the document in the
         // returned cursor.  This will throw, so we 
         // have to ignore that exception in this test.
-        var cursor = testDB.foo.find( {_id:1} );
+        cursor = testDB.foo.find( {_id:1} );
         assert.eq(null, testDB.getLastError());
         assert.throws( function(){ cursor.next(); } );
 
@@ -41,6 +52,8 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
@@ -49,6 +62,17 @@ auditTest(
             'params.command': 'find',
             result: 13, // <-- Unauthorized error, see error_codes.err...
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.ns': testDBName + '.' + 'foo',
+            'params.command': 'find',
+            result: 0, // <-- Authorization successful
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
     },
     { auth:"" }
 );

--- a/jstests/audit/audit_authz_insert.js
+++ b/jstests/audit/audit_authz_insert.js
@@ -16,16 +16,22 @@ auditTest(
         var user = createNoPermissionUserForAudit(m, testDB);
 
         // Admin should be allowed to perform the operation.
-        // NOTE: We expect NOT to see an audit event
-        // when an 'admin' user performs this operation.
+        // NOTE: We expect NOT to see an audit event when 'admin' user
+        // performs this operation with auditAuthorized=false
         var adminDB = m.getDB('admin');
         adminDB.auth('admin','admin');
         assert.writeOK(testDB.foo.insert({'_id': 1}));
+
+        // Admin tries to run another insert with auditAuthorized=true
+        // Only one event should be logged
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        assert.writeOK(testDB.foo.insert({'_id': 2}));
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
         adminDB.logout();
 
         // User with no permissions logs in.
         testDB.auth('tom', 'tom');
-        
+
         // Tom inserts data.
         assert.writeError(testDB.foo.insert({'_id': 2}));
 
@@ -35,6 +41,8 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
@@ -42,6 +50,16 @@ auditTest(
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'insert',
             result: 13, // <-- Unauthorized error, see error_codes.err...
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.ns': testDBName + '.' + 'foo',
+            'params.command': 'insert',
+            result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }

--- a/jstests/audit/audit_authz_kill_op.js
+++ b/jstests/audit/audit_authz_kill_op.js
@@ -20,10 +20,29 @@ auditTest(
         // when an 'admin' user performs this operation.
         var adminDB = m.getDB('admin');
         adminDB.auth('admin','admin');
+
+        // Admin tries to kill an operation with auditAuthorized=false
         var operation = testDB.currentOp(false);
         assert.eq(null, testDB.getLastError());
         var first = operation.inprog[0];
         var id = first.opid;
+        testDB.killOp(id);
+
+        // Admin tries to kill an operation with auditAuthorized=true, only
+        // one operation should be killed
+        operation = testDB.currentOp(false);
+        assert.eq(null, testDB.getLastError());
+        first = operation.inprog[0];
+        id = first.opid;
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        testDB.killOp(id);
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
+
+        // Get next operation id to kill as tom
+        operation = testDB.currentOp(false);
+        assert.eq(null, testDB.getLastError());
+        first = operation.inprog[0];
+        id = first.opid;
         adminDB.logout();
 
         // User (tom) with no permissions logs in.
@@ -39,12 +58,23 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.command': 'killOp',
             result: 13, // <-- Unauthorized error, see error_codes.err...
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.command': 'killOp',
+            result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }

--- a/jstests/audit/audit_authz_update.js
+++ b/jstests/audit/audit_authz_update.js
@@ -21,11 +21,18 @@ auditTest(
         var adminDB = m.getDB('admin');
         adminDB.auth('admin','admin');
         assert.writeOK(testDB.foo.insert({'_id': 1, 'bar':1}));
+
+        // Admin tries to run an update with auditAuthorized=false and then
+        // with auditAuthorized=true only one event should be logged
+        assert.writeOK(testDB.foo.update({'_id':1},{'bar':3}));
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': true });
+        assert.writeOK(testDB.foo.update({'_id':1},{'bar':4}));
+        adminDB.runCommand({ setParameter: 1, 'auditAuthorized': false });
         adminDB.logout();
 
         // User with no permissions logs in.
         testDB.auth('tom', 'tom');
-        
+
         // Tom updates data.
         assert.writeError(testDB.foo.update({'_id':1},{'bar':2}));
 
@@ -35,6 +42,8 @@ auditTest(
         // Verify that audit event was inserted.
         beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
+
+        // Audit event for user tom.
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinFewSecondsBefore(beforeLoad),
@@ -42,6 +51,16 @@ auditTest(
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'update',
             result: 13, // <-- Unauthorized error, see error_codes.err...
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for user admin.
+        assert.eq(1, auditColl.count({
+            atype: "authCheck",
+            ts: withinTheLastFewSeconds(),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'params.ns': testDBName + '.' + 'foo',
+            'params.command': 'update',
+            result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }

--- a/jstests/audit/audit_replset_reconfig.js
+++ b/jstests/audit/audit_replset_reconfig.js
@@ -1,4 +1,5 @@
 // test that replSetReconfig gets audited
+// it doesn't work for now https://jira.mongodb.org/browse/SERVER-20845
 
 if (TestData.testData !== undefined) {
     load(TestData.testData + '/audit/_audit_helpers.js');

--- a/src/mongo/db/audit/audit_options.cpp
+++ b/src/mongo/db/audit/audit_options.cpp
@@ -27,6 +27,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "mongo/base/status.h"
 #include "mongo/db/server_options.h"
+#include "mongo/db/server_parameters.h"
 #include "mongo/db/json.h"
 #include "mongo/util/file.h"
 #include "mongo/util/log.h"
@@ -37,6 +38,12 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "audit_options.h"
 
 namespace mongo {
+    std::atomic<bool> AuditOptions::auditAuthorized(false);
+
+    ExportedServerParameter<bool, ServerParameterType::kStartupAndRuntime>
+        auditAuthorizedParameter(ServerParameterSet::getGlobal(),
+                                 "auditAuthorized",
+                                 &AuditOptions::auditAuthorized);
 
     AuditOptions auditOptions;
 

--- a/src/mongo/db/audit/audit_options.h
+++ b/src/mongo/db/audit/audit_options.h
@@ -50,6 +50,9 @@ namespace optionenvironment {
         // Event destination file path and name, eg '/data/db/audit.json'
         std::string path;
 
+        // Determines if Authz operations with status success are logged
+        static std::atomic<bool> auditAuthorized;
+
         AuditOptions();
         BSONObj toBSON();
     };


### PR DESCRIPTION
This commit adds new server parameter "auditAuthorized". This parameter allows to enable logging operations with successful authorization status to audit log.  It can be set at runtime and startup.
