### PR TITLE
Disallow cache_resident for InMemory engine

### DIFF
--- a/src/mongo/db/storage/inmemory/inmemory_init.cpp
+++ b/src/mongo/db/storage/inmemory/inmemory_init.cpp
@@ -137,8 +137,12 @@ private:
         // Don't change the order as user-defined config string should go
         // AFTER InMemory config to override it if needed
         wiredTigerGlobalOptions.engineConfig += inMemoryGlobalOptions.engineConfig;
+        // Don't change the order as user-defined collection & index config strings should go
+        // BEFORE InMemory configs to disable cache_resident option later
         wiredTigerGlobalOptions.collectionConfig = inMemoryGlobalOptions.collectionConfig;
+        wiredTigerGlobalOptions.collectionConfig += ",cache_resident=false";
         wiredTigerGlobalOptions.indexConfig = inMemoryGlobalOptions.indexConfig;
+        wiredTigerGlobalOptions.indexConfig += ",cache_resident=false";
     }
 };
 }  // namespace


### PR DESCRIPTION
cache_resident=true causes InMemory to eventually overflow and
throw WT_CACHE_FULL error. This happens because of disabling
page eviction and splitting, thus causing pages to grow unlimited.

See for additional info:
https://jira.mongodb.org/browse/WT-2642?focusedCommentId=1280522&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1280522