### PR TITLE
Fix tests to not archive if archiveFile not specified

### DIFF
--- a/buildscripts/resmokelib/testing/job.py
+++ b/buildscripts/resmokelib/testing/job.py
@@ -115,7 +115,6 @@ class Job(object):
 
         finally:
             success = self.report.find_test_info(test).status == "pass"
-            self.archival.archive(self.logger, test, success)
             if self.archival:
                 self.archival.archive(self.logger, test, success)
 


### PR DESCRIPTION
I think this is a bug, reported upstream: https://jira.mongodb.org/browse/SERVER-36111
On 3.6 and master it should be ok, not sure how this ended up in 3.4.

Let's wait for some tests to finish and then merge this if ok.