### PR TITLE
Change the default in mongod.conf template for RocksDB counters to true

### DIFF
--- a/percona-packaging/conf/mongod.conf
+++ b/percona-packaging/conf/mongod.conf
@@ -40,7 +40,7 @@ storage:
 #    compression: snappy
 #    maxWriteMBPerSec: 1024
 #    crashSafeCounters: false
-#    counters: false
+#    counters: true
 #    singleDeleteIndex: false
 
 #  More info for inMemory: https://www.percona.com/doc/percona-server-for-mongodb/3.4/inmemory.html#configuring-percona-memory-engine


### PR DESCRIPTION
The default for `counters` in RocksDB has changed from `false` to `true` between 3.2 and 3.4 (rocksdb 4.4->4.11) so this is to make the change in config file template.