### PR TITLE
[BLD-638] Different version string in server and client

### DIFF
--- a/src/mongo/shell/mongo.js
+++ b/src/mongo/shell/mongo.js
@@ -245,7 +245,7 @@ connect = function(url, user, pass) {
 
     // Check server version
     var serverVersion = db.version();
-    chatty("Percona Server for MongoDB server version: " + serverVersion);
+    chatty("Percona Server for MongoDB server version: v" + serverVersion);
 
     var shellVersion = version();
     if (serverVersion.slice(0, 3) != shellVersion.slice(0, 3)) {


### PR DESCRIPTION
`vagrant@vagrant:~$ mongo
Percona Server for MongoDB shell version v3.4.3-1.3
connecting to: mongodb://127.0.0.1:27017
Percona Server for MongoDB server version: v3.4.3-1.3
Welcome to the Percona Server for MongoDB shell.
For interactive help, type "help".
`