### PR TITLE
Fix percona-server-mongodb-enable-auth.sh for usage with ansible

### DIFF
--- a/percona-packaging/conf/percona-server-mongodb-enable-auth.sh
+++ b/percona-packaging/conf/percona-server-mongodb-enable-auth.sh
@@ -130,9 +130,9 @@ add_value_to_yaml() {
 }
 
 add_user_to_mongo() {
-    port=$(get_value_from_yaml net port)
-    user='dba'
-    password=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
+    port="$(get_value_from_yaml net port)"
+    user="dba"
+    password="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 32)"
     password="${password%\\n}"
     echo "db.createUser({user: \"$user\", pwd: \"$password\", roles: [ \"root\" ] });" | ${MONGO_CLIENT_BIN} -p $port localhost/admin
     if [ $? -eq 0 ];then


### PR DESCRIPTION
First two lines are changed just to make bash usage consistent.
Third line is problematic for ansible as found here: https://github.com/ansible/ansible/issues/12459
It just makes ansible stuck.
The purpose of this is to include `percona-server-mongodb-enable-auth.sh` into our package release tests which are done with ansible.