### PR TITLE
Support numa interleaving on Systemd-based Redhat/CentOS hosts

### DIFF
--- a/percona-packaging/conf/mongod.service
+++ b/percona-packaging/conf/mongod.service
@@ -14,7 +14,7 @@ LimitNOFILE=64000
 LimitNPROC=64000
 EnvironmentFile=/etc/@@LOCATION@@/mongod
 ExecStartPre=/usr/bin/percona-server-mongodb-helper.sh
-ExecStart=/usr/bin/env bash -c "/usr/bin/mongod $OPTIONS > ${STDOUT} 2> ${STDERR}"
+ExecStart=/usr/bin/env bash -c "${NUMACTL} /usr/bin/mongod $OPTIONS > ${STDOUT} 2> ${STDERR}"
 PIDFile=/var/run/mongod.pid
 
 [Install]

--- a/percona-packaging/conf/percona-server-mongodb-helper.sh
+++ b/percona-packaging/conf/percona-server-mongodb-helper.sh
@@ -18,6 +18,16 @@ print_error(){
 #
 . /etc/@@LOCATION@@/mongod
 #
+# Handle NUMA access to CPUs (SERVER-3574)
+# This verifies the existence of numactl as well as testing that the command works
+NUMACTL_ARGS="--interleave=all"
+if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
+then
+    NUMACTL="numactl $NUMACTL_ARGS"
+else
+    NUMACTL=""
+fi
+#
 # checking if PerconaFT is used looking at defaults file and daemon config
 defaults=$(echo "${OPTIONS}" | egrep -o 'storageEngine.*PerconaFT' | tr -d '[[:blank:]]' | awk -F'=' '{print $NF}' 2>/dev/null)
 config=$(egrep -o '^[[:blank:]]+engine.*PerconaFT' ${CONF} | tr -d '[[:blank:]]' | awk -F':' '{print $NF}' 2>/dev/null)

--- a/percona-packaging/conf/percona-server-mongodb-helper.sh
+++ b/percona-packaging/conf/percona-server-mongodb-helper.sh
@@ -17,6 +17,7 @@ print_error(){
 }
 #
 . /etc/@@LOCATION@@/mongod
+DAEMON_OPTS="${OPTIONS}"
 #
 # Handle NUMA access to CPUs (SERVER-3574)
 # This verifies the existence of numactl as well as testing that the command works
@@ -24,8 +25,10 @@ NUMACTL_ARGS="--interleave=all"
 if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
 then
     NUMACTL="numactl $NUMACTL_ARGS"
+    DAEMON_OPTS=${DAEMON_OPTS:-"--config $CONF"}
 else
     NUMACTL=""
+    DAEMON_OPTS=${DAEMON_OPTS:-"--config $CONF"}
 fi
 #
 # checking if PerconaFT is used looking at defaults file and daemon config

--- a/percona-packaging/debian/percona-server-mongodb-32-server.mongod.init
+++ b/percona-packaging/debian/percona-server-mongodb-32-server.mongod.init
@@ -74,18 +74,6 @@ if [ -f /etc/default/$NAME ] ; then
 fi
 DAEMON_OPTS="${OPTIONS}"
 
-# Handle NUMA access to CPUs (SERVER-3574)
-# This verifies the existence of numactl as well as testing that the command works
-NUMACTL_ARGS="--interleave=all"
-if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
-then
-  NUMACTL="`which numactl` -- $NUMACTL_ARGS"
-  DAEMON_OPTS=${DAEMON_OPTS:-"--config $CONF"}
-else
-  NUMACTL=""
-  DAEMON_OPTS="-- "${DAEMON_OPTS:-"--config $CONF"}
-fi
-
 if test ! -x $DAEMON; then
   echo "Could not find $DAEMON"
   exit 0

--- a/percona-packaging/debian/percona-server-mongodb-32-server.mongod.init
+++ b/percona-packaging/debian/percona-server-mongodb-32-server.mongod.init
@@ -72,7 +72,6 @@ DIETIME=10
 if [ -f /etc/default/$NAME ] ; then
 	. /etc/default/$NAME
 fi
-DAEMON_OPTS="${OPTIONS}"
 
 if test ! -x $DAEMON; then
   echo "Could not find $DAEMON"

--- a/percona-packaging/redhat/mongod.init
+++ b/percona-packaging/redhat/mongod.init
@@ -27,16 +27,6 @@ if [ -f "$SYSCONFIG" ]; then
     . "$SYSCONFIG"
 fi
 
-# Handle NUMA access to CPUs (SERVER-3574)
-# This verifies the existence of numactl as well as testing that the command works
-NUMACTL_ARGS="--interleave=all"
-if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
-then
-    NUMACTL="numactl $NUMACTL_ARGS"
-else
-    NUMACTL=""
-fi
-
 start()
 {
   # Make sure the default pidfile directory exists

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -39,6 +39,7 @@ Requires: %{name}-mongos = %{version}-%{release}
 Requires: %{name}-server = %{version}-%{release}
 Requires: %{name}-shell = %{version}-%{release}
 Requires: %{name}-tools = %{version}-%{release}
+Requires: numactl
 
 Conflicts: Percona-Server-MongoDB
 


### PR DESCRIPTION
Merged over SERVER-3574 from MongoDB Inc into our systemd-based init scripts. We will now start mongod with 'numactl --interleave=all' if numactl exists.

This was already supported in mongod.init (for non-systemd-based RPMs that use /etc/init.d for init scripts), seen here: https://github.com/percona/percona-server-mongodb/blob/v3.2/percona-packaging/redhat/mongod.init. Only systemd-based hosts are missing this change, so I moved the logic down to /usr/bin/percona-server-mongodb-helper.sh, called by all RPMs on startup (systemd or not).

Redhat/CentOS RPMs will require the 'numactl' package to achieve this (added to Requires: in .spec file).