### PR TITLE
Stabilize audit tests by fixing withinTheLastFewSeconds and surrounding

### DIFF
--- a/jstests/audit/_audit_helpers.js
+++ b/jstests/audit/_audit_helpers.js
@@ -169,11 +169,11 @@ var loadAuditEventsIntoCollection = function(m, filename, dbname, collname, prim
     return auditCollection;
 }
 
-// Get a query that matches any timestamp generated in the last few (or n) seconds
-var withinTheLastFewSeconds = function(n) {
-    now = Date.now();
-    fewSecondsAgo = now - ((n !== undefined ? n : 3) * 1000);
-    return { '$gte' : new Date(fewSecondsAgo), '$lte': new Date(now) };
+// Get a query that matches any timestamp generated in the interval
+// of (t - n) <= t <= now for some time t.
+var withinFewSecondsBefore = function(t, n) {
+    fewSecondsAgo = t - ((n !== undefined ? n : 3) * 1000);
+    return { '$gte' : new Date(fewSecondsAgo), '$lte': new Date() };
 }
 
 // Create Admin user.  Used for authz tests.

--- a/jstests/audit/audit_add_shard.js
+++ b/jstests/audit/audit_add_shard.js
@@ -15,10 +15,11 @@ auditTestShard(
         var hostandport = conn1.host;
         assert.commandWorked(st.s0.adminCommand({addshard: hostandport}));
 
+        beforeLoad = Date.now();
         auditColl = loadAuditEventsIntoCollection(st.s0, getDBPath() + '/auditLog-s0.json', jsTestName(), 'auditEvents');
         assert.eq(1, auditColl.count({
             atype: "addShard",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.connectionString': hostandport,
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_authenticate.js
+++ b/jstests/audit/audit_authenticate.js
@@ -25,10 +25,11 @@ auditTest(
 
         assert(testDB.auth('john', 'john'), "could not auth as john (pwd john)");
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: 'authenticate',
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.user': 'john',
             'params.mechanism': 'SCRAM-SHA-1',
             'params.db': testDBName,
@@ -40,10 +41,11 @@ auditTest(
         // ErrorCodes::AuthenticationFailed in src/mongo/base/error_codes.err
         var authenticationFailureCode = 18;
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: 'authenticate',
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.user': 'john',
             'params.mechanism': 'SCRAM-SHA-1',
             'params.db': testDBName,

--- a/jstests/audit/audit_authz_command.js
+++ b/jstests/audit/audit_authz_command.js
@@ -26,10 +26,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'count',

--- a/jstests/audit/audit_authz_current_op.js
+++ b/jstests/audit/audit_authz_current_op.js
@@ -27,10 +27,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.command': 'currentOp',
             result: 13, // <-- Unauthorized error, see error_codes.err...

--- a/jstests/audit/audit_authz_delete.js
+++ b/jstests/audit/audit_authz_delete.js
@@ -35,10 +35,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'delete',

--- a/jstests/audit/audit_authz_find.js
+++ b/jstests/audit/audit_authz_find.js
@@ -39,10 +39,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'find',

--- a/jstests/audit/audit_authz_get_more.js
+++ b/jstests/audit/audit_authz_get_more.js
@@ -52,10 +52,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'getMore',

--- a/jstests/audit/audit_authz_insert.js
+++ b/jstests/audit/audit_authz_insert.js
@@ -33,10 +33,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'insert',

--- a/jstests/audit/audit_authz_kill_op.js
+++ b/jstests/audit/audit_authz_kill_op.js
@@ -37,10 +37,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.command': 'killOp',
             result: 13, // <-- Unauthorized error, see error_codes.err...

--- a/jstests/audit/audit_authz_update.js
+++ b/jstests/audit/audit_authz_update.js
@@ -33,10 +33,11 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             users: { $elemMatch: { user:'tom', db:testDBName} },
             'params.ns': testDBName + '.' + 'foo',
             'params.command': 'update',

--- a/jstests/audit/audit_create_collection.js
+++ b/jstests/audit/audit_create_collection.js
@@ -14,10 +14,11 @@ auditTest(
         testDB = m.getDB(testDBName);
         assert.commandWorked(testDB.createCollection('foo'));
 
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "createCollection",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName + '.' + 'foo',
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_create_database.js
+++ b/jstests/audit/audit_create_database.js
@@ -15,10 +15,11 @@ auditTest(
         assert.commandWorked(testDB.dropDatabase());
         assert.commandWorked(testDB.createCollection('foo'));
 
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "createDatabase",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName,
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_create_index.js
+++ b/jstests/audit/audit_create_index.js
@@ -18,11 +18,12 @@ auditTest(
 
         assert.commandWorked(testDB.coll.createIndex({ b: 1 }, { name: 'hot', background: true }));
 
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
 
         assert.eq(1, auditColl.count({
             atype: "createIndex",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName + '.coll',
             'params.indexSpec.key': { a: 1 },
             'params.indexName': 'cold',
@@ -31,7 +32,7 @@ auditTest(
 
         assert.eq(1, auditColl.count({
             atype: "createIndex",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName + '.coll' ,
             'params.indexSpec.key': { b: 1 },
             'params.indexName': 'hot',

--- a/jstests/audit/audit_drop_collection.js
+++ b/jstests/audit/audit_drop_collection.js
@@ -17,10 +17,11 @@ auditTest(
         assert.writeOK(coll.insert({ a: 17 }));
         assert(coll.drop());
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "dropCollection",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName + '.' + collName,
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_drop_database.js
+++ b/jstests/audit/audit_drop_database.js
@@ -15,10 +15,11 @@ auditTest(
         assert.writeOK(testDB.getCollection('foo').insert({ a: 1 }));
         assert.commandWorked(testDB.dropDatabase());
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "dropDatabase",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName,
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_drop_index.js
+++ b/jstests/audit/audit_drop_index.js
@@ -18,10 +18,11 @@ auditTest(
         assert.commandWorked(coll.createIndex({ a: 1 }, { name: idxName }));
         assert.commandWorked(coll.dropIndex({ a: 1 }));
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "dropIndex",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': testDBName + '.' + collName,
             'params.indexName': idxName,
             result: 0,

--- a/jstests/audit/audit_enable_sharding.js
+++ b/jstests/audit/audit_enable_sharding.js
@@ -13,10 +13,11 @@ auditTestShard(
         assert.commandWorked(testDB.dropDatabase());
         assert.commandWorked(st.s0.adminCommand({enableSharding: jsTestName()}));
 
+        beforeLoad = Date.now();
         auditColl = loadAuditEventsIntoCollection(st.s0, getDBPath() + '/auditLog-s0.json', testDB.getName(), 'auditEvents');
         assert.eq(1, auditColl.count({
             atype: "enableSharding",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': jsTestName(),
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_log_application_message.js
+++ b/jstests/audit/audit_log_application_message.js
@@ -12,10 +12,11 @@ auditTest(
         var msg = "it's a trap!"
         assert.commandWorked(m.getDB('admin').runCommand({ logApplicationMessage: msg }));
 
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "applicationMessage",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.msg': msg,
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_remove_shard.js
+++ b/jstests/audit/audit_remove_shard.js
@@ -21,10 +21,11 @@ auditTestShard(
             assert.commandWorked(removeRet);
         } while (removeRet.state != 'completed');
 
+        beforeLoad = Date.now();
         auditColl = loadAuditEventsIntoCollection(st.s0, getDBPath() + '/auditLog-s0.json', jsTestName(), 'auditEvents');
         assert.eq(1, auditColl.count({
             atype: "removeShard",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.shard': 'removable',
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_rename_collection.js
+++ b/jstests/audit/audit_rename_collection.js
@@ -20,11 +20,12 @@ auditTest(
         assert.commandWorked(testDB.createCollection(oldName));
         assert.commandWorked(testDB.getCollection(oldName).renameCollection(newName));
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m);
         var checkAuditLogForSingleRename = function() {
             assert.eq(1, auditColl.count({
                 atype: "renameCollection",
-                ts: withinTheLastFewSeconds(),
+                ts: withinFewSecondsBefore(beforeLoad),
                 'params.old': testDBName + '.' + oldName,
                 'params.new': testDBName + '.' + newName,
                 result: 0,

--- a/jstests/audit/audit_replset_reconfig.js
+++ b/jstests/audit/audit_replset_reconfig.js
@@ -29,7 +29,7 @@ auditTestRepl(
         sleep(5000);
 
         // Ensure that the reconfig audit event got logged on every member.
-        withinTheLast20Seconds = withinTheLastFewSeconds(20);
+        withinTheLast20Seconds = withinFewSecondsBefore(Date.now(), 20);
         replTest.nodes.forEach(function(m) { 
             print('audit check looking for old, new: ' +tojson(oldConfig)+', '+tojson(newConfig));
             // We need to import the audit events collection into the master node.

--- a/jstests/audit/audit_shard_collection.js
+++ b/jstests/audit/audit_shard_collection.js
@@ -14,10 +14,11 @@ auditTestShard(
         assert.commandWorked(st.s0.adminCommand({enableSharding: jsTestName()}));
         assert.commandWorked(st.s0.adminCommand({shardCollection: jsTestName() + '.foo', key: {a: 1, b: 1}}));
 
+        beforeLoad = Date.now();
         auditColl = loadAuditEventsIntoCollection(st.s0, getDBPath() + '/auditLog-s0.json', testDB.getName(), 'auditEvents');
         assert.eq(1, auditColl.count({
             atype: "shardCollection",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.ns': jsTestName() + '.foo',
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));

--- a/jstests/audit/audit_shutdown.js
+++ b/jstests/audit/audit_shutdown.js
@@ -12,11 +12,12 @@ auditTest(
         m.getDB('admin').shutdownServer();
         m = restartServer();
 
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "shutdown",
             // Give 10 seconds of slack in case shutdown / restart was particularly slow
-            ts: withinTheLastFewSeconds(10),
+            ts: withinFewSecondsBefore(beforeLoad, 10),
             result: 0,
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
     },

--- a/jstests/audit/audit_system_users.js
+++ b/jstests/audit/audit_system_users.js
@@ -20,10 +20,11 @@ auditTest(
         var userObj = { user: 'john', pwd: 'john', roles: [ { role:'userAdmin', db:testDBName} ] };
         testDB.createUser(userObj);
 
+        beforeLoad = Date.now();
         var auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "createUser",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.db': testDBName,
             'params.user': userObj.user,
             //'params.roles': userObj.roles,
@@ -35,10 +36,11 @@ auditTest(
         testDB.updateUser(userObj.user, updateObj);
         assert.eq(1, adminDB.system.users.count({ user: userObj.user, roles: updateObj.roles }),
                      "system.users update did not update role for user: " + userObj.user);
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "updateUser",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.db': testDBName,
             'params.user': userObj.user,
             //'params.roles': updateObj.roles,
@@ -50,10 +52,11 @@ auditTest(
         testDB.removeUser(userObj.user);
         assert.eq(0, testDB.system.users.count({ user: userObj.user }),
                      "removeUser did not remove user:" + userObj.user);
+        beforeLoad = Date.now();
         auditColl = getAuditEventsCollection(m);
         assert.eq(1, auditColl.count({
             atype: "dropUser",
-            ts: withinTheLastFewSeconds(),
+            ts: withinFewSecondsBefore(beforeLoad),
             'params.db': testDBName,
             'params.user': userObj.user,
             result: 0,


### PR DESCRIPTION
The problem was in that importing data from auditLog.json was done
with mongoimport starting in the separate process and it could
sometimes take more time than just couple of (milli)seconds.
With heavily loaded system, it could take up to 10 seconds, which
was breaking the following condition in audit collection query
that expected the entries to be within couple of seconds before
import was started, but that was not true for the cases when
mongoimport took long.

(cherry picked from commit f3998894119516ee6c57f1318f166f27ac920bc4)