### PR TITLE
MongoRocks tag tests and adapt replsettest.js

### DIFF
--- a/jstests/aggregation/bugs/server6179.js
+++ b/jstests/aggregation/bugs/server6179.js
@@ -1,4 +1,5 @@
 // SERVER-6179: support for two $groups in sharded agg
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/aggregation/bugs/server7781.js
+++ b/jstests/aggregation/bugs/server7781.js
@@ -1,4 +1,5 @@
 // SERVER-7781 $geoNear pipeline stage
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/aggregation/mongos_merge.js
+++ b/jstests/aggregation/mongos_merge.js
@@ -10,7 +10,7 @@
  * and will therefore invalidate the results of the test cases below, we tag this test to prevent it
  * running under the 'aggregation_facet_unwind' passthrough.
  *
- * @tags: [do_not_wrap_aggregations_in_facets]
+ * @tags: [do_not_wrap_aggregations_in_facets, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/aggregation/mongos_slaveok.js
+++ b/jstests/aggregation/mongos_slaveok.js
@@ -1,6 +1,8 @@
 /**
  * Tests aggregate command against mongos with slaveOk. For more tests on read preference,
  * please refer to jstests/sharding/read_pref_cmd.js.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     load('jstests/replsets/rslib.js');

--- a/jstests/aggregation/shard_targeting.js
+++ b/jstests/aggregation/shard_targeting.js
@@ -20,7 +20,7 @@
  * and will therefore invalidate the results of the test cases below, we tag this test to prevent it
  * running under the 'aggregation_facet_unwind' passthrough.
  *
- * @tags: [do_not_wrap_aggregations_in_facets]
+ * @tags: [do_not_wrap_aggregations_in_facets, rocks_requires_fcv36]
  */
 (function() {
     load("jstests/libs/profiler.js");  // For profilerHas*OrThrow helper functions.

--- a/jstests/aggregation/sources/addFields/use_cases.js
+++ b/jstests/aggregation/sources/addFields/use_cases.js
@@ -2,6 +2,8 @@
  * $addFields can be used to add fixed and computed fields to documents while preserving the
  * original document. Verify that using $addFields and adding computed fields in a $project yield
  * the same result.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/aggregation/sources/addFields/weather.js
+++ b/jstests/aggregation/sources/addFields/weather.js
@@ -2,6 +2,8 @@
  * $addFields can be used to add fixed and computed fields to documents while preserving the
  * original document. Verify that using $addFields and adding computed fields in a $project yield
  * the same result. Use the sample case of computing weather metadata.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/aggregation/sources/collStats/shard_host_info.js
+++ b/jstests/aggregation/sources/collStats/shard_host_info.js
@@ -1,6 +1,8 @@
 /**
  * Verifies that the $collStats aggregation stage includes the shard and hostname for each output
  * document when run via mongoS, and that the former is absent when run on a non-shard mongoD.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/aggregation/sources/facet/use_cases.js
+++ b/jstests/aggregation/sources/facet/use_cases.js
@@ -1,5 +1,7 @@
 /**
  * Tests some practical use cases of the $facet stage.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/aggregation/sources/graphLookup/sharded.js
+++ b/jstests/aggregation/sources/graphLookup/sharded.js
@@ -1,5 +1,6 @@
 // In SERVER-23725, $graphLookup was introduced. In this file, we test that the expression behaves
 // correctly on a sharded collection.
+// @tags: [rocks_requires_fcv36]
 load("jstests/aggregation/extras/utils.js");  // For assertErrorCode.
 
 (function() {

--- a/jstests/aggregation/sources/lookup/lookup.js
+++ b/jstests/aggregation/sources/lookup/lookup.js
@@ -1,4 +1,5 @@
 // Basic $lookup regression tests.
+// @tags: [rocks_requires_fcv36]
 
 load("jstests/aggregation/extras/utils.js");  // For assertErrorCode.
 

--- a/jstests/aggregation/sources/replaceRoot/address.js
+++ b/jstests/aggregation/sources/replaceRoot/address.js
@@ -1,5 +1,7 @@
 /**
  * $replaceRoot can be used to extract parts of a document; here we test a simple address case.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/aggregation/testshard1.js
+++ b/jstests/aggregation/testshard1.js
@@ -1,3 +1,5 @@
+// @tags: [rocks_requires_fcv36]
+
 load('jstests/aggregation/extras/utils.js');
 load('jstests/libs/analyze_plan.js');  // For planHasStage.
 

--- a/jstests/audit/audit_add_shard.js
+++ b/jstests/audit/audit_add_shard.js
@@ -1,4 +1,5 @@
 // test that enableSharding gets audited
+// @tags: [rocks_requires_fcv36]
 
 if (TestData.testData !== undefined) {
     load(TestData.testData + '/audit/_audit_helpers.js');

--- a/jstests/audit/audit_enable_sharding.js
+++ b/jstests/audit/audit_enable_sharding.js
@@ -1,4 +1,5 @@
 // test that enableSharding gets audited
+// @tags: [rocks_requires_fcv36]
 
 if (TestData.testData !== undefined) {
     load(TestData.testData + '/audit/_audit_helpers.js');

--- a/jstests/audit/audit_remove_shard.js
+++ b/jstests/audit/audit_remove_shard.js
@@ -1,4 +1,5 @@
 // test that enableSharding gets audited
+// @tags: [rocks_requires_fcv36]
 
 if (TestData.testData !== undefined) {
     load(TestData.testData + '/audit/_audit_helpers.js');

--- a/jstests/audit/audit_shard_collection.js
+++ b/jstests/audit/audit_shard_collection.js
@@ -1,4 +1,5 @@
 // test that shardCollection gets audited
+// @tags: [rocks_requires_fcv36]
 
 if (TestData.testData !== undefined) {
     load(TestData.testData + '/audit/_audit_helpers.js');

--- a/jstests/auth/access_control_with_unreachable_configs.js
+++ b/jstests/auth/access_control_with_unreachable_configs.js
@@ -2,6 +2,7 @@
 // localhost exception does not apply.  That is, if mongos cannot verify that there
 // are user documents stored in the configuration information, it must assume that
 // there are.
+// @tags: [rocks_requires_fcv36]
 
 var dopts = {smallfiles: "", nopreallocj: ""};
 var st = new ShardingTest({

--- a/jstests/auth/auth_schema_upgrade.js
+++ b/jstests/auth/auth_schema_upgrade.js
@@ -1,4 +1,5 @@
 // Standalone test of authSchemaUpgrade
+// @tags: [rocks_requires_fcv36]
 load('./jstests/multiVersion/libs/auth_helpers.js');
 
 var setupCRUsers = function(conn) {

--- a/jstests/auth/authentication_restrictions.js
+++ b/jstests/auth/authentication_restrictions.js
@@ -1,5 +1,7 @@
 /**
  * This test checks that authentication restrictions can be set and respected.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/auth/authentication_restrictions_role.js
+++ b/jstests/auth/authentication_restrictions_role.js
@@ -1,5 +1,7 @@
 /**
  * This test checks that authentication restrictions can be set on roles and respected.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/auth/authz_modifications_access_control.js
+++ b/jstests/auth/authz_modifications_access_control.js
@@ -1,5 +1,7 @@
 /**
  * This tests that the proper access control is enforced around modifications to user and role data.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 function runTest(conn) {

--- a/jstests/auth/basic_role_auth.js
+++ b/jstests/auth/basic_role_auth.js
@@ -1,6 +1,8 @@
 /**
  * This file tests basic authorization for different roles in stand alone and sharded
  * environment. This file covers all types of operations except commands.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 /**

--- a/jstests/auth/clac_system_colls.js
+++ b/jstests/auth/clac_system_colls.js
@@ -1,5 +1,7 @@
 /**
  * This tests that CLAC (collection level access control) handles system collections properly.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 // Verify that system collections are treated correctly

--- a/jstests/auth/commands_builtin_roles.js
+++ b/jstests/auth/commands_builtin_roles.js
@@ -5,6 +5,7 @@ Exhaustive test for authorization of commands with builtin roles.
 The test logic implemented here operates on the test cases defined
 in jstests/auth/commands.js.
 
+@tags: [rocks_requires_fcv36]
 */
 
 load("jstests/auth/lib/commands_lib.js");

--- a/jstests/auth/commands_user_defined_roles.js
+++ b/jstests/auth/commands_user_defined_roles.js
@@ -5,6 +5,7 @@ Exhaustive test for authorization of commands with user-defined roles.
 The test logic implemented here operates on the test cases defined
 in jstests/auth/commands.js.
 
+@tags: [rocks_requires_fcv36]
 */
 
 // constants

--- a/jstests/auth/copyauth.js
+++ b/jstests/auth/copyauth.js
@@ -1,5 +1,6 @@
 // Test copyDatabase command with various combinations of authed/unauthed and single node/replica
 // set source and dest.
+// @tags: [rocks_requires_fcv36]
 
 TestData.authMechanism = "SCRAM-SHA-1";                        // SERVER-11428
 DB.prototype._defaultAuthenticationMechanism = "SCRAM-SHA-1";  // SERVER-11428

--- a/jstests/auth/copyauth_between_shards.js
+++ b/jstests/auth/copyauth_between_shards.js
@@ -1,5 +1,6 @@
 // Test copyDatabase command inside a sharded cluster with and without auth.  Tests with auth are
 // currently disabled due to SERVER-13080.
+// @tags: [rocks_requires_fcv36]
 
 var baseName = "jstests_clone_copyauth_between_shards";
 

--- a/jstests/auth/feature_compat_36_roles_collection.js
+++ b/jstests/auth/feature_compat_36_roles_collection.js
@@ -1,4 +1,5 @@
 // Verify custom roles still exist after a FeatureCompatability upgrade from 3.4 to 3.6
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/auth/getMore.js
+++ b/jstests/auth/getMore.js
@@ -1,4 +1,5 @@
 // Tests that a user can only run a getMore on a cursor that they created.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/auth/kill_cursors.js
+++ b/jstests/auth/kill_cursors.js
@@ -1,4 +1,5 @@
 // Test the killCursors command.
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/auth/kill_sessions.js
+++ b/jstests/auth/kill_sessions.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 load("jstests/libs/kill_sessions.js");
 
 (function() {

--- a/jstests/auth/list_all_local_sessions.js
+++ b/jstests/auth/list_all_local_sessions.js
@@ -1,4 +1,5 @@
 // Auth tests for the $listLocalSessions {allUsers:true} aggregation stage.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/auth/list_all_sessions.js
+++ b/jstests/auth/list_all_sessions.js
@@ -1,4 +1,5 @@
 // Auth tests for the $listSessions {allUsers:true} aggregation stage.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/auth/list_local_sessions.js
+++ b/jstests/auth/list_local_sessions.js
@@ -1,4 +1,5 @@
 // All tests for the $listLocalSessions aggregation stage.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/auth/list_sessions.js
+++ b/jstests/auth/list_sessions.js
@@ -1,4 +1,5 @@
 // Auth tests for the $listSessions aggregation pipeline.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/auth/log_userid_off.js
+++ b/jstests/auth/log_userid_off.js
@@ -2,6 +2,7 @@
  * Tests that logged users will not show up in the log.
  *
  * @param mongo {Mongo} connection object.
+ * @tags: [rocks_requires_fcv36]
  */
 var doTest = function(mongo, callSetParam) {
     var TEST_USER = 'foo';

--- a/jstests/auth/mergeAuthCollsCommand.js
+++ b/jstests/auth/mergeAuthCollsCommand.js
@@ -1,5 +1,7 @@
 /**
  * Tests the behavior of the _mergeAuthzCollections command.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 function assertUsersAndRolesHaveRole(admin, role) {

--- a/jstests/auth/mongos_cache_invalidation.js
+++ b/jstests/auth/mongos_cache_invalidation.js
@@ -1,6 +1,8 @@
 /**
  * This tests that updates to user and role definitions made on one mongos propagate properly
  * to other mongoses.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 var authzErrorCode = 13;

--- a/jstests/auth/pre_auth_commands_with_sessions.js
+++ b/jstests/auth/pre_auth_commands_with_sessions.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/auth/pseudo_commands.js
+++ b/jstests/auth/pseudo_commands.js
@@ -2,6 +2,8 @@
  * This tests the access control for the pseudo-commands inprog, curop, and killop.  Once
  * SERVER-5466 is resolved this test should be removed and its functionality merged into
  * commands_builtin_roles.js and commands_user_defined_roles.js.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 function runTest(conn) {

--- a/jstests/auth/refresh_logical_session_cache_with_long_usernames.js
+++ b/jstests/auth/refresh_logical_session_cache_with_long_usernames.js
@@ -1,5 +1,6 @@
 // Verifies that we've fixed SERVER-33158 by creating large user lsid refresh records (via large
 // usernames)
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/auth/resource_pattern_matching.js
+++ b/jstests/auth/resource_pattern_matching.js
@@ -1,5 +1,6 @@
 /*
  * Tests that resource pattern matching rules work as expected.
+ * @tags: [rocks_requires_fcv36]
  */
 
 function setup_users(granter) {

--- a/jstests/auth/role_management_commands_edge_cases.js
+++ b/jstests/auth/role_management_commands_edge_cases.js
@@ -1,6 +1,8 @@
 /**
  * This tests that all the different commands for role manipulation all properly handle invalid
  * and atypical inputs.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 function runTest(conn) {

--- a/jstests/auth/role_management_commands_sharded_wc_1.js
+++ b/jstests/auth/role_management_commands_sharded_wc_1.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/auth/role_management_commands_sharded_wc_majority.js
+++ b/jstests/auth/role_management_commands_sharded_wc_majority.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/auth/upgrade_noauth_to_keyfile_with_sharding.js
+++ b/jstests/auth/upgrade_noauth_to_keyfile_with_sharding.js
@@ -1,5 +1,6 @@
 // Tests access control upgrade on a sharded cluster
 // The purpose is to verify the connectivity between mongos, config server, and the shards
+// @tags: [rocks_requires_fcv36]
 
 load('jstests/ssl/libs/ssl_helpers.js');
 

--- a/jstests/auth/user_defined_roles.js
+++ b/jstests/auth/user_defined_roles.js
@@ -1,6 +1,8 @@
 /**
  * This tests that user defined roles actually grant users the ability to perform the actions they
  * should, and that changing the privileges assigned to roles changes the access granted to the user
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 function runTest(conn) {

--- a/jstests/auth/user_management_commands_edge_cases.js
+++ b/jstests/auth/user_management_commands_edge_cases.js
@@ -1,6 +1,8 @@
 /**
  * This tests that all the different commands for user manipulation all properly handle invalid and
  * atypical inputs.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 function runTest(conn) {

--- a/jstests/auth/user_management_commands_sharded_wc_1.js
+++ b/jstests/auth/user_management_commands_sharded_wc_1.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/auth/user_management_commands_sharded_wc_majority.js
+++ b/jstests/auth/user_management_commands_sharded_wc_majority.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/auth/views_authz.js
+++ b/jstests/auth/views_authz.js
@@ -1,6 +1,8 @@
 /**
  * Tests authorization special cases with views. These are special exceptions that prohibit certain
  * operations on views even if the user has an explicit privilege on that view.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/core/json_schema/additional_items.js
+++ b/jstests/core/json_schema/additional_items.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests the JSON Schema "additionalItems" keyword.

--- a/jstests/core/json_schema/additional_properties.js
+++ b/jstests/core/json_schema/additional_properties.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for the JSON Schema 'additionalProperties' keyword.

--- a/jstests/core/json_schema/bsontype.js
+++ b/jstests/core/json_schema/bsontype.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for the non-standard 'bsonType' keyword in JSON Schema, as well as some tests for 'type'.

--- a/jstests/core/json_schema/dependencies.js
+++ b/jstests/core/json_schema/dependencies.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for the JSON Schema 'dependencies' keyword.

--- a/jstests/core/json_schema/items.js
+++ b/jstests/core/json_schema/items.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests the JSON Schema "items" keyword.

--- a/jstests/core/json_schema/json_schema.js
+++ b/jstests/core/json_schema/json_schema.js
@@ -1,5 +1,5 @@
 // listCollections tests expect that a collection is not implicitly created after a drop.
-// @tags: [assumes_no_implicit_collection_creation_after_drop, requires_non_retryable_commands]
+// @tags: [assumes_no_implicit_collection_creation_after_drop, requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for JSON Schema document validation.

--- a/jstests/core/json_schema/logical_keywords.js
+++ b/jstests/core/json_schema/logical_keywords.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for the JSON Schema logical keywords, including:

--- a/jstests/core/json_schema/min_max_items.js
+++ b/jstests/core/json_schema/min_max_items.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests the JSON Schema keywords "minItems" and "maxItems".

--- a/jstests/core/json_schema/min_max_properties.js
+++ b/jstests/core/json_schema/min_max_properties.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for the JSON Schema 'minProperties' and 'maxProperties' keywords.

--- a/jstests/core/json_schema/misc_validation.js
+++ b/jstests/core/json_schema/misc_validation.js
@@ -17,6 +17,7 @@
  *   requires_eval_command,
  *   requires_non_retryable_commands,
  *   requires_non_retryable_writes,
+ *   rocks_requires_fcv36,
  * ]
  */
 (function() {

--- a/jstests/core/json_schema/pattern_properties.js
+++ b/jstests/core/json_schema/pattern_properties.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for the JSON Schema 'patternProperties' keyword.

--- a/jstests/core/json_schema/required.js
+++ b/jstests/core/json_schema/required.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests for handling of the JSON Schema 'required' keyword.

--- a/jstests/core/json_schema/unique_items.js
+++ b/jstests/core/json_schema/unique_items.js
@@ -1,4 +1,4 @@
-// @tags: [requires_non_retryable_commands]
+// @tags: [requires_non_retryable_commands, rocks_requires_fcv36]
 
 /**
  * Tests the JSON Schema "uniqueItems" keyword.

--- a/jstests/fail_point/fail_point.js
+++ b/jstests/fail_point/fail_point.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/gle/create_index_gle.js
+++ b/jstests/gle/create_index_gle.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 load('jstests/replsets/rslib.js');
 (function() {
     "use strict";

--- a/jstests/gle/gle_sharded_wc.js
+++ b/jstests/gle/gle_sharded_wc.js
@@ -3,7 +3,7 @@
 //
 // This test asserts that a journaled write to a mongod running with --nojournal should be rejected,
 // so cannot be run on the ephemeralForTest storage engine, as it accepts all journaled writes.
-// @tags: [SERVER-21420]
+// @tags: [SERVER-21420, rocks_requires_fcv36]
 
 // Checking UUID consistency involves talking to the shard primaries, but by the end of this test,
 // one shard does not have a primary.

--- a/jstests/gle/gle_sharded_write.js
+++ b/jstests/gle/gle_sharded_write.js
@@ -2,6 +2,7 @@
 // Ensures GLE correctly reports basic write stats and failures
 // Note that test should work correctly with and without write commands.
 //
+// @tags: [rocks_requires_fcv36]
 
 // Checking UUID consistency involves talking to shards, but this test shuts down one shard.
 TestData.skipCheckingUUIDsConsistentAcrossCluster = true;

--- a/jstests/gle/updated_existing.js
+++ b/jstests/gle/updated_existing.js
@@ -1,6 +1,8 @@
 /**
 * SERVER-5872 : This test checks that the return message "updatedExisting" of
 *               an upsert is not missing when autosplit takes place.
+*
+* @tags: [rocks_requires_fcv36]
 */
 
 var st = new ShardingTest({shards: 1, mongos: 1, verbose: 1, chunkSize: 1});

--- a/jstests/multiVersion/add_invalid_shard.js
+++ b/jstests/multiVersion/add_invalid_shard.js
@@ -1,5 +1,7 @@
 /**
  * Test that adding invalid or duplicate shards will fail.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
 

--- a/jstests/multiVersion/causal_consistency_downgrade_cluster.js
+++ b/jstests/multiVersion/causal_consistency_downgrade_cluster.js
@@ -1,6 +1,8 @@
 /**
  * Test the downgrade of a sharded cluster from latest to last-stable version succeeds, verifying
  * behavior related to causal consistency at each stage.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/causal_consistency_downgrade_rs.js
+++ b/jstests/multiVersion/causal_consistency_downgrade_rs.js
@@ -1,6 +1,7 @@
 /**
  * Test the downgrade of a standalone replica set from latest to last-stable version succeeds,
  * verifying behavior related to causal consistency at each stage.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/causal_consistency_upgrade_cluster.js
+++ b/jstests/multiVersion/causal_consistency_upgrade_cluster.js
@@ -2,6 +2,8 @@
  * Tests upgrading a cluster with two shards and two mongos servers from last stable to current
  * version, verifying the behavior of $clusterTime metadata and afterClusterTime commands throughout
  * the process.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/causal_consistency_upgrade_rs.js
+++ b/jstests/multiVersion/causal_consistency_upgrade_rs.js
@@ -1,6 +1,8 @@
 /**
  * Test the upgrade of a standalone replica set from the last-stable to the version succeeds,
  * verifying behavior related to causal consistency at each stage.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/collection_validator_feature_compatibility_version.js
+++ b/jstests/multiVersion/collection_validator_feature_compatibility_version.js
@@ -3,7 +3,7 @@
  * the feature compatibility version is older than 3.6.
  *
  * We restart mongod during the test and expect it to have the same data after restarting.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/multiVersion/downgrade_replset.js
+++ b/jstests/multiVersion/downgrade_replset.js
@@ -1,5 +1,6 @@
 // Test the downgrade of a replica set from latest version
 // to last-stable version succeeds, while reads and writes continue.
+// @tags: [rocks_requires_fcv36]
 
 load('./jstests/multiVersion/libs/multi_rs.js');
 load('./jstests/libs/test_background_ops.js');

--- a/jstests/multiVersion/feature_compatibility_version_lagging_secondary.js
+++ b/jstests/multiVersion/feature_compatibility_version_lagging_secondary.js
@@ -1,5 +1,6 @@
 // Tests that a primary with upgrade featureCompatibilityVersion cannot connect with a secondary
 // with a lower binary version.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/multiVersion/incomplete_upgrade_downgrade.js
+++ b/jstests/multiVersion/incomplete_upgrade_downgrade.js
@@ -1,6 +1,8 @@
 /**
  * This test verifies that if mongod exits after setting the FCV document to 3.4 before the
  * collection UUIDs are removed, that re-running the downgrade to 3.4 is possible.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/migration_between_mixed_FCV_mixed_version_mongods.js
+++ b/jstests/multiVersion/migration_between_mixed_FCV_mixed_version_mongods.js
@@ -1,6 +1,8 @@
 /**
  * Test that it is not possible to move a chunk from an upgrade featureCompatibilityVersion node to
  * a downgrade binary version node.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 // This test will not end with consistent UUIDs, since there is inconsistent

--- a/jstests/multiVersion/rename_across_dbs_last_stable_secondary.js
+++ b/jstests/multiVersion/rename_across_dbs_last_stable_secondary.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/multiVersion/rename_across_dbs_last_stable_secondary_drop_target.js
+++ b/jstests/multiVersion/rename_across_dbs_last_stable_secondary_drop_target.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/multiVersion/set_feature_compatibility_version.js
+++ b/jstests/multiVersion/set_feature_compatibility_version.js
@@ -1,4 +1,4 @@
-
+// @tags: [rocks_requires_fcv36]
 // Checking UUID consistency involves talking to a shard node, which in this test is shutdown
 TestData.skipCheckingUUIDsConsistentAcrossCluster = true;
 

--- a/jstests/multiVersion/set_schema_version.js
+++ b/jstests/multiVersion/set_schema_version.js
@@ -1,4 +1,5 @@
 // Tests for setFeatureCompatibilityVersion.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/multiVersion/shell_causal_consistency_downgrade.js
+++ b/jstests/multiVersion/shell_causal_consistency_downgrade.js
@@ -1,6 +1,7 @@
 /**
  * Tests that the mongo shell doesn't gossip its highest seen clusterTime or inject an
  * afterClusterTime into its command requests after downgrading from 3.6 to 3.4.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/shell_retryable_writes_downgrade.js
+++ b/jstests/multiVersion/shell_retryable_writes_downgrade.js
@@ -1,6 +1,7 @@
 /**
  * Tests that the mongo shell doesn't attempt to retry its write operations after downgrading from
  * 3.6 to 3.4.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/updates_in_heterogeneous_repl_set.js
+++ b/jstests/multiVersion/updates_in_heterogeneous_repl_set.js
@@ -3,6 +3,7 @@
 // primary. Finally, upgrade the 3.4 member to 3.6, upgrade the replica set to
 // feature compatibility version 3.6, and again update documents with each
 // member as the primary.
+// @tags: [rocks_requires_fcv36]
 
 const testName = "updates_in_heterogeneous_repl_set";
 

--- a/jstests/multiVersion/upgrade_downgrade_while_creating_collection.js
+++ b/jstests/multiVersion/upgrade_downgrade_while_creating_collection.js
@@ -1,5 +1,6 @@
 /*
  * Tests that upgrade/downgrade works correctly even while creating a new collection.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/multiVersion/view_definition_feature_compatibility_version.js
+++ b/jstests/multiVersion/view_definition_feature_compatibility_version.js
@@ -3,7 +3,7 @@
  * compatibility version is older than 3.6.
  *
  * We restart mongod during the test and expect it to have the same data after restarting.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/noPassthrough/after_cluster_time.js
+++ b/jstests/noPassthrough/after_cluster_time.js
@@ -1,4 +1,5 @@
 // This test verifies readConcern:afterClusterTime behavior on a standalone mongod.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
     var standalone =

--- a/jstests/noPassthrough/apply_ops_mode.js
+++ b/jstests/noPassthrough/apply_ops_mode.js
@@ -2,6 +2,8 @@
  * Tests that applyOps correctly respects the 'oplogApplicationMode' and 'alwaysUpsert' flags.
  * 'alwaysUpsert' defaults to true and 'oplogApplicationMode' defaults to 'ApplyOps'. We test
  * that these default values do not lead to command failure.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/noPassthrough/apply_ops_overwrite_admin_system_version.js
+++ b/jstests/noPassthrough/apply_ops_overwrite_admin_system_version.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
     var standalone = MongoRunner.runMongod();

--- a/jstests/noPassthrough/arrayFilters_feature_compatibility_version.js
+++ b/jstests/noPassthrough/arrayFilters_feature_compatibility_version.js
@@ -1,4 +1,5 @@
 // Test that arrayFilters usage is restricted when the featureCompatibilityVersion is 3.4.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/noPassthrough/auth_reject_mismatching_logical_times.js
+++ b/jstests/noPassthrough/auth_reject_mismatching_logical_times.js
@@ -1,6 +1,7 @@
 /**
  * Verifies mismatching cluster time objects are rejected by a sharded cluster when auth is on. In
  * noPassthrough because auth is manually set.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/auto_retry_on_network_error.js
+++ b/jstests/noPassthrough/auto_retry_on_network_error.js
@@ -1,6 +1,7 @@
 /**
  * Tests that the auto_retry_on_network_error.js override automatically retries commands on network
  * errors for commands run under a session.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/causal_consistency_feature_compatibility.js
+++ b/jstests/noPassthrough/causal_consistency_feature_compatibility.js
@@ -1,6 +1,7 @@
 /**
  * Tests the behavior of a sharded cluster when featureCompatibilityVersion is set to 3.4, with
  * respect to causal consistency. In noPassthrough to avoid issues with auth.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/change_stream_feature_compatibility_version.js
+++ b/jstests/noPassthrough/change_stream_feature_compatibility_version.js
@@ -1,5 +1,6 @@
 // Test that $changeStreams usage is disallowed when the featureCompatibilityVersion is 3.4.
 // and that existing streams close when FCV is set to 3.4
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/noPassthrough/change_streams_require_majority_read_concern.js
+++ b/jstests/noPassthrough/change_streams_require_majority_read_concern.js
@@ -1,4 +1,5 @@
 // Tests that the $changeStream requires read concern majority.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/noPassthrough/change_streams_update_lookup_collation.js
+++ b/jstests/noPassthrough/change_streams_update_lookup_collation.js
@@ -2,7 +2,7 @@
 // collation, regardless of the collation on the change stream.
 //
 // Collation is only supported with the find command, not with op query.
-// @tags: [requires_find_command]
+// @tags: [requires_find_command, rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/noPassthrough/client_metadata_log.js
+++ b/jstests/noPassthrough/client_metadata_log.js
@@ -1,5 +1,7 @@
 /**
  * Test that verifies client metadata is logged into log file on new connections.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     'use strict';

--- a/jstests/noPassthrough/coll_mod_apply_ops.js
+++ b/jstests/noPassthrough/coll_mod_apply_ops.js
@@ -1,5 +1,6 @@
 // SERVER-30665 Ensure that a non-empty collMod with a nonexistent UUID is not applied
 // in applyOps.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/noPassthrough/command_line_parsing.js
+++ b/jstests/noPassthrough/command_line_parsing.js
@@ -1,4 +1,5 @@
 // validate command line parameter parsing
+// @tags: [rocks_requires_fcv36]
 
 var baseName = "jstests_slowNightly_command_line_parsing";
 

--- a/jstests/noPassthrough/cross_user_getmore_has_no_side_effects.js
+++ b/jstests/noPassthrough/cross_user_getmore_has_no_side_effects.js
@@ -1,6 +1,7 @@
 // Test that a user is not allowed to getMore a cursor they did not create, and that such a failed
 // getMore will leave the cursor unaffected, so that a subsequent getMore by the original author
 // will work.
+// @tags: [rocks_requires_fcv36]
 (function() {
     const st = new ShardingTest({shards: 2, config: 1, other: {keyFile: "jstests/libs/key1"}});
     const kDBName = "test";

--- a/jstests/noPassthrough/data_consistency_checks.js
+++ b/jstests/noPassthrough/data_consistency_checks.js
@@ -2,7 +2,7 @@
  * Verifies that the data consistency checks work against the variety of cluster types we use in our
  * testing.
  *
- * @tags: [requires_replication, requires_sharding]
+ * @tags: [requires_replication, requires_sharding, rocks_requires_fcv36]
  */
 
 // The global 'db' variable is used by the data consistency hooks.

--- a/jstests/noPassthrough/drop_collections_two_phase_feature_compatibility_version.js
+++ b/jstests/noPassthrough/drop_collections_two_phase_feature_compatibility_version.js
@@ -4,7 +4,7 @@
  *
  * This test does not work with non-persistent storage engines because it checks for the presence of
  * drop-pending collections across server restarts.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/noPassthrough/end_sessions_command.js
+++ b/jstests/noPassthrough/end_sessions_command.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use script";
 

--- a/jstests/noPassthrough/exit_logging.js
+++ b/jstests/noPassthrough/exit_logging.js
@@ -1,5 +1,7 @@
 /**
  * Tests that various forms of normal and abnormal shutdown write to the log files as expected.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/noPassthrough/feature_compatibility_version.js
+++ b/jstests/noPassthrough/feature_compatibility_version.js
@@ -1,5 +1,6 @@
 // Tests that manipulating the featureCompatibilityVersion document in admin.system.version changes
 // the value of the featureCompatibilityVersion server parameter.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/noPassthrough/ftdc_setdirectory.js
+++ b/jstests/noPassthrough/ftdc_setdirectory.js
@@ -1,5 +1,7 @@
 /**
  * Test that verifies FTDC works in mongos.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 load('jstests/libs/ftdc.js');
 

--- a/jstests/noPassthrough/json_schema_ignore_unknown_keywords.js
+++ b/jstests/noPassthrough/json_schema_ignore_unknown_keywords.js
@@ -1,6 +1,8 @@
 /**
  * Test that setting the query knob 'internalQueryIgnoreUnknownJSONSchemaKeywords' correctly
  * ignores unknown keywords within $jsonSchema.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/kill_sessions.js
+++ b/jstests/noPassthrough/kill_sessions.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 load("jstests/libs/kill_sessions.js");
 
 (function() {

--- a/jstests/noPassthrough/killop.js
+++ b/jstests/noPassthrough/killop.js
@@ -1,4 +1,5 @@
 // Confirms basic killOp execution via mongod and mongos.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/noPassthrough/logical_session_cursor_checks.js
+++ b/jstests/noPassthrough/logical_session_cursor_checks.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/noPassthrough/logical_session_feature_compatibility.js
+++ b/jstests/noPassthrough/logical_session_feature_compatibility.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
     var cases = [

--- a/jstests/noPassthrough/max_acceptable_logical_clock_drift_secs_parameter.js
+++ b/jstests/noPassthrough/max_acceptable_logical_clock_drift_secs_parameter.js
@@ -2,6 +2,8 @@
  * Tests what values are accepted for the maxAcceptableLogicalClockDriftSecs startup parameter, and
  * that servers in a sharded clusters reject cluster times more than
  * maxAcceptableLogicalClockDriftSecs ahead of their wall clocks.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/minvalid2.js
+++ b/jstests/noPassthrough/minvalid2.js
@@ -15,7 +15,7 @@
  * scenario, none of the members will have any data, and upon restart will each look for a member to
  * initial sync from, so no primary will be elected. This test induces such a scenario, so cannot be
  * run on ephemeral storage engines.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  */
 
 print("1. make 3-member set w/arb (2)");

--- a/jstests/noPassthrough/read_majority_reads.js
+++ b/jstests/noPassthrough/read_majority_reads.js
@@ -14,6 +14,8 @@
  * Each operation is tested on a single node, and (if supported) through mongos on both sharded and
  * unsharded collections. Mongos doesn't directly handle readConcern majority, but these tests
  * should ensure that it correctly propagates the setting to the shards when running commands.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/noPassthrough/refresh_logical_session_cache_now.js
+++ b/jstests/noPassthrough/refresh_logical_session_cache_now.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use script";
 

--- a/jstests/noPassthrough/refresh_sessions_command.js
+++ b/jstests/noPassthrough/refresh_sessions_command.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/noPassthrough/retryable_writes_standalone_api.js
+++ b/jstests/noPassthrough/retryable_writes_standalone_api.js
@@ -1,5 +1,7 @@
 /*
  * Verify behavior of retryable write commands on a standalone mongod.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/sessions_collection_auto_healing.js
+++ b/jstests/noPassthrough/sessions_collection_auto_healing.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 load('jstests/libs/sessions_collection.js');
 
 (function() {

--- a/jstests/noPassthrough/shell_can_retry_writes.js
+++ b/jstests/noPassthrough/shell_can_retry_writes.js
@@ -1,6 +1,7 @@
 /**
  * Tests that write operations executed through the mongo shell's CRUD API are assigned a
  * transaction number so that they can be retried.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/shell_can_use_read_concern.js
+++ b/jstests/noPassthrough/shell_can_use_read_concern.js
@@ -1,6 +1,7 @@
 /**
  * Tests that read operations executed through the mongo shell's API are specify afterClusterTime
  * when causal consistency is enabled.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/shell_gossip_cluster_time.js
+++ b/jstests/noPassthrough/shell_gossip_cluster_time.js
@@ -1,6 +1,7 @@
 /**
  * Tests that the mongo shell gossips the greater of the client's clusterTime and the session's
  * clusterTime.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/noPassthrough/skip_sharding_configuration_checks.js
+++ b/jstests/noPassthrough/skip_sharding_configuration_checks.js
@@ -1,6 +1,6 @@
 /**
  *  Starts standalone RS with skipShardingConfigurationChecks.
- *  @tags: [requires_persistence]
+ *  @tags: [requires_persistence, rocks_requires_fcv36]
  */
 (function() {
     'use strict';

--- a/jstests/noPassthrough/start_session_command.js
+++ b/jstests/noPassthrough/start_session_command.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
     var conn;

--- a/jstests/noPassthrough/stepdown_query.js
+++ b/jstests/noPassthrough/stepdown_query.js
@@ -1,6 +1,7 @@
 /**
  * Tests that a query with default read preference ("primary") will succeed even if the node being
  * queried steps down before the final result batch has been delivered.
+ * @tags: [rocks_requires_fcv36]
  */
 
 // Checking UUID consistency involves talking to a shard node, which in this test is shutdown

--- a/jstests/noPassthrough/transaction_reaper.js
+++ b/jstests/noPassthrough/transaction_reaper.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/noPassthrough/unsupported_change_stream_deployments.js
+++ b/jstests/noPassthrough/unsupported_change_stream_deployments.js
@@ -1,4 +1,5 @@
 // Tests that the $changeStream stage returns an error when run against a standalone mongod.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
     load("jstests/aggregation/extras/utils.js");  // For assertErrorCode.

--- a/jstests/noPassthrough/verify_session_cache_updates.js
+++ b/jstests/noPassthrough/verify_session_cache_updates.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/noPassthrough/view_definition_feature_compatibility_version.js
+++ b/jstests/noPassthrough/view_definition_feature_compatibility_version.js
@@ -1,6 +1,7 @@
 // Test that query and aggregation syntax introduced in 3.6 is restricted from view definitions when
 // the featureCompatibilityVersion is 3.4.
 // TODO SERVER-31588: Remove FCV 3.4 validation during the 3.7 development cycle.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/noPassthroughWithMongod/isMaster_feature_compatibility_version.js
+++ b/jstests/noPassthroughWithMongod/isMaster_feature_compatibility_version.js
@@ -2,6 +2,7 @@
 // isMaster with internalClient returns a response with minWireVersion=maxWireVersion. This ensures
 // that an older version mongod/mongos will fail to connect to the node when it is upgraded,
 // upgrading, or downgrading.
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/noPassthroughWithMongod/moveprimary-replset.js
+++ b/jstests/noPassthroughWithMongod/moveprimary-replset.js
@@ -1,6 +1,7 @@
 // This test ensures that data we add on a replica set is still accessible via mongos when we add it
 // as a shard.  Then it makes sure that we can move the primary for this unsharded database to
 // another shard that we add later, and after the move the data is still accessible.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/noPassthroughWithMongod/no_balance_collection.js
+++ b/jstests/noPassthroughWithMongod/no_balance_collection.js
@@ -1,4 +1,5 @@
 // Tests whether the noBalance flag disables balancing for collections
+// @tags: [rocks_requires_fcv36]
 
 var st = new ShardingTest({shards: 2, mongos: 1});
 

--- a/jstests/noPassthroughWithMongod/sharding_migrate_large_docs.js
+++ b/jstests/noPassthroughWithMongod/sharding_migrate_large_docs.js
@@ -1,6 +1,7 @@
 //
 // Tests migration behavior of large documents
 //
+// @tags: [rocks_requires_fcv36]
 
 var st = new ShardingTest({shards: 2, mongos: 1});
 

--- a/jstests/noPassthroughWithMongod/sharding_rs_arb1.js
+++ b/jstests/noPassthroughWithMongod/sharding_rs_arb1.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 var name = "sharding_rs_arb1";
 var replTest = new ReplSetTest({name: name, nodes: 3});
 replTest.startSet();

--- a/jstests/noPassthroughWithMongod/ttl_sharded.js
+++ b/jstests/noPassthroughWithMongod/ttl_sharded.js
@@ -4,6 +4,8 @@
  *  - Checks that both shards have TTL index, and docs get deleted on both shards.
  *  - Run the collMod command to update the expireAfterSeconds field. Check that more docs get
  *    deleted.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 // start up a new sharded cluster

--- a/jstests/parallel/basic.js
+++ b/jstests/parallel/basic.js
@@ -1,4 +1,5 @@
 // perform basic js tests in parallel
+// @tags: [rocks_requires_fcv36]
 load('jstests/libs/parallelTester.js');
 
 Random.setRandomSeed();

--- a/jstests/parallel/basicPlus.js
+++ b/jstests/parallel/basicPlus.js
@@ -1,4 +1,5 @@
 // perform basic js tests in parallel & some other tasks as well
+// @tags: [rocks_requires_fcv36]
 load('jstests/libs/parallelTester.js');
 
 var c = db.jstests_parallel_basicPlus;

--- a/jstests/redaction/redaction_mongos_command_line.js
+++ b/jstests/redaction/redaction_mongos_command_line.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/redaction/redaction_mongos_config.js
+++ b/jstests/redaction/redaction_mongos_config.js
@@ -1,5 +1,6 @@
 // test that security.redactClientLogData configuration parameter is
 // correctly loaded from config file
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     'use strict';

--- a/jstests/redaction/redaction_mongos_setparameter.js
+++ b/jstests/redaction/redaction_mongos_setparameter.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/replsets/apply_ops_concurrent_non_atomic_different_db.js
+++ b/jstests/replsets/apply_ops_concurrent_non_atomic_different_db.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/replsets/apply_ops_concurrent_non_atomic_same_collection.js
+++ b/jstests/replsets/apply_ops_concurrent_non_atomic_same_collection.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/replsets/apply_ops_concurrent_non_atomic_same_db.js
+++ b/jstests/replsets/apply_ops_concurrent_non_atomic_same_db.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/replsets/apply_ops_create_indexes.js
+++ b/jstests/replsets/apply_ops_create_indexes.js
@@ -1,6 +1,7 @@
 /* This test ensures that indexes created by running applyOps are successfully replicated (see
  * SERVER-31435). Both insertion into system.indexes and createIndexes style oplog entries are
  * passed to applyOps here.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/apply_ops_create_with_uuid.js
+++ b/jstests/replsets/apply_ops_create_with_uuid.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     // Test applyOps behavior for collection creation with explicit UUIDs.
     "use strict";

--- a/jstests/replsets/apply_ops_idempotency.js
+++ b/jstests/replsets/apply_ops_idempotency.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
     const debug = 0;

--- a/jstests/replsets/apply_ops_lastop.js
+++ b/jstests/replsets/apply_ops_lastop.js
@@ -1,6 +1,7 @@
 //
 // Test that last optime is updated properly when the applyOps command fails and there's a no-op.
 // lastOp is used as the optime to wait for when write concern waits for replication.
+// @tags: [rocks_requires_fcv36]
 //
 
 (function() {

--- a/jstests/replsets/auth2.js
+++ b/jstests/replsets/auth2.js
@@ -1,7 +1,7 @@
 // Tests authentication with replica sets using key files.
 //
 // This test requires users to persist across a restart.
-// @tags: [requires_persistence]
+// @tags: [requires_persistence, rocks_requires_fcv36]
 
 // We turn off gossiping the mongo shell's clusterTime because this test connects to replica sets
 // and sharded clusters as a user other than __system. Attempting to advance the clusterTime while

--- a/jstests/replsets/catchup.js
+++ b/jstests/replsets/catchup.js
@@ -1,4 +1,5 @@
 // Test the catch-up behavior of new primaries.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/replsets/collection_validator_initial_sync_with_feature_compatibility.js
+++ b/jstests/replsets/collection_validator_initial_sync_with_feature_compatibility.js
@@ -4,7 +4,7 @@
  *
  * We restart the secondary as part of this test with the expecation that it still has the same
  * data after the restart.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  */
 
 load("jstests/replsets/rslib.js");

--- a/jstests/replsets/command_response_operation_time.js
+++ b/jstests/replsets/command_response_operation_time.js
@@ -2,6 +2,7 @@
  * Tests that reads and writes in a replica set return the correct operationTime for their
  * read/write concern level. Majority reads and writes return the last committed optime's timestamp
  * and local reads and writes return the last applied optime's timestamp.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/drop_collections_two_phase_apply_ops_convert_to_capped.js
+++ b/jstests/replsets/drop_collections_two_phase_apply_ops_convert_to_capped.js
@@ -1,5 +1,6 @@
 /**
  * Test to ensure that it is OK to run convertToCapped using applyOps on a drop-pending collection.
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/drop_collections_two_phase_apply_ops_create.js
+++ b/jstests/replsets/drop_collections_two_phase_apply_ops_create.js
@@ -3,6 +3,7 @@
  * drop-pending collection, is a no-op. The existing collection remains in a drop-pending state.
  * This is the same behavior as trying to creating a collection with the same name as an existing
  * collection.
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/drop_collections_two_phase_apply_ops_drop.js
+++ b/jstests/replsets/drop_collections_two_phase_apply_ops_drop.js
@@ -1,6 +1,7 @@
 /**
  * Test to ensure that using applyOps to drop a drop-pending collection is a no-op.
  * By definition, a drop-pending collection will be removed by the server eventually.
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/drop_collections_two_phase_apply_ops_rename.js
+++ b/jstests/replsets/drop_collections_two_phase_apply_ops_rename.js
@@ -1,6 +1,7 @@
 /**
  * Test to ensure that using applyOps to rename a drop-pending collection is a no-op. The collection
  * remains in a drop-pending state. This is the same behavior as renaming a non-existent collection.
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/initial_sync_drop_collection.js
+++ b/jstests/replsets/initial_sync_drop_collection.js
@@ -1,4 +1,5 @@
 // Test that CollectionCloner completes without error when a collection is dropped during cloning.
+// @tags: [rocks_requires_fcv36]
 
 (function() {
     "use strict";

--- a/jstests/replsets/initial_sync_fcv.js
+++ b/jstests/replsets/initial_sync_fcv.js
@@ -2,6 +2,7 @@
  * Tests that setting the feature compatibility version during initial sync leads to initial sync
  * restarting. This test also ensures that even if initial sync takes two attempts to complete,
  * that the fCV is reset between attempts.
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/initial_sync_update_missing_doc3.js
+++ b/jstests/replsets/initial_sync_update_missing_doc3.js
@@ -11,6 +11,7 @@
  * collection on which the document to be fetched resides as drop pending, thus effectively
  * renaming the collection but preserving the UUID. This ensures the secondary fetches the
  * document by UUID rather than namespace.
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/initial_sync_uuid_not_found.js
+++ b/jstests/replsets/initial_sync_uuid_not_found.js
@@ -3,6 +3,7 @@
  * commands using UUIDs instead of namespaces. This verifies initial sync behavior in
  * cases where using UUIDs results in NamespaceNotFound while using namespace strings
  * results in an empty result or zero count.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     'use strict';

--- a/jstests/replsets/last_op_visible.js
+++ b/jstests/replsets/last_op_visible.js
@@ -3,6 +3,7 @@
 // lastOpVisible, and that majority read with afterOpTime of lastOpVisible will return it as well.
 // We then confirm that a writeConcern majority write will be seen as the lastVisibleOp by a
 // majority read.
+// @tags: [rocks_requires_fcv36]
 
 load("jstests/replsets/rslib.js");
 

--- a/jstests/replsets/noop_writes_wait_for_write_concern_fcv.js
+++ b/jstests/replsets/noop_writes_wait_for_write_concern_fcv.js
@@ -1,5 +1,6 @@
 /**
  * Tests that a no-op setFeatureCompatibilityVersion request still waits for write concern.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/operation_time_read_and_write_concern.js
+++ b/jstests/replsets/operation_time_read_and_write_concern.js
@@ -1,6 +1,7 @@
 /**
  * Validates the operationTime value in the command response depends on the read/writeConcern of the
  * the read/write commmand that produced it.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/oplog_format.js
+++ b/jstests/replsets/oplog_format.js
@@ -3,6 +3,7 @@
  *
  * Do not add more tests here but instead add C++ unit tests in db/ops/modifier*_test files
  *
+ * @tags: [rocks_requires_fcv36]
  */
 
 "use strict";

--- a/jstests/replsets/optime.js
+++ b/jstests/replsets/optime.js
@@ -1,4 +1,5 @@
 // Tests tracking of latestOptime and earliestOptime in serverStatus.oplog
+// @tags: [rocks_requires_fcv36]
 
 function timestampCompare(o1, o2) {
     if (o1.t < o2.t) {

--- a/jstests/replsets/refresh_sessions_rs.js
+++ b/jstests/replsets/refresh_sessions_rs.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     "use strict";
 

--- a/jstests/replsets/retryable_writes_direct_write_to_config_transactions.js
+++ b/jstests/replsets/retryable_writes_direct_write_to_config_transactions.js
@@ -1,4 +1,5 @@
 // Validates the expected behaviour of direct writes against the `config.transactions` collection
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/replsets/retryable_writes_failover.js
+++ b/jstests/replsets/retryable_writes_failover.js
@@ -1,6 +1,7 @@
 /**
  * Tests that a retryable write started on one primary can be continued on a different node after
  * failover.
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/rollback_all_op_types.js
+++ b/jstests/replsets/rollback_all_op_types.js
@@ -7,6 +7,8 @@
  * will mock many system components, and sometimes will mock behaviors that don't necessarily match
  * true system behavior i.e. mocking an oplog entry with an incorrect format. So, this integration
  * test provides an additional verification of rollback's correctness within a real replica set.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/rollback_during_downgrade.js
+++ b/jstests/replsets/rollback_during_downgrade.js
@@ -1,6 +1,8 @@
 /**
  * Test that rollback via refetch with no UUID support succeeds during downgrade. This runs various
  * ddl commands that are expected to cause different UUID conflicts among the two nodes.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/rollback_during_upgrade.js
+++ b/jstests/replsets/rollback_during_upgrade.js
@@ -1,6 +1,8 @@
 /**
  * Test that rollback via refetch with no UUID support succeeds during upgrade. This runs various
  * ddl commands that are expected to cause different UUID conflicts among the two nodes.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/rollback_rename_collection_on_sync_source.js
+++ b/jstests/replsets/rollback_rename_collection_on_sync_source.js
@@ -2,6 +2,8 @@
  * Test to ensure that a 'renameCollection' operation that occurs on the sync source past the
  * rollback common point for a collection that also exists on the rollback node will not cause data
  * corruption on the rollback node.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/replsets/rollback_transaction_table.js
+++ b/jstests/replsets/rollback_transaction_table.js
@@ -16,6 +16,7 @@
  *  - There is no record for the second session id.
  *  - A record for the third session id was created during oplog replay.
  *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/sessions_collection_auto_healing.js
+++ b/jstests/replsets/sessions_collection_auto_healing.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 load('jstests/libs/sessions_collection.js');
 
 (function() {

--- a/jstests/replsets/transaction_table_oplog_replay.js
+++ b/jstests/replsets/transaction_table_oplog_replay.js
@@ -1,5 +1,7 @@
 /**
  * Tests that the transaction table is properly updated on secondaries through oplog replay.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 (function() {
     "use strict";

--- a/jstests/replsets/view_definition_initial_sync_with_feature_compatibility.js
+++ b/jstests/replsets/view_definition_initial_sync_with_feature_compatibility.js
@@ -4,7 +4,7 @@
  *
  * We restart the secondary as part of this test with the expectation that it still has the same
  * data after the restart.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  *
  * TODO SERVER-31588: Remove FCV 3.4 validation during the 3.7 development cycle.
  */

--- a/jstests/sharding/shard_aware_init.js
+++ b/jstests/sharding/shard_aware_init.js
@@ -3,7 +3,7 @@
  * to primary (for replica set nodes).
  * Note: test will deliberately cause a mongod instance to terminate abruptly and mongod instance
  * without journaling will complain about unclean shutdown.
- * @tags: [requires_persistence, requires_journaling]
+ * @tags: [requires_persistence, requires_journaling, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/sharding/shard_aware_init_secondaries.js
+++ b/jstests/sharding/shard_aware_init_secondaries.js
@@ -1,7 +1,7 @@
 /**
  * Tests for shard aware initialization on secondaries during startup and shard
  * identity document creation.
- * @tags: [requires_persistence]
+ * @tags: [requires_persistence, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/sharding/shard_identity_rollback.js
+++ b/jstests/sharding/shard_identity_rollback.js
@@ -1,7 +1,7 @@
 /**
  * Tests that rolling back the insertion of the shardIdentity document on a shard causes the node
  * rolling it back to shut down.
- * @tags: [requires_persistence, requires_journaling]
+ * @tags: [requires_persistence, requires_journaling, rocks_requires_fcv36]
  */
 
 (function() {

--- a/jstests/slow1/large_role_chain.js
+++ b/jstests/slow1/large_role_chain.js
@@ -1,5 +1,6 @@
 // Tests SERVER-11475 - Make sure server does't crash when many user defined roles are created where
 // each role is a member of the next, creating a large chain.
+// @tags: [rocks_requires_fcv36]
 
 function runTest(conn) {
     var testdb = conn.getDB("rolechain");

--- a/jstests/slow1/mr_during_migrate.js
+++ b/jstests/slow1/mr_during_migrate.js
@@ -1,4 +1,5 @@
 // Do parallel ops with migrates occurring
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/slow1/sharding_multiple_collections.js
+++ b/jstests/slow1/sharding_multiple_collections.js
@@ -1,3 +1,4 @@
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/ssl/mixed_mode_sharded.js
+++ b/jstests/ssl/mixed_mode_sharded.js
@@ -1,6 +1,8 @@
 /**
  * This test checks if different mixtures of ssl modes
  * in a sharded cluster can or cannot function
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 load("jstests/ssl/libs/ssl_helpers.js");
 

--- a/jstests/ssl/mixed_mode_sharded_transition.js
+++ b/jstests/ssl/mixed_mode_sharded_transition.js
@@ -4,6 +4,8 @@
  *
  * NOTE: This test is similar to the mixed_mode_sharded_transition.js in the sslSpecial
  * test suite. This suite must use ssl so it cannot test modes without ssl.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 load('jstests/ssl/libs/ssl_helpers.js');

--- a/jstests/ssl/sharding_with_x509.js
+++ b/jstests/ssl/sharding_with_x509.js
@@ -1,5 +1,6 @@
 // Tests basic sharding with x509 cluster auth. The purpose is to verify the connectivity between
 // mongos and the shards.
+// @tags: [rocks_requires_fcv36]
 (function() {
     'use strict';
 

--- a/jstests/ssl/x509_client.js
+++ b/jstests/ssl/x509_client.js
@@ -1,4 +1,5 @@
 // Check if this build supports the authenticationMechanisms startup parameter.
+// @tags: [rocks_requires_fcv36]
 var conn = MongoRunner.runMongod({
     smallfiles: "",
     auth: "",

--- a/jstests/sslSpecial/SERVER-26369.js
+++ b/jstests/sslSpecial/SERVER-26369.js
@@ -1,4 +1,5 @@
 // Checking UUID consistency involves talking to a shard node, which in this test is shutdown
+// @tags: [rocks_requires_fcv36]
 TestData.skipCheckingUUIDsConsistentAcrossCluster = true;
 
 (function() {

--- a/jstests/sslSpecial/mixed_mode_sharded_nossl.js
+++ b/jstests/sslSpecial/mixed_mode_sharded_nossl.js
@@ -1,6 +1,8 @@
 /**
  * This test checks if different mixtures of ssl modes
  * in a sharded clutster can or cannot function
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 load("jstests/ssl/libs/ssl_helpers.js");

--- a/jstests/sslSpecial/mixed_mode_sharded_transition_nossl.js
+++ b/jstests/sslSpecial/mixed_mode_sharded_transition_nossl.js
@@ -4,6 +4,8 @@
  *
  * NOTE: This test is similar to the mixed_mode_sharded_transition.js in the ssl
  * test suite. This suite does not use ssl so it cannot test modes with ssl.
+ *
+ * @tags: [rocks_requires_fcv36]
  */
 
 load('jstests/ssl/libs/ssl_helpers.js');

--- a/jstests/tool/gridfs.js
+++ b/jstests/tool/gridfs.js
@@ -1,4 +1,5 @@
 // tests gridfs with a sharded fs.chunks collection.
+// @tags: [rocks_requires_fcv36]
 
 var test = new ShardingTest({shards: 3, mongos: 1, config: 1, verbose: 2, other: {chunkSize: 1}});
 

--- a/src/mongo/shell/replsettest.js
+++ b/src/mongo/shell/replsettest.js
@@ -922,6 +922,10 @@ var ReplSetTest = function(opts) {
                     print("Set shouldWaitForKeys from start options: " + shouldWaitForKeys);
                 }
             }
+            if (jsTest.options().storageEngine === "rocksdb") {
+                shouldWaitForKeys = false;
+                print("Set shouldWaitForKeys to false because running tests for MongoRocks!");
+            }
         }
         /**
          * Blocks until the primary node generates cluster time sign keys.


### PR DESCRIPTION
This PR does 3 things:
1. tags specific tests which cannot run for MongoRocks with `rocks_requires_fcv36`
2. sets `shouldWaitForKeys` to `false` when running tests for MongoRocks because it's not supported in FCV 3.4
3. then additionally tags tests which don't even pass with point  number 2 changed

Filtered test suite which will be run for MongoRocks is here:
https://github.com/Percona-QA/psmdb-misc-scripts/blob/master/suite_sets/resmoke_psmdb_3.6_big_rocksdb_filtered.txt
All the test suites inside which are indented by 1 space will be skipped (example most of the sharding test suites).
It also includes the `--excludeWithAnyTags=requires_fcv36,rocks_requires_fcv36` to skip tagged tests even if the suite is running.

Test run can be seen here:
https://jenkins.percona.com/job/percona-server-for-mongodb-3.6-param/124/testReport/

