### PR TITLE
PSMDB-106 add redaction of command objects logged at verbosity 1-4

### DIFF
--- a/src/mongo/db/commands.cpp
+++ b/src/mongo/db/commands.cpp
@@ -325,7 +325,7 @@ void Command::generateErrorResponse(OperationContext* txn,
                                     const BSONObj& metadata) {
     LOG(1) << "assertion while executing command '" << request.getCommandName() << "' "
            << "on database '" << request.getDatabase() << "' "
-           << "with arguments '" << command->getRedactedCopyForLogging(request.getCommandArgs())
+           << "with arguments '" << redact(command->getRedactedCopyForLogging(request.getCommandArgs()))
            << "' "
            << "and metadata '" << request.getMetadata() << "': " << exception.toString();
 

--- a/src/mongo/db/run_commands.cpp
+++ b/src/mongo/db/run_commands.cpp
@@ -62,7 +62,7 @@ void runCommands(OperationContext* txn,
         }
 
         LOG(2) << "run command " << request.getDatabase() << ".$cmd" << ' '
-               << c->getRedactedCopyForLogging(request.getCommandArgs());
+               << redact(c->getRedactedCopyForLogging(request.getCommandArgs()));
 
         {
             // Try to set this as early as possible, as soon as we have figured out the command.


### PR DESCRIPTION
This is a fix for the issue with unredacted information being logged when redaction is enabled and verbosity level is higher than 0 (1-4).
This fix affects logging format of all commands. For example output for `createUser` command at verbosity 1 will be changed from:
```
2017-01-24T14:43:48.494+0200 D COMMAND  [conn1] run command test.$cmd { createUser: "moe", pwd: "xxx", roles: [ "readWrite" ], digestPassword: false, writeConcern: { w: "majority", wtimeout: 300000.0 } }
2017-01-24T14:43:48.506+0200 D COMMAND  [conn1] run command admin.$cmd { update: "system.version", updates: [ { q: { _id: "authSchema" }, u: { $set: { currentVersion: 5 } }, multi: false, upsert: true } ] }
2017-01-24T14:43:48.507+0200 D QUERY    [conn1] Using idhack: { _id: "###" }
2017-01-24T14:43:48.507+0200 I WRITE    [conn1] update admin.system.version appName: "MongoDB Shell" query: { _id: "###" } planSummary: ### update: { $set: { currentVersion: "###" } } keysExamined:1 docsExamined:1 nMatched:1 nModified:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { W: 1 } }, Collection: { acquireCount: { w: 1 } } } 0ms
2017-01-24T14:43:48.507+0200 D REPL     [conn1] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
2017-01-24T14:43:48.507+0200 I COMMAND  [conn1] command admin.$cmd appName: "MongoDB Shell" command: update { update: "###", updates: [ { q: { _id: "###" }, u: { $set: { currentVersion: "###" } }, multi: "###", upsert: "###" } ] } numYields:0 reslen:59 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { W: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_query 0ms
2017-01-24T14:43:48.507+0200 D COMMAND  [conn1] run command admin.$cmd { insert: "system.users", documents: [ { _id: "test.moe", user: "moe", db: "test", credentials: { SCRAM-SHA-1: { iterationCount: 10000, salt: "giU1B8vGbNQe9oi0lGVLLw==", storedKey: "ZIb7TMyeFHgfCMsf24GUYTrWQMY=", serverKey: "h8MaoWvfzBWyXvY1z2bYyS4GFgA=" } }, roles: [ { role: "readWrite", db: "test" } ] } ] }
2017-01-24T14:43:48.507+0200 D REPL     [conn1] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
2017-01-24T14:43:48.507+0200 I COMMAND  [conn1] command admin.system.users appName: "MongoDB Shell" command: insert { insert: "###", documents: [ { _id: "###", user: "###", db: "###", credentials: { SCRAM-SHA-1: { iterationCount: "###", salt: "###", storedKey: "###", serverKey: "###" } }, roles: [ { role: "###", db: "###" } ] } ] } ninserted:1 keysInserted:2 numYields:0 reslen:44 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, Database: { acquireCount: { W: 2 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_query 0ms
2017-01-24T14:43:48.507+0200 D REPL     [conn1] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: "majority", wtimeout: 300000 }
2017-01-24T14:43:48.507+0200 I COMMAND  [conn1] command test.$cmd appName: "MongoDB Shell" command: createUser { createUser: "###", pwd: "###", roles: [ "###" ], digestPassword: "###", writeConcern: { w: "###", wtimeout: "###" } } numYields:0 reslen:22 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, Database: { acquireCount: { W: 2 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_command 13ms
2017-01-24T14:43:48.512+0200 D COMMAND  [conn1] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
2017-01-24T14:43:48.513+0200 I COMMAND  [conn1] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: "###", forShell: "###" } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
```
to
```
2017-01-24T14:52:31.052+0200 D COMMAND  [conn1] run command test.$cmd { createUser: "###", pwd: "###", roles: [ "###" ], digestPassword: "###", writeConcern: { w: "###", wtimeout: "###" } }
2017-01-24T14:52:31.064+0200 D COMMAND  [conn1] run command admin.$cmd { update: "###", updates: [ { q: { _id: "###" }, u: { $set: { currentVersion: "###" } }, multi: "###", upsert: "###" } ] }
2017-01-24T14:52:31.064+0200 D QUERY    [conn1] Using idhack: { _id: "###" }
2017-01-24T14:52:31.064+0200 I WRITE    [conn1] update admin.system.version appName: "MongoDB Shell" query: { _id: "###" } planSummary: ### update: { $set: { currentVersion: "###" } } keysExamined:1 docsExamined:1 nMatched:1 nModified:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { W: 1 } }, Collection: { acquireCount: { w: 1 } } } 0ms
2017-01-24T14:52:31.064+0200 D REPL     [conn1] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
2017-01-24T14:52:31.064+0200 I COMMAND  [conn1] command admin.$cmd appName: "MongoDB Shell" command: update { update: "###", updates: [ { q: { _id: "###" }, u: { $set: { currentVersion: "###" } }, multi: "###", upsert: "###" } ] } numYields:0 reslen:59 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { W: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_query 0ms
2017-01-24T14:52:31.064+0200 D COMMAND  [conn1] run command admin.$cmd { insert: "###", documents: [ { _id: "###", user: "###", db: "###", credentials: { SCRAM-SHA-1: { iterationCount: "###", salt: "###", storedKey: "###", serverKey: "###" } }, roles: [ { role: "###", db: "###" } ] } ] }
2017-01-24T14:52:31.064+0200 D REPL     [conn1] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
2017-01-24T14:52:31.065+0200 I COMMAND  [conn1] command admin.system.users appName: "MongoDB Shell" command: insert { insert: "###", documents: [ { _id: "###", user: "###", db: "###", credentials: { SCRAM-SHA-1: { iterationCount: "###", salt: "###", storedKey: "###", serverKey: "###" } }, roles: [ { role: "###", db: "###" } ] } ] } ninserted:1 keysInserted:2 numYields:0 reslen:44 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, Database: { acquireCount: { W: 2 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_query 0ms
2017-01-24T14:52:31.065+0200 D REPL     [conn1] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: "majority", wtimeout: 300000 }
2017-01-24T14:52:31.065+0200 I COMMAND  [conn1] command test.$cmd appName: "MongoDB Shell" command: createUser { createUser: "###", pwd: "###", roles: [ "###" ], digestPassword: "###", writeConcern: { w: "###", wtimeout: "###" } } numYields:0 reslen:22 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, Database: { acquireCount: { W: 2 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_command 12ms
2017-01-24T14:52:31.066+0200 D COMMAND  [conn1] run command test.$cmd { isMaster: "###", forShell: "###" }
2017-01-24T14:52:31.067+0200 I COMMAND  [conn1] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: "###", forShell: "###" } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
```