### PR TITLE
restore `addShard` audit events after logAddShard was moved to config server…

### DIFF
--- a/src/mongo/s/commands/cluster_add_shard_cmd.cpp
+++ b/src/mongo/s/commands/cluster_add_shard_cmd.cpp
@@ -88,6 +88,12 @@ public:
                      BSONObjBuilder& result) {
         auto parsedRequest = uassertStatusOK(AddShardRequest::parseFromMongosCommand(cmdObj));
 
+        audit::logAddShard(ClientBasic::getCurrent(),
+                           parsedRequest.hasName() ? parsedRequest.getName() : "",
+                           parsedRequest.getConnString().toString(),
+                           parsedRequest.hasMaxSize() ? parsedRequest.getMaxSize()
+                                                      : 0 /*kMaxSizeMBDefault*/);
+
         auto configShard = Grid::get(txn)->shardRegistry()->getConfigShard();
         auto cmdResponseStatus =
             uassertStatusOK(configShard->runCommand(txn,


### PR DESCRIPTION
… (see commit 8dbc6f2d)