### PR TITLE
Fix crash when size storer throws WT_CACHE_FULL during session release

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -413,6 +413,13 @@ void WiredTigerKVEngine::syncSizeInfo(bool sync) const {
         _sizeStorer->syncCache(sync);
     } catch (const WriteConflictException&) {
         // ignore, we'll try again later.
+    } catch (const UserException& ex) {
+        // re-throw exception if it's not WT_CACHE_FULL.
+        if (!_durable && ex.getCode() == ErrorCodes::ExceededMemoryLimit) {
+            error() << "size storer failed to sync cache... ignoring: " << ex.what();
+        } else {
+            throw;
+        }
     }
 }
 


### PR DESCRIPTION
Don't crash in this case as size storer only updates counters that are:
1) already cached by Mongo and are actual as long as the instance is
running (and for Memory Engine - the data is dropped on shutdown, so
counters are always relevant)
2) allowed to be a bit out-of-sync as they are purely informative and
will be synced on the next use of corresponding databases/collections
(in case of persistent storage).