### PR TITLE
SERVER-15793 pass the old record's size to the stoarage engine's updateRecord

### DIFF
--- a/src/mongo/db/catalog/collection.cpp
+++ b/src/mongo/db/catalog/collection.cpp
@@ -589,8 +589,8 @@ StatusWith<RecordId> Collection::updateDocument(OperationContext* txn,
 
     // This can call back into Collection::recordStoreGoingToMove.  If that happens, the old
     // object is removed from all indexes.
-    StatusWith<RecordId> newLocation = _recordStore->updateRecord(
-        txn, oldLocation, newDoc.objdata(), newDoc.objsize(), _enforceQuota(enforceQuota), this);
+    StatusWith<RecordId> newLocation = _recordStore->updateRecordEx(
+        txn, oldLocation, oldSize, newDoc.objdata(), newDoc.objsize(), _enforceQuota(enforceQuota), this);
 
     if (!newLocation.isOK()) {
         return newLocation;

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -413,6 +413,16 @@ public:
                                               bool enforceQuota,
                                               UpdateNotifier* notifier) = 0;
 
+    virtual StatusWith<RecordId> updateRecordEx(OperationContext* txn,
+                                                const RecordId& oldLocation,
+                                                int oldlen,
+                                                const char* data,
+                                                int len,
+                                                bool enforceQuota,
+                                                UpdateNotifier* notifier) {
+        return updateRecord(txn, oldLocation, data, len, enforceQuota, notifier);
+    }
+
     /**
      * @return Returns 'false' if this record store does not implement
      * 'updatewithDamages'. If this method returns false, 'updateWithDamages' must not be


### PR DESCRIPTION
This is MongoDB part of proposed updateRecord optimization. This is just extension of record store interface with new updateRecordEx method accepting additional oldlen parameter.