### PR TITLE
Universal hotbackup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -218,6 +218,11 @@ add_option('audit',
     nargs=0,
 )
 
+add_option('hotbackup',
+    help='Enable Hot Backup',
+    nargs=0,
+)
+
 add_option('tokubackup',
     help='Enable Hot Backup for the Fractal Tree engine.',
     nargs=0,

--- a/buildscripts/resmokeconfig/suites/backup.yml
+++ b/buildscripts/resmokeconfig/suites/backup.yml
@@ -2,6 +2,8 @@ selector:
   js_test:
     roots:
     - jstests/backup/*.js
+    exclude_files:
+    - jstests/backup/_*.js
 
 # backup tests start their own mongod's.
 executor:

--- a/buildscripts/resmokeconfig/suites/backup.yml
+++ b/buildscripts/resmokeconfig/suites/backup.yml
@@ -1,0 +1,17 @@
+selector:
+  js_test:
+    roots:
+    - jstests/backup/*.js
+
+# backup tests start their own mongod's.
+executor:
+  js_test:
+    config:
+      shell_options:
+        nodb: ''
+        readMode: commands
+    fixture:
+      class: MongoDFixture
+      mongod_options:
+        set_parameters:
+          enableTestCommands: 1

--- a/jstests/backup/_backup_helpers.js
+++ b/jstests/backup/_backup_helpers.js
@@ -30,7 +30,7 @@ function backup(conn) {
     var backupPath = MongoRunner.dataPath + 'backup';
     mkdir(backupPath);
     var adminDB = conn.getDB('admin');
-    assert.commandWorked(adminDB.runCommand({createBackup: 1, path: backupPath}));
+    assert.commandWorked(adminDB.runCommand({createBackup: 1, backupDir: backupPath}));
     return backupPath;
 }
 

--- a/jstests/backup/_backup_helpers.js
+++ b/jstests/backup/_backup_helpers.js
@@ -1,3 +1,7 @@
+function getDB(conn) {
+    return conn.getDB('db0');
+}
+
 function fillData(conn, count = 1000) {
     Random.setRandomSeed();
     for (var i = 0, dbs = Random.randInt(10); i < dbs; i++) {

--- a/jstests/backup/_backup_helpers.js
+++ b/jstests/backup/_backup_helpers.js
@@ -1,0 +1,40 @@
+function fillData(conn, count = 1000) {
+    Random.setRandomSeed();
+    for (var i = 0, dbs = Random.randInt(10); i < dbs; i++) {
+        var db = conn.getDB('db' + i);
+        for (var j = 0, colls = Random.randInt(10) + 1; j < colls; j++) {
+            var coll = db.getCollection('coll' + j);
+            var entries = Math.ceil(count / (dbs * colls));
+            for (var k = 0; k < entries; k++) {
+                assert.writeOK(coll.insert({k: k}));
+            }
+        }
+    }
+}
+
+function computeHashes(conn) {
+    hashes = [];
+    // Just go through all possible database names.
+    for (var i = 0; i < 10; i++) {
+        var db = conn.getDB('db' + i);
+        hashes.push(db.runCommand({dbHash: 1}));
+    }
+    return hashes;
+}
+
+function backup(conn) {
+    var backupPath = MongoRunner.dataPath + 'backup';
+    mkdir(backupPath);
+    var adminDB = conn.getDB('admin');
+    assert.commandWorked(adminDB.runCommand({createBackup: 1, path: backupPath}));
+    return backupPath;
+}
+
+assert.hashesEq = function(orig, backup) {
+    assert.eq(orig.length, backup.length, 'hash count doesn\'t match');
+    for (var i = 0, len = orig.length; i < len; i++) {
+        var hashOrig = orig[i];
+        var hashBackup = backup[i];
+        assert.eq(hashOrig.md5, hashBackup.md5, 'original and backup hashes don\'t match');
+    }
+}

--- a/jstests/backup/backup_simple.js
+++ b/jstests/backup/backup_simple.js
@@ -1,0 +1,32 @@
+load('jstests/backup/_backup_helpers.js');
+
+(function() {
+    'use strict';
+
+    // Run the original instance and fill it with data.
+    var dbPath = MongoRunner.dataPath + 'original';
+    var conn = MongoRunner.runMongod({
+        dbpath: dbPath,
+    });
+
+    fillData(conn);
+    var hashesOrig = computeHashes(conn);
+
+    // Create backup.
+    var backupPath = backup(conn);
+    // Ensure we can still write after backup has finished
+    // and the data written doesn't affect backed up values.
+    fillData(conn, 500);
+    MongoRunner.stopMongod(conn);
+
+    // Run the backup instance.
+    var conn = MongoRunner.runMongod({
+        dbpath: backupPath,
+        noCleanData: true,
+    });
+
+    var hashesBackup = computeHashes(conn);
+    assert.hashesEq(hashesOrig, hashesBackup);
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/jstests/backup/backup_simple.js
+++ b/jstests/backup/backup_simple.js
@@ -19,6 +19,13 @@ load('jstests/backup/_backup_helpers.js');
     fillData(conn, 500);
     MongoRunner.stopMongod(conn);
 
+    // Check that backup instanse has engine metadata copied.
+    assert.isnull(MongoRunner.runMongod({
+        dbpath: backupPath,
+        noCleanData: true,
+        storageEngine: 'mmapv1',
+    }));
+
     // Run the backup instance.
     var conn = MongoRunner.runMongod({
         dbpath: backupPath,

--- a/jstests/backup/dest_path.js
+++ b/jstests/backup/dest_path.js
@@ -5,19 +5,19 @@
 
     var db = conn.getDB('test');
     // Non-admin execution
-    assert.commandFailed(db.runCommand({createBackup: 1, path: MongoRunner.dataPath}));
+    assert.commandFailed(db.runCommand({createBackup: 1, backupDir: MongoRunner.dataPath}));
 
     var adminDB = db.getSiblingDB('admin');
 
     // Wrong value format
-    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: 0}));
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, backupDir: 0}));
 
     // Non-existent path
-    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: '/non-existent/path'}));
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, backupDir: '/non-existent/path'}));
 
     // Relative path
-    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: '../usr'}));
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, backupDir: '../usr'}));
 
     // Non-empty backup folder
-    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: '/'}));
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, backupDir: '/'}));
 })();

--- a/jstests/backup/dest_path.js
+++ b/jstests/backup/dest_path.js
@@ -1,0 +1,23 @@
+(function() {
+    'use strict';
+
+    var conn = MongoRunner.runMongod({});
+
+    var db = conn.getDB('test');
+    // Non-admin execution
+    assert.commandFailed(db.runCommand({createBackup: 1, path: MongoRunner.dataPath}));
+
+    var adminDB = db.getSiblingDB('admin');
+
+    // Wrong value format
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: 0}));
+
+    // Non-existent path
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: '/non-existent/path'}));
+
+    // Relative path
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: '../usr'}));
+
+    // Non-empty backup folder
+    assert.commandFailed(adminDB.runCommand({createBackup: 1, path: '/'}));
+})();

--- a/jstests/backup/stats_check.js
+++ b/jstests/backup/stats_check.js
@@ -1,0 +1,32 @@
+load('jstests/backup/_backup_helpers.js');
+
+(function() {
+    'use strict';
+
+    // Run the original instance and fill it with data.
+    var dbPath = MongoRunner.dataPath + 'original';
+    var conn = MongoRunner.runMongod({
+        dbpath: dbPath,
+    });
+
+    fillData(conn);
+    var statsOrig = getDB(conn).runCommand({dbStats: 1});
+    assert.commandWorked(statsOrig);
+
+    // Create backup.
+    var backupPath = backup(conn);
+    MongoRunner.stopMongod(conn);
+
+    // Run the backup instance.
+    var conn = MongoRunner.runMongod({
+        dbpath: backupPath,
+        noCleanData: true,
+    });
+
+    var statsBackup = getDB(conn).runCommand({dbStats: 1});
+    assert.commandWorked(statsBackup);
+    assert.eq(statsOrig.objects, statsBackup.objects, 'objects doesn\'t match');
+    assert.eq(statsOrig.dataSize, statsBackup.dataSize, 'dataSize doesn\'t match');
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/jstests/backup/updates_during_backup.js
+++ b/jstests/backup/updates_during_backup.js
@@ -1,0 +1,67 @@
+// Check that updates don't fail during backup.
+load('jstests/backup/_backup_helpers.js');
+
+var updateWorkers = 3;
+// The minimum speed ratio backup should have compared to normal
+// performance. Otherwise it's not 'hot' as writes are blocked for
+// sufficient time.
+var backupSpeedRatio = 0.7;
+
+function countObjs(conn) {
+    // Just go through all possible database names.
+    var objs = 0;
+    for (var i = 0; i < 10; i++) {
+        var db = conn.getDB('db' + i);
+        objs += db.stats().objects;
+    }
+    return objs;
+}
+
+(function() {
+    'use strict';
+
+    // Run the original instance.
+    var dbPath = MongoRunner.dataPath + 'original';
+    var conn = MongoRunner.runMongod({
+        dbpath: dbPath,
+        port: 20100,
+    });
+    var signal = conn.getDB('signal').signal;
+
+    // Start parallel update workers.
+    var w = [];
+    for (var i = 0; i < updateWorkers; i++) {
+        w[i] = startParallelShell(function() {
+            db = db.getSiblingDB('db' + Random.randInt(10));
+            var coll = db.getCollection('coll' + Random.randInt(10));
+            var signal = db.getSiblingDB('signal').signal;
+            while (signal.findOne() == null) {
+                var key = 'key' + Random.randInt(1000);
+                assert.writeOK(coll.insert({k: 1}));
+            }
+        }, 20100);
+    }
+
+    // Wait for filling in some data.
+    var sleepTime = 1000;
+    sleep(sleepTime);
+
+    // Create backup.
+    var objsSleep = countObjs(conn);
+    var startTime = Date.now();
+    backup(conn);
+
+    // Signal workers.
+    signal.insert({1: 1});
+    var backupTime = Date.now() - startTime;
+
+    for (var i = 0; i < updateWorkers; i++) {
+        assert.eq(0, w[i](), 'wrong shell\'s exit code');
+    }
+
+    // Ensure backup speed is good enough.
+    var objsBackup = countObjs(conn) - objsSleep;
+    assert.gte(objsBackup / backupTime, backupSpeedRatio * objsSleep / sleepTime, 'hot backup is too slow');
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -10,6 +10,7 @@ env.SConscript(
     dirs=[
         'audit',
         'auth',
+        'backup',
         'catalog',
         'commands',
         'concurrency',

--- a/src/mongo/db/backup/SConscript
+++ b/src/mongo/db/backup/SConscript
@@ -1,0 +1,10 @@
+# -*- mode: python -*-
+
+Import("env")
+
+env.Library(
+    target='backup',
+    source=[
+        'backup_commands.cpp',
+    ],
+)

--- a/src/mongo/db/backup/SConscript
+++ b/src/mongo/db/backup/SConscript
@@ -7,4 +7,7 @@ env.Library(
     source=[
         'backup_commands.cpp',
     ],
+    LIBDEPS=[
+        '$BUILD_DIR/mongo/db/storage/engine_extension',
+    ],
 )

--- a/src/mongo/db/backup/SConscript
+++ b/src/mongo/db/backup/SConscript
@@ -9,5 +9,6 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/db/storage/engine_extension',
+        '$BUILD_DIR/mongo/db/storage/storage_options',
     ],
 )

--- a/src/mongo/db/backup/backup_commands.cpp
+++ b/src/mongo/db/backup/backup_commands.cpp
@@ -1,0 +1,75 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (c) 2006, 2016, Percona and/or its affiliates. All rights reserved.
+
+    Percona Server for MongoDB is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Affero General
+    Public License, version 3, as published by the Free Software
+    Foundation.
+
+    Percona Server for MongoDB is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with Percona Server for MongoDB.  If not, see
+    <http://www.gnu.org/licenses/>.
+======= */
+
+#include <boost/filesystem.hpp>
+
+#include "mongo/db/auth/action_type.h"
+#include "mongo/db/commands.h"
+
+using namespace mongo;
+
+namespace percona {
+
+class CreateBackupCommand : public Command {
+public:
+    CreateBackupCommand() : Command("createBackup") {}
+    void help(std::stringstream& help) const override {
+        help << "Creates a hot backup, into the given directory, of the files currently in the "
+                "storage engine's data directory."
+             << std::endl
+             << "{ createBackup: <destination directory> }";
+    }
+    void addRequiredPrivileges(const std::string& dbname,
+                               const BSONObj& cmdObj,
+                               std::vector<Privilege>* out) override {
+        ActionSet actions;
+        actions.addAction(ActionType::startBackup);
+        out->push_back(Privilege(parseResourcePattern(dbname, cmdObj), actions));
+    }
+    bool isWriteCommandForConfigServer() const override {
+        return false;
+    }
+    bool adminOnly() const override {
+        return true;
+    }
+    bool slaveOk() const override {
+        return true;
+    }
+    bool run(mongo::OperationContext* txn,
+             const std::string& db,
+             BSONObj& cmdObj,
+             int options,
+             std::string& errmsg,
+             BSONObjBuilder& result) override;
+} createBackupCmd;
+
+bool CreateBackupCommand::run(mongo::OperationContext* txn,
+                              const std::string& db,
+                              BSONObj& cmdObj,
+                              int options,
+                              std::string& errmsg,
+                              BSONObjBuilder& result) {
+    // TODO: Check if destination directory is empty.
+    // TODO: Get global storage engine interface
+    // TODO: Pass destination directory to SE API.
+    return true;
+}
+
+}  // end of percona namespace.

--- a/src/mongo/db/backup/backup_commands.cpp
+++ b/src/mongo/db/backup/backup_commands.cpp
@@ -41,7 +41,7 @@ public:
         help << "Creates a hot backup, into the given directory, of the files currently in the "
                 "storage engine's data directory."
              << std::endl
-             << "{ createBackup: <destination directory> }";
+             << "{ createBackup: 1, backupDir: <destination directory> }";
     }
     void addRequiredPrivileges(const std::string& dbname,
                                const BSONObj& cmdObj,
@@ -75,7 +75,7 @@ bool CreateBackupCommand::run(mongo::OperationContext* txn,
                               BSONObjBuilder& result) {
     namespace fs = boost::filesystem;
 
-    const std::string& dest = cmdObj["path"].String();
+    const std::string& dest = cmdObj["backupDir"].String();
     fs::path destPath(dest);
 
     // Validate destination directory.

--- a/src/mongo/db/backup/backup_commands.cpp
+++ b/src/mongo/db/backup/backup_commands.cpp
@@ -23,6 +23,7 @@ Copyright (c) 2006, 2016, Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/auth/action_type.h"
 #include "mongo/db/backup/backupable.h"
 #include "mongo/db/commands.h"
+#include "mongo/db/service_context.h"
 #include "mongo/db/storage/engine_extension.h"
 #include "mongo/db/storage/storage_options.h"
 
@@ -97,6 +98,10 @@ bool CreateBackupCommand::run(mongo::OperationContext* txn,
         errmsg = ex.what();
         return false;
     }
+
+    // Flush all files first.
+    auto se = getGlobalServiceContext()->getGlobalStorageEngine();
+    se->flushAllFiles(true);
 
     // Do the backup itself.
     auto ee = getEngineExtension();

--- a/src/mongo/db/backup/backup_commands.cpp
+++ b/src/mongo/db/backup/backup_commands.cpp
@@ -66,7 +66,31 @@ bool CreateBackupCommand::run(mongo::OperationContext* txn,
                               int options,
                               std::string& errmsg,
                               BSONObjBuilder& result) {
-    // TODO: Check if destination directory is empty.
+    namespace fs = boost::filesystem;
+
+    const std::string& dest = cmdObj["path"].String();
+    // Validate destination directory.
+    try {
+        fs::path destPath(dest);
+
+        if (!destPath.is_absolute()) {
+            errmsg = "Destination path must be absolute";
+            return false;
+        }
+
+        if (!fs::is_directory(destPath)) {
+            errmsg = "Destination directory doesn't exist";
+            return false;
+        }
+
+        if (!fs::is_empty(destPath)) {
+            errmsg = "Destination directory is not empty";
+            return false;
+        }
+    } catch (const fs::filesystem_error& ex) {
+        errmsg = ex.what();
+        return false;
+    }
     // TODO: Get global storage engine interface
     // TODO: Pass destination directory to SE API.
     return true;

--- a/src/mongo/db/backup/backupable.h
+++ b/src/mongo/db/backup/backupable.h
@@ -20,24 +20,27 @@ Copyright (c) 2006, 2016, Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
-#include "mongo/db/backup/backupable.h"
+#include <string>
+
+#include "mongo/base/status.h"
 
 namespace percona {
 
 /**
- * Storage engine extension interface.
+ * The interface which provides the ability to perform hot
+ * backups of the storage engine.
  */
-class EngineExtension : public Backupable {
-protected:
-    EngineExtension();
-    virtual ~EngineExtension() {}
-};
+struct Backupable {
+    virtual ~Backupable() {}
 
-/**
- * Returns the singleton EngineExtension to storage engine interface
- * for querying for additional functionality.
- * Caller does not own the pointer.
- */
-EngineExtension* getEngineExtension();
+    /**
+     * Perform hot backup.
+     * @param path destination path to perform backup into.
+     * @return Status code of the operation.
+     */
+    virtual mongo::Status hotBackup(const std::string& path) {
+        return mongo::Status::OK();
+    }
+};
 
 }  // end of percona namespace.

--- a/src/mongo/db/commands/SConscript
+++ b/src/mongo/db/commands/SConscript
@@ -26,6 +26,9 @@ coredbOptionalLibdeps = []
 if has_option('audit'):
     coredbOptionalLibdeps.append('$BUILD_DIR/mongo/db/audit/audit')
 
+if has_option('hotbackup'):
+    coredbOptionalLibdeps.append('$BUILD_DIR/mongo/db/backup/backup')
+
 env.Library(
     target="core",
     source=[

--- a/src/mongo/db/storage/SConscript
+++ b/src/mongo/db/storage/SConscript
@@ -21,6 +21,15 @@ env.SConscript(
 
 
 env.Library(
+    target='engine_extension',
+    source=[
+        'engine_extension.cpp',
+        ],
+    LIBDEPS=[
+        ],
+    )
+
+env.Library(
     target='journal_listener',
     source=[
         'journal_listener.cpp',

--- a/src/mongo/db/storage/engine_extension.cpp
+++ b/src/mongo/db/storage/engine_extension.cpp
@@ -1,0 +1,39 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (c) 2006, 2016, Percona and/or its affiliates. All rights reserved.
+
+    Percona Server for MongoDB is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Affero General
+    Public License, version 3, as published by the Free Software
+    Foundation.
+
+    Percona Server for MongoDB is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with Percona Server for MongoDB.  If not, see
+    <http://www.gnu.org/licenses/>.
+======= */
+
+#include "engine_extension.h"
+
+#include "mongo/util/assert_util.h"
+
+namespace percona {
+
+static EngineExtension* _currentEngine;
+
+EngineExtension::EngineExtension() {
+    verify(_currentEngine == nullptr);
+    _currentEngine = this;
+}
+
+EngineExtension* getEngineExtension() {
+    verify(_currentEngine != nullptr);
+    return _currentEngine;
+}
+
+}  // end of percona namespace.

--- a/src/mongo/db/storage/engine_extension.h
+++ b/src/mongo/db/storage/engine_extension.h
@@ -1,0 +1,41 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (c) 2006, 2016, Percona and/or its affiliates. All rights reserved.
+
+    Percona Server for MongoDB is free software: you can redistribute
+    it and/or modify it under the terms of the GNU Affero General
+    Public License, version 3, as published by the Free Software
+    Foundation.
+
+    Percona Server for MongoDB is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with Percona Server for MongoDB.  If not, see
+    <http://www.gnu.org/licenses/>.
+======= */
+
+#pragma once
+
+namespace percona {
+
+/**
+ * Storage engine extension interface.
+ */
+class EngineExtension {
+protected:
+    EngineExtension();
+    virtual ~EngineExtension() {}
+};
+
+/**
+ * Returns the singleton EngineExtension to storage engine interface
+ * for querying for additional functionality.
+ * Caller does not own the pointer.
+ */
+EngineExtension* getEngineExtension();
+
+}  // end of percona namespace.

--- a/src/mongo/db/storage/kv/SConscript
+++ b/src/mongo/db/storage/kv/SConscript
@@ -12,6 +12,7 @@ env.Library(
         '$BUILD_DIR/mongo/db/index/index_descriptor',
         '$BUILD_DIR/mongo/db/namespace_string',
         '$BUILD_DIR/mongo/db/storage/bson_collection_catalog_entry',
+        '$BUILD_DIR/mongo/db/storage/engine_extension',
         ],
     LIBDEPS_TAGS=[
         # Depends on KVDatabaseCatalogEntry::getIndex, which does not have

--- a/src/mongo/db/storage/kv/kv_engine.h
+++ b/src/mongo/db/storage/kv/kv_engine.h
@@ -36,6 +36,7 @@
 #include "mongo/base/status.h"
 #include "mongo/base/string_data.h"
 #include "mongo/db/catalog/collection_options.h"
+#include "mongo/db/storage/engine_extension.h"
 
 namespace mongo {
 
@@ -47,7 +48,7 @@ class RecoveryUnit;
 class SortedDataInterface;
 class SnapshotManager;
 
-class KVEngine {
+class KVEngine : public percona::EngineExtension {
 public:
     virtual RecoveryUnit* newRecoveryUnit() = 0;
 

--- a/src/mongo/db/storage/wiredtiger/SConscript
+++ b/src/mongo/db/storage/wiredtiger/SConscript
@@ -88,6 +88,7 @@ if wiredtiger:
             'wiredtiger_record_store_mock.cpp',
             ],
         LIBDEPS=['storage_wiredtiger_core',
+                 '$BUILD_DIR/mongo/db/storage/engine_extension',
              ]
         )
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -405,6 +405,34 @@ void WiredTigerKVEngine::endBackup(OperationContext* txn) {
     _backupSession.reset();
 }
 
+Status WiredTigerKVEngine::hotBackup(const std::string& path) {
+    // Open backup cursor in new session, the session will kill the
+    // cursor upon closing.
+    WiredTigerSession sessionBackup(_conn);
+    WT_CURSOR* c = NULL;
+    WT_SESSION* s = sessionBackup.getSession();
+    int ret = s->open_cursor(s, "backup:", NULL, NULL, &c);
+    if (ret != 0) {
+        return wtRCToStatus(ret);
+    }
+
+    // Copy the list of files.
+    boost::filesystem::path srcPath(_path);
+    boost::filesystem::path destPath(path);
+    const char* filename = NULL;
+    while ((ret = c->next(c)) == 0 && (ret = c->get_key(c, &filename)) == 0) {
+        try {
+            boost::filesystem::copy_file(
+                srcPath / filename, destPath / filename, boost::filesystem::copy_option::none);
+        } catch (const boost::filesystem::filesystem_error& ex) {
+            return Status(ErrorCodes::InvalidPath, str::stream() << ex.what());
+        }
+    }
+    if (ret == WT_NOTFOUND)
+        ret = 0;
+    return wtRCToStatus(ret);
+}
+
 void WiredTigerKVEngine::syncSizeInfo(bool sync) const {
     if (!_sizeStorer)
         return;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -109,6 +109,8 @@ public:
 
     virtual void endBackup(OperationContext* txn);
 
+    virtual Status hotBackup(const std::string& path);
+
     virtual int64_t getIdentSize(OperationContext* opCtx, StringData ident);
 
     virtual Status repairIdent(OperationContext* opCtx, StringData ident);


### PR DESCRIPTION
Added `createBackup` command.
WiredTiger & RocksDB are supported.

https://github.com/percona/mongo-rocks/pull/4 & https://github.com/percona/percona-server-mongodb/pull/72 should go first.