### PR TITLE
[PSMDB-67] Odd messages for service status on ubuntu trusty

### DIFF
--- a/percona-packaging/debian/percona-server-mongodb-34-server.mongod.init
+++ b/percona-packaging/debian/percona-server-mongodb-34-server.mongod.init
@@ -231,11 +231,11 @@ case "$1" in
   status)
   log_daemon_msg "Checking status of $DESC" "$NAME"
   if running ;  then
-    log_progress_msg "running"
     log_end_msg 0
+    log_daemon_msg "mongod service is running"
   else
-    log_progress_msg "apparently not running"
-    log_end_msg 1
+    log_end_msg 0
+    log_daemon_msg "mongod service is apparently not running"
     exit 1
   fi
   ;;


### PR DESCRIPTION
How it looks now:
`root@vagrant-ubuntu-trusty-64:~# sudo service mongod status
 * Checking status of database                                                                          [ OK ] 
 * mongod service is running
root@vagrant-ubuntu-trusty-64:~# sudo service mongod stop
 * Stopping database mongod                                                                             [ OK ] 
root@vagrant-ubuntu-trusty-64:~# sudo service mongod status
 * Checking status of database                                                                          [ OK ] 
 * mongod service is apparently not running                                                                    `
