### PR TITLE
mongo-tools build modifications

### DIFF
--- a/percona-packaging/debian/rules
+++ b/percona-packaging/debian/rules
@@ -9,6 +9,7 @@ export MONGOTOOLS=bsondump mongostat mongofiles mongoexport mongoimport mongores
 export INSTALLDIR=$(PSMSRC)/install
 export PORTABLE=1
 export TOOLS_TAGS=ssl sasl
+export PATH := /usr/local/go/bin:$(PATH)
 CC = gcc-4.8
 CXX = g++-4.8
 #
@@ -53,10 +54,11 @@ compile-mongo-tools:
 	for tool in $(MONGOTOOLS) ; do \
 		cd $(PSMSRC)/mongo-tools; \
 		. ./set_gopath.sh; \
-		go build -a -o $(PSMSRC)/bin/$$tool -tags "$(TOOLS_TAGS)" $(PSMSRC)/mongo-tools/$$tool/main/$$tool.go ; \
+		. ./set_tools_revision.sh; \
+		go build -a -o $(PSMSRC)/bin/$$tool -ldflags "-X github.com/mongodb/mongo-tools/common/options.Gitspec=$$PSMDB_TOOLS_COMMIT_HASH -X github.com/mongodb/mongo-tools/common/options.VersionStr=$$PSMDB_TOOLS_REVISION" -tags "$(TOOLS_TAGS)" $(PSMSRC)/mongo-tools/$$tool/main/$$tool.go; \
 	done
 
-build: compile-mongo-tools PerconaFT RocksDB TokuBackup percona-server-mongodb
+build: PerconaFT RocksDB TokuBackup percona-server-mongodb compile-mongo-tools
 
 override_dh_auto_install:
 	dh_auto_install

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -15,10 +15,7 @@ Source2:        mongod.service
 Source3:        mongod.default
 Source4:        percona-server-mongodb-helper.sh
 Source5:        mongod.init
-%if 0%{?rhel} < 6
-Source6:        http://jenkins.percona.com/downloads/mongo-tools-ce5-v@@VERSION@@.tar.gz
-%endif
-Source7:        mongod.pp
+Source6:        mongod.pp
 
 BuildRoot:      /var/tmp/%{name}-%{version}-%{release}
 %undefine       _missing_build_ids_terminate_build
@@ -37,10 +34,6 @@ BuildRequires: /usr/bin/scons
 # %if 0%{?rhel} >= 6
 # BuildRequires: policycoreutils-python
 # %endif
-
-%if 0%{?rhel} > 5
-BuildRequires: golang
-%endif
 
 Requires: %{name}-mongos = %{version}-%{release}
 Requires: %{name}-server = %{version}-%{release}
@@ -109,18 +102,7 @@ export PORTABLE=1
 export PSM_TARGETS="mongod mongos mongo"
 export INSTALLDIR=$RPM_BUILD_DIR/install
 export TOOLS_TAGS="ssl sasl"
-
-%if 0%{?rhel} > 5
-# Mongo Tools compilation
-pushd $RPM_BUILD_DIR/%{src_dir}/mongo-tools
-. ./set_gopath.sh
-rm -rf $RPM_BUILD_DIR/%{src_dir}/mongo-tools/vendor/pkg
-mkdir -p $RPM_BUILD_DIR/%{src_dir}/bin
-for tool in bsondump mongostat mongofiles mongoexport mongoimport mongorestore mongodump mongotop mongooplog; do
-  go build -a -x -o $RPM_BUILD_DIR/%{src_dir}/bin/${tool} -tags "${TOOLS_TAGS}" $RPM_BUILD_DIR/%{src_dir}/mongo-tools/${tool}/main/${tool}.go;
-done
-popd
-%endif
+export PATH=/usr/local/go/bin:$PATH
 
 # TokuBackup
 pushd $RPM_BUILD_DIR/%{src_dir}/src/third_party/Percona-TokuBackup/backup
@@ -150,12 +132,23 @@ scons CC=${CC} CXX=${CXX} --audit --release --ssl --opt=on  \
 --PerconaFT --rocksdb --wiredtiger --tokubackup ${PSM_TARGETS}
 popd
 
+# Mongo Tools compilation
+pushd $RPM_BUILD_DIR/%{src_dir}/mongo-tools
+. ./set_gopath.sh
+. ./set_tools_revision.sh
+rm -rf $RPM_BUILD_DIR/%{src_dir}/mongo-tools/vendor/pkg
+mkdir -p $RPM_BUILD_DIR/%{src_dir}/bin
+for tool in bsondump mongostat mongofiles mongoexport mongoimport mongorestore mongodump mongotop mongooplog; do
+  go build -a -x -o $RPM_BUILD_DIR/%{src_dir}/bin/${tool} -ldflags "-X github.com/mongodb/mongo-tools/common/options.Gitspec=${PSMDB_TOOLS_COMMIT_HASH} -X github.com/mongodb/mongo-tools/common/options.VersionStr=${PSMDB_TOOLS_REVISION}" -tags "${TOOLS_TAGS}" $RPM_BUILD_DIR/%{src_dir}/mongo-tools/${tool}/main/${tool}.go
+done
+popd
+
 %install
 #
 rm -rf %{buildroot}
 #
 install -m 755 -d %{buildroot}/etc/selinux/targeted/modules/active/modules
-install -m 644 %{SOURCE7} %{buildroot}/etc/selinux/targeted/modules/active/modules/
+install -m 644 %{SOURCE6} %{buildroot}/etc/selinux/targeted/modules/active/modules/
 #
 install -m 755 -d %{buildroot}/%{_bindir}
 install -m 755 -d %{buildroot}/%{_sysconfdir}
@@ -184,16 +177,9 @@ install -m 755 mongo %{buildroot}/%{_bindir}/
 install -m 755 mongod %{buildroot}/%{_bindir}/
 install -m 755 mongos %{buildroot}/%{_bindir}/
 
-%if 0%{?rhel} > 5
 install -m 755 $RPM_BUILD_DIR/%{src_dir}/bin/* %{buildroot}/%{_bindir}/
-%endif
 
 install -m 644 $RPM_BUILD_DIR/%{src_dir}/manpages/* %{buildroot}/%{_mandir}/man1/
-
-%if 0%{?rhel} < 6
-tar xzf %{SOURCE6} -C $RPM_BUILD_DIR
-cp -av $RPM_BUILD_DIR/mongo-tools-ce5/* %{buildroot}/%{_bindir}/
-%endif
 
 %files
 


### PR DESCRIPTION
Now uses golang 1.5 compiler
version info passed via linker options
Removed non-compiled binary inclusion for Centos5