### PR TITLE
Fix rocksdb validate() interruption and add fixed test

### DIFF
--- a/buildscripts/resmokeconfig/suites/percona_no_passthrough_with_mongod.yml
+++ b/buildscripts/resmokeconfig/suites/percona_no_passthrough_with_mongod.yml
@@ -1,0 +1,19 @@
+selector:
+  js_test:
+    roots:
+    - jstests/percona/noPassthroughWithMongod/*.js
+
+executor:
+  js_test:
+    config:
+      shell_options:
+        readMode: commands
+    hooks:
+    - class: ValidateCollections
+    - class: CleanEveryN
+      n: 20
+    fixture:
+      class: MongoDFixture
+      mongod_options:
+        set_parameters:
+          enableTestCommands: 1

--- a/jstests/percona/noPassthroughWithMongod/validate_interrupt.js
+++ b/jstests/percona/noPassthroughWithMongod/validate_interrupt.js
@@ -1,0 +1,40 @@
+// Tests that the validate command can be interrupted by timeout specified in 'validate'
+// command. This should cause validate() to fail with an ExceededTimeLimit error.
+// Original validate_interrupt.js has two issues:
+// - 1000 documents is not enough to trigger timeout (at least 4096 is necessary)
+// - using failpoint makes this test to succeed even with those storage engines
+//   which doesn't support interrupting validation
+
+'use strict';
+
+(function() {
+    var t = db.validate_interrupt;
+    t.drop();
+
+    var bulk = t.initializeUnorderedBulkOp();
+
+    var i;
+    for (i = 0; i < 1000000; i++) {
+        bulk.insert({a: i});
+    }
+    assert.writeOK(bulk.execute());
+
+    var res = t.runCommand({validate: t.getName(), full: true, maxTimeMS: 1});
+
+    if (res.ok === 0) {
+        assert.eq(res.code,
+                  ErrorCodes.ExceededTimeLimit,
+                  'validate command did not time out:\n' + tojson(res));
+    } else {
+        // validate() should only succeed if it EBUSY'd. See SERVER-23131.
+        var numWarnings = res.warnings.length;
+        // validate() could EBUSY when verifying the index and/or the RecordStore, so EBUSY could
+        // appear once or twice.
+        assert((numWarnings === 1) || (numWarnings === 2),
+               'Expected 1 or 2 validation warnings:\n' + tojson(res));
+        assert(res.warnings[0].includes('EBUSY'), 'Expected an EBUSY warning:\n' + tojson(res));
+        if (numWarnings === 2) {
+            assert(res.warnings[1].includes('EBUSY'), 'Expected an EBUSY warning:\n' + tojson(res));
+        }
+    }
+})();


### PR DESCRIPTION
Two fixes included:
1. Move  mongo-rocks submodule pointer to corresponding fix in mongo-rocks
2. Add Percona version of validate_interrupt.js test and percona_no_passthrough_with_mongod suite
   because upstream version does not actually test behaviour of 'validate' command with timeout
   (it uses failpoint and thus succeeds even with storage engines which doesn't support interrupting validation)