### PR TITLE
SERVER-15793 pass the old record's size to the stoarage engine's updateRecord

### DIFF
--- a/jstests/core/server15793.js
+++ b/jstests/core/server15793.js
@@ -1,0 +1,28 @@
+// Check that data size of the storage grows properly after updates.
+// This checks that updateRecordEx works as expected.
+
+(function() {
+    "use strict";
+
+    var t = db.server15793;
+    t.drop();
+
+    assert.writeOK(t.insert({key: 0}));
+    var stats = db.runCommand({dbStats: 1});
+    assert.commandWorked(stats);
+    var origSize = stats.dataSize;
+
+    // Do some updates of our only document.
+    for (var i = 0; i < 10; i++) {
+        var k = Random.randInt(100).toString();
+        assert.writeOK(t.update({key: i}, {key: (i + 1), k: Random.randInt(100)}));
+    }
+
+    var stats = db.runCommand({dbStats: 1});
+    assert.commandWorked(stats);
+    assert.eq(stats.objects, 1, 'invalid objects value');
+    // Check that our object grew as new fields were added.
+    assert.gt(stats.dataSize, origSize, 'invalid dataSize value');
+    // Check that our object didn't grow to be unexpectedly large.
+    assert.lt(stats.dataSize, 2 * origSize, 'invalid dataSize value');
+}());

--- a/src/mongo/db/catalog/collection.cpp
+++ b/src/mongo/db/catalog/collection.cpp
@@ -591,8 +591,8 @@ StatusWith<RecordId> Collection::updateDocument(OperationContext* txn,
 
     // This can call back into Collection::recordStoreGoingToMove.  If that happens, the old
     // object is removed from all indexes.
-    StatusWith<RecordId> newLocation = _recordStore->updateRecord(
-        txn, oldLocation, newDoc.objdata(), newDoc.objsize(), _enforceQuota(enforceQuota), this);
+    StatusWith<RecordId> newLocation = _recordStore->updateRecordEx(
+        txn, oldLocation, oldSize, newDoc.objdata(), newDoc.objsize(), _enforceQuota(enforceQuota), this);
 
     if (!newLocation.isOK()) {
         return newLocation;

--- a/src/mongo/db/storage/kv/dictionary/kv_record_store.h
+++ b/src/mongo/db/storage/kv/dictionary/kv_record_store.h
@@ -117,6 +117,14 @@ namespace mongo {
                                                   bool enforceQuota,
                                                   UpdateNotifier* notifier );
 
+        virtual StatusWith<RecordId> updateRecordEx( OperationContext* txn,
+                                                    const RecordId& oldLocation,
+                                                    int old_length,
+                                                    const char* data,
+                                                    int len,
+                                                    bool enforceQuota,
+                                                    UpdateNotifier* notifier );
+
         virtual bool updateWithDamagesSupported() const {
             return _db->updateSupported();
         }
@@ -250,6 +258,9 @@ namespace mongo {
         void _updateStats(OperationContext *txn, long long nrDelta, long long dsDelta);
 
         bool _findRecord(OperationContext* txn, const RecordId& loc, RecordData* out, bool skipPessimisticLocking) const;
+
+        StatusWith<RecordId> _updateRecord(OperationContext* txn, const RecordId& oldLocation, int old_length, const char* data,
+                                           int len, bool enforceQuota, UpdateNotifier* notifier);
 
         // Internal version of dataFor that takes a KVDictionary - used by
         // the RecordCursor to implement dataFor.

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -413,6 +413,16 @@ public:
                                               bool enforceQuota,
                                               UpdateNotifier* notifier) = 0;
 
+    virtual StatusWith<RecordId> updateRecordEx(OperationContext* txn,
+                                                const RecordId& oldLocation,
+                                                int oldLen,
+                                                const char* data,
+                                                int len,
+                                                bool enforceQuota,
+                                                UpdateNotifier* notifier) {
+        return updateRecord(txn, oldLocation, data, len, enforceQuota, notifier);
+    }
+
     /**
      * @return Returns 'false' if this record store does not implement
      * 'updatewithDamages'. If this method returns false, 'updateWithDamages' must not be

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
@@ -138,6 +138,14 @@ public:
                                               bool enforceQuota,
                                               UpdateNotifier* notifier);
 
+    virtual StatusWith<RecordId> updateRecordEx(OperationContext* txn,
+                                                const RecordId& oldLocation,
+                                                int old_length,
+                                                const char* data,
+                                                int len,
+                                                bool enforceQuota,
+                                                UpdateNotifier* notifier);
+
     virtual bool updateWithDamagesSupported() const;
 
     virtual StatusWith<RecordData> updateWithDamages(OperationContext* txn,
@@ -265,6 +273,14 @@ private:
     void _increaseDataSize(OperationContext* txn, int64_t amount);
     RecordData _getData(const WiredTigerCursor& cursor) const;
     void _oplogSetStartHack(WiredTigerRecoveryUnit* wru) const;
+
+    StatusWith<RecordId> _updateRecord(OperationContext* txn,
+                                       const RecordId& oldLocation,
+                                       int old_length,
+                                       const char* data,
+                                       int len,
+                                       bool enforceQuota,
+                                       UpdateNotifier* notifier);
 
     const std::string _uri;
     const uint64_t _tableId;  // not persisted


### PR DESCRIPTION
This is MongoDB part of proposed updateRecord optimization. This is just extension of record store interface with new updateRecordEx method accepting additional old_length parameter.

Implemented for WiredTiger, PerconaFT, and RocksDB (https://github.com/percona/mongo-rocks/pull/5).