### PR TITLE
Add audit::logCreateDatabase event for mmapv1

### DIFF
--- a/jstests/audit/audit_no_createdb_restart.js
+++ b/jstests/audit/audit_no_createdb_restart.js
@@ -1,0 +1,33 @@
+// test that createDatabase isn't audited after restart
+
+if (TestData.testData !== undefined) {
+    load(TestData.testData + '/audit/_audit_helpers.js');
+} else {
+    load('jstests/audit/_audit_helpers.js');
+}
+
+var testDBName = 'audit_no_createdb_restart';
+
+auditTest(
+    'noCreateDatabaseRestart',
+    function(m, restartServer) {
+        testDB = m.getDB(testDBName);
+        assert.commandWorked(testDB.dropDatabase());
+        assert.commandWorked(testDB.createCollection('foo'));
+
+        m.getDB('admin').shutdownServer();
+        var auditPath = getDBPath() + '/auditLog.json';
+        removeFile(auditPath);
+        m = restartServer();
+
+        beforeLoad = Date.now();
+        auditColl = getAuditEventsCollection(m);
+        assert.eq(0, auditColl.count({
+            atype: "createDatabase",
+            ts: withinFewSecondsBefore(beforeLoad),
+            'params.ns': testDBName,
+            result: 0,
+        }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+    },
+    { /* no special mongod options */ }
+);

--- a/src/mongo/db/storage/mmap_v1/mmap_v1_extent_manager.cpp
+++ b/src/mongo/db/storage/mmap_v1/mmap_v1_extent_manager.cpp
@@ -196,6 +196,8 @@ Status MmapV1ExtentManager::init(OperationContext* txn) {
         // Commit the journal and all changes to disk so that even if exceptions occur during
         // subsequent initialization, we won't have uncommited changes during file close.
         getDur().commitNow(txn);
+
+        audit::logCreateDatabase(&cc(), _dbname);
     }
 
     return Status::OK();


### PR DESCRIPTION
Test createDatabase audit event not called for existing dbs after restart.

This is instead of https://github.com/percona/percona-server-mongodb/pull/119