### PR TITLE
Add --useDeprecatedMongoRocks when running test for mongod with rocksdb

### DIFF
--- a/buildscripts/resmokelib/core/programs.py
+++ b/buildscripts/resmokelib/core/programs.py
@@ -73,11 +73,12 @@ def mongod_program(logger, executable=None, process_kwargs=None, **kwargs):
 
     if config.STORAGE_ENGINE == "rocksdb":
         shortcut_opts["rocksdbCacheSizeGB"] = config.STORAGE_ENGINE_CACHE_SIZE
+        shortcut_opts["useDeprecatedMongoRocks"] = True
     elif config.STORAGE_ENGINE == "wiredTiger" or config.STORAGE_ENGINE is None:
         shortcut_opts["wiredTigerCacheSizeGB"] = config.STORAGE_ENGINE_CACHE_SIZE
 
     # These options are just flags, so they should not take a value.
-    opts_without_vals = ("nojournal", "nopreallocj")
+    opts_without_vals = ("nojournal", "nopreallocj", "useDeprecatedMongoRocks")
 
     # Have the --nojournal command line argument to resmoke.py unset the journal option.
     if shortcut_opts["nojournal"] and "journal" in kwargs:

--- a/src/mongo/shell/servers.js
+++ b/src/mongo/shell/servers.js
@@ -1126,6 +1126,7 @@ var MongoRunner, _startMongod, startMongoProgram, runMongoProgram, startMongoPro
                             argArray.push(...['--rocksdbCacheSizeGB',
                                               jsTest.options().storageEngineCacheSizeGB]);
                         }
+                        argArray.push(...['--useDeprecatedMongoRocks']);
                     }
                     // apply setParameters for mongod
                     if (jsTest.options().setParameters) {


### PR DESCRIPTION
This is to add `--useDeprecatedMongoRocks` option when running standard MongoRocks tests.

Tested here:
https://jenkins.percona.com/view/PSMDB-3.6/job/percona-server-for-mongodb-3.6-param/115/
https://jenkins.percona.com/view/PSMDB-3.6/job/percona-server-for-mongodb-3.6-param/107/

Listing of the files (this is for the first listed run only) that use this option only show it for rocksdb which is what was expected:
``` plavi@fry  ~/Downloads/resmoke  grep -R -l useDeprecatedMongoRocks .
./resmoke_audit_rocksdb_1.log
./resmoke_read_only_rocksdb_1.log
./resmoke_read_only_sharded_rocksdb_1.log
./resmoke_core_rocksdb_1.log
```