### PR TITLE
fix audit_replset_reconfig.js issue

### DIFF
--- a/jstests/audit/_audit_helpers.js
+++ b/jstests/audit/_audit_helpers.js
@@ -156,8 +156,8 @@ var loadAuditEventsIntoCollection = function(m, filename, dbname, collname, prim
 
     // there should be no duplicate audit log lines
     assert.commandWorked(auditCollection.createIndex(
-        { atype: 1, ts: 1, local: 1, remote: 1, users: 1, params: 1, result: 1 },
-        { unique: true }
+        { atype: 1, ts: 1, local: 1, remote: 1, users: 1, result: 1 },
+        {}
     ));
 
     return auditCollection;

--- a/jstests/audit/audit_replset_reconfig.js
+++ b/jstests/audit/audit_replset_reconfig.js
@@ -17,7 +17,7 @@ auditTestRepl(
         var newConfig = JSON.parse(JSON.stringify(oldConfig));
         newConfig.version = 200; // tired of playing games with the version
 
-        //var master = replTest.getMaster();
+        //var master = replTest.getPrimary();
         //try {
         //    assert.commandWorked(master.adminCommand({ replSetReconfig: newConfig }));
         //} catch (e) {
@@ -33,7 +33,7 @@ auditTestRepl(
         replTest.nodes.forEach(function(m) { 
             print('audit check looking for old, new: ' +tojson(oldConfig)+', '+tojson(newConfig));
             // We need to import the audit events collection into the master node.
-            auditColl = getAuditEventsCollection(m, replTest.getMaster());
+            auditColl = getAuditEventsCollection(m, replTest.getPrimary());
             assert.eq(1, auditColl.count({
                 atype: "replSetReconfig",
                 // Allow timestamps up to 20 seconds old, since replSetReconfig may be slow


### PR DESCRIPTION
logReplsetReconfig calls added to replication code + audit logging framework fixed to be able to handle ReplsetReconfig audit events
