### PR TITLE
Enable noPassthrough/index_version_v2.js test for MongoRocks

### DIFF
--- a/jstests/noPassthrough/index_version_v2.js
+++ b/jstests/noPassthrough/index_version_v2.js
@@ -10,7 +10,7 @@
 (function() {
     "use strict";
 
-    const storageEnginesUsingKeyString = new Set(["wiredTiger", "inMemory"]);
+    const storageEnginesUsingKeyString = new Set(["wiredTiger", "inMemory", "rocksdb"]);
 
     function getFeatureCompatibilityVersion(conn) {
         const res = assert.commandWorked(


### PR DESCRIPTION
Requires https://github.com/percona/mongo-rocks/pull/32 to be incorporated first.