### PR TITLE
Disable THP on all storage engine types

### DIFF
--- a/percona-packaging/conf/percona-server-mongodb-helper.sh
+++ b/percona-packaging/conf/percona-server-mongodb-helper.sh
@@ -31,13 +31,9 @@ else
     DAEMON_OPTS=${DAEMON_OPTS:-"--config $CONF"}
 fi
 #
-# checking if PerconaFT is used looking at defaults file and daemon config
-defaults=$(echo "${OPTIONS}" | egrep -o 'storageEngine.*PerconaFT' | tr -d '[[:blank:]]' | awk -F'=' '{print $NF}' 2>/dev/null)
-config=$(egrep -o '^[[:blank:]]+engine.*PerconaFT' ${CONF} | tr -d '[[:blank:]]' | awk -F':' '{print $NF}' 2>/dev/null)
-#
-if [ -z "${defaults}" ] && [ -z "${config}" ]; then # nothing to do
-  exit 0
-fi
+# checking if storageEngine is defined twice (in default and config file)
+defaults=$(echo "${OPTIONS}" | egrep -o 'storageEngine.*' | tr -d '[[:blank:]]' | awk -F'=' '{print $NF}' 2>/dev/null)
+config=$(egrep -o '^[[:blank:]]+engine.*' ${CONF} | tr -d '[[:blank:]]' | awk -F':' '{print $NF}' 2>/dev/null)
 #
 if [ -n "${defaults}" ] && [ -n "${config}" ]; then # engine is set in 2 places
   if [ "${defaults}" ==  "${config}" ]; then # it's OK
@@ -47,14 +43,6 @@ if [ -n "${defaults}" ] && [ -n "${config}" ]; then # engine is set in 2 places
     exit 1
   fi
 fi
-#
-if [ -n "${defaults}" ]; then
-  storageEngine=${defaults}
-else
-  storageEngine=${config}
-fi
-# trying to disable THP only if PerconaFT engine is enabled and THP is set to always
-if [ "${storageEngine}" = PerconaFT ]; then
-  fgrep '[always]' ${KTHP}/enabled  > /dev/null 2>&1 && (echo never > ${KTHP}/enabled 2> /dev/null || print_error) || true
-  fgrep '[always]' ${KTHP}/defrag   > /dev/null 2>&1 && (echo never > ${KTHP}/defrag  2> /dev/null || print_error) || true
-fi
+# disable THP
+fgrep '[always]' ${KTHP}/enabled  > /dev/null 2>&1 && (echo never > ${KTHP}/enabled 2> /dev/null || print_error) || true
+fgrep '[always]' ${KTHP}/defrag   > /dev/null 2>&1 && (echo never > ${KTHP}/defrag  2> /dev/null || print_error) || true


### PR DESCRIPTION
Disable THP on all storage engine types, as per MongoDB Production Notes and shell warnings.

Right now we only do this for PerconaFT, resulting with these shell+mongod.log warnings on mongod 3.2 w/WiredTiger, Percona InMemory, MMAPv1 and RocksDB storage engines (unless you disable these manually/externally):

```
2015-04-03T13:37:53.536+0530 I CONTROL  [initandlisten] 
2015-04-03T13:37:53.536+0530 I CONTROL  [initandlisten] ** WARNING:        /sys/kernel/mm/transparent_hugepage/enabled is 'always'.
2015-04-03T13:37:53.536+0530 I CONTROL  [initandlisten] **        We suggest setting it to 'never'
2015-04-03T13:37:53.536+0530 I CONTROL  [initandlisten] 
2015-04-03T13:37:53.537+0530 I CONTROL  [initandlisten] ** WARNING: /sys/kernel/mm/transparent_hugepage/defrag is 'always'.
2015-04-03T13:37:53.537+0530 I CONTROL  [initandlisten] **        We suggest setting it to 'never'
2015-04-03T13:37:53.537+0530 I CONTROL  [initandlisten]
```

As mentioned in MongoDB Production Notes, THP should be disabled for MongoDB usage, regardless of storage engine:

```
Disable Transparent Huge Pages. MongoDB performs better with normal (4096 bytes) virtual memory pages. See Transparent Huge Pages Settings.
```
Links: https://docs.mongodb.com/v3.2/administration/production-notes/#recommended-configuration and https://docs.mongodb.com/v3.2/tutorial/transparent-huge-pages/

This PR moves to disabling THP regardless of engine and also allows the checking for if the storage engine is defined twice (in default and config file) on all engines, not just FT.