### PR TITLE
Invert LIBDEP dependency for audit in SCons

### DIFF
--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -6,9 +6,11 @@ Import("rocksdb")
 Import("wiredtiger")
 Import("inmemory")
 
+if has_option('audit'):
+    env.SConscript(dirs='audit')
+
 env.SConscript(
     dirs=[
-        'audit',
         'auth',
         'backup',
         'catalog',

--- a/src/mongo/db/audit/SConscript
+++ b/src/mongo/db/audit/SConscript
@@ -2,4 +2,13 @@
 
 Import("env")
 
-env.Library('audit', ['audit_commands.cpp', 'audit_file.cpp', 'audit_options.cpp', 'audit.cpp'])
+env.Library(
+    target='audit',
+    source=[
+        'audit_commands.cpp',
+        'audit_file.cpp',
+        'audit_options.cpp',
+        'audit.cpp',
+    ],
+    LIBDEPS_DEPENDENTS=['$BUILD_DIR/mongo/db/commands'],
+)

--- a/src/mongo/db/commands/SConscript
+++ b/src/mongo/db/commands/SConscript
@@ -23,9 +23,6 @@ env.Library(
     )
 
 coredbOptionalLibdeps = []
-if has_option('audit'):
-    coredbOptionalLibdeps.append('$BUILD_DIR/mongo/db/audit/audit')
-
 if has_option('hotbackup'):
     coredbOptionalLibdeps.append('$BUILD_DIR/mongo/db/backup/backup')
 


### PR DESCRIPTION
So we don't hack into Mongo's SCons* files and do all the work locally.