### PR TITLE
meta package should depend on subpackages with version

### DIFF
--- a/percona-packaging/debian/control
+++ b/percona-packaging/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper (>= 9), debconf, libbz2-dev, libsnappy-dev, pkg-config,
 Package: percona-server-mongodb-32
 Architecture: any
 Breaks: percona-server-mongodb
-Depends: ${shlibs:Depends}, ${misc:Depends}, percona-server-mongodb-32-mongos, percona-server-mongodb-32-shell, percona-server-mongodb-32-server, percona-server-mongodb-32-tools
+Depends: ${shlibs:Depends}, ${misc:Depends}, percona-server-mongodb-32-mongos (>= ${source:Version}), percona-server-mongodb-32-shell (>= ${source:Version}), percona-server-mongodb-32-server (>= ${source:Version}), percona-server-mongodb-32-tools (>= ${source:Version})
 Description: This metapackage will install the mongo shell, import/export tools, other client utilities, server software, default configuration, and init.d scripts.
  This package contains high-performance MongoDB replacement from Percona - Percona Server for MongoDB.
  Percona Server for MongoDB is built for scalability, performance and high availability, scaling from single server deployments to large, complex multi-site architectures.


### PR DESCRIPTION
PSMDB-95 percona-server-mongodb-32 meta package depends on subpackages without specifying version