### PR TITLE
Implementing nGram tokenizer & search for PSMDB-3.4

### DIFF
--- a/jstests/core/fts_ngram1.js
+++ b/jstests/core/fts_ngram1.js
@@ -1,0 +1,64 @@
+// This is for ngram fts by matt.lee
+// @tags: [assumes_no_implicit_index_creation]
+(function() {
+    "use strict";
+
+    const coll = db.text1;
+    coll.drop();
+
+    assert.commandWorked(coll.createIndex({name:"text"}, {default_language: "ngram", name: "x_ngramtext"}));
+
+    assert.writeOK(coll.insert({ _id: 1, name: "MongoDB는 좋은 비관계형 데이터베이스 서버입니다" }));
+
+    var res_count;
+
+    // Found
+    res_count = coll.find({ $text: { $search: "go" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd 'go'");
+
+    res_count = coll.find({ $text: { $search: "od" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd 'od'");
+
+    res_count = coll.find({ $text: { $search: "좋은" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '좋은'");
+
+    res_count = coll.find({ $text: { $search: "계형" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '계형'");
+
+    res_count = coll.find({ $text: { $search: "데이" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '데이'");
+
+    res_count = coll.find({ $text: { $search: "이터" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '이터'");
+
+    res_count = coll.find({ $text: { $search: "터베" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '터베'");
+
+    res_count = coll.find({ $text: { $search: "베이" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '베이'");
+
+    res_count = coll.find({ $text: { $search: "이스" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '이스'");
+
+    res_count = coll.find({ $text: { $search: "서버" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '서버'");
+
+    res_count = coll.find({ $text: { $search: "버입" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '버입'");
+
+    res_count = coll.find({ $text: { $search: "입니" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '입니'");
+
+    res_count = coll.find({ $text: { $search: "니다" } }).count();
+    assert.eq(1, res_count, "Not found for keyworkd '니다'");
+
+    // Not found
+    res_count = coll.find({ $text: { $search: "나다" } }).count();
+    assert.eq(0, res_count, "Not found for keyworkd '나다'");
+
+    // Index meta info
+    const index = coll.getIndexes().find(index => index.name === "x_ngramtext");
+    assert.neq(index, undefined);
+    assert.gte(index.textIndexVersion, 3, tojson(index));
+    assert.eq(index.default_language, "ngram", tojson(index));
+}());

--- a/jstests/core/fts_ngram1.js
+++ b/jstests/core/fts_ngram1.js
@@ -14,47 +14,47 @@
 
     // Found
     res_count = coll.find({ $text: { $search: "go" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd 'go'");
+    assert.eq(1, res_count, "Not found for keyword 'go'");
 
     res_count = coll.find({ $text: { $search: "od" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd 'od'");
+    assert.eq(1, res_count, "Not found for keyword 'od'");
 
     res_count = coll.find({ $text: { $search: "좋은" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '좋은'");
+    assert.eq(1, res_count, "Not found for keyword '좋은'");
 
     res_count = coll.find({ $text: { $search: "계형" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '계형'");
+    assert.eq(1, res_count, "Not found for keyword '계형'");
 
     res_count = coll.find({ $text: { $search: "데이" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '데이'");
+    assert.eq(1, res_count, "Not found for keyword '데이'");
 
     res_count = coll.find({ $text: { $search: "이터" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '이터'");
+    assert.eq(1, res_count, "Not found for keyword '이터'");
 
     res_count = coll.find({ $text: { $search: "터베" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '터베'");
+    assert.eq(1, res_count, "Not found for keyword '터베'");
 
     res_count = coll.find({ $text: { $search: "베이" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '베이'");
+    assert.eq(1, res_count, "Not found for keyword '베이'");
 
     res_count = coll.find({ $text: { $search: "이스" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '이스'");
+    assert.eq(1, res_count, "Not found for keyword '이스'");
 
     res_count = coll.find({ $text: { $search: "서버" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '서버'");
+    assert.eq(1, res_count, "Not found for keyword '서버'");
 
     res_count = coll.find({ $text: { $search: "버입" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '버입'");
+    assert.eq(1, res_count, "Not found for keyword '버입'");
 
     res_count = coll.find({ $text: { $search: "입니" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '입니'");
+    assert.eq(1, res_count, "Not found for keyword '입니'");
 
     res_count = coll.find({ $text: { $search: "니다" } }).count();
-    assert.eq(1, res_count, "Not found for keyworkd '니다'");
+    assert.eq(1, res_count, "Not found for keyword '니다'");
 
     // Not found
     res_count = coll.find({ $text: { $search: "나다" } }).count();
-    assert.eq(0, res_count, "Not found for keyworkd '나다'");
+    assert.eq(0, res_count, "Not found for keyword '나다'");
 
     // Index meta info
     const index = coll.getIndexes().find(index => index.name === "x_ngramtext");

--- a/jstests/core/fts_ngram2.js
+++ b/jstests/core/fts_ngram2.js
@@ -1,0 +1,61 @@
+// This is for ngram fts by matt.lee
+// @tags: [assumes_no_implicit_index_creation]
+(function() {
+    "use strict";
+
+    const coll = db.text1;
+    coll.drop();
+
+    assert.commandWorked(coll.createIndex({name:"text"}, {default_language: "ngram", name: "x_ngramtext"}));
+
+    assert.writeOK(coll.insert({ _id: 1, name: "MongoDB 3.6은 2016/12일 릴리즈되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 2, name: "MongoDB 3.6은 2016-12일 릴리저되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 3, name: "MongoDB 3.6은 2016+12일 릴리즈되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 4, name: "MongoDB 3.6은 2016*12일 릴리저되었습니다." }));
+
+    var res_count;
+
+    // Single keyword without any special things
+    res_count = coll.find({ $text: { $search: "2016" } }).count();
+    assert.eq(4, res_count, "Result count is not matched for keyword '2016'");
+
+    // Single keyword contains special character
+    res_count = coll.find({ $text: { $search: "2016/12" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyword '2016/12'");
+
+    res_count = coll.find({ $text: { $search: "2016-12" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyword '2016-12'");
+
+    res_count = coll.find({ $text: { $search: "2016+12" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyword '2016+12'");
+
+    res_count = coll.find({ $text: { $search: "2016*12" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyword '2016*12'");
+
+    // Not found
+    res_count = coll.find({ $text: { $search: "2016#12" } }).count();
+    assert.eq(0, res_count, "Result count is not matched for keyword '2016#12'");
+
+    // Phrase search
+    res_count = coll.find({ $text: { $search: "\"2016/12\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"2016/12\"'");
+
+    res_count = coll.find({ $text: { $search: "\"2016-12\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"2016-12\"'");
+
+    res_count = coll.find({ $text: { $search: "\"2016+12\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"2016+12\"'");
+
+    res_count = coll.find({ $text: { $search: "\"2016*12\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"2016*12\"'");
+
+    // Not found
+    res_count = coll.find({ $text: { $search: "\"2016#12\"" } }).count();
+    assert.eq(0, res_count, "Result count is not matched for phrase '\"2016#12\"'");
+
+    // Index meta info
+    const index = coll.getIndexes().find(index => index.name === "x_ngramtext");
+    assert.neq(index, undefined);
+    assert.gte(index.textIndexVersion, 3, tojson(index));
+    assert.eq(index.default_language, "ngram", tojson(index));
+}());

--- a/jstests/core/fts_ngram3.js
+++ b/jstests/core/fts_ngram3.js
@@ -17,14 +17,14 @@
 
     // Single character before and after special character
     res_count = coll.find({ $text: { $search: "6/2" } }).count();
-    assert.eq(1, res_count, "Result count is not matched for keyworkd '6/2'");
+    assert.eq(1, res_count, "Result count is not matched for keyword '6/2'");
 
     res_count = coll.find({ $text: { $search: "6-2" } }).count();
-    assert.eq(1, res_count, "Result count is not matched for keyworkd '6-2'");
+    assert.eq(1, res_count, "Result count is not matched for keyword '6-2'");
 
     // Not found
     res_count = coll.find({ $text: { $search: "6#2" } }).count();
-    assert.eq(0, res_count, "Result count is not matched for keyworkd '6#2'");
+    assert.eq(0, res_count, "Result count is not matched for keyword '6#2'");
 
 
     // Single character before and after special character & phrase search

--- a/jstests/core/fts_ngram3.js
+++ b/jstests/core/fts_ngram3.js
@@ -1,0 +1,52 @@
+// This is for ngram fts by matt.lee
+// @tags: [assumes_no_implicit_index_creation]
+(function() {
+    "use strict";
+
+    const coll = db.text1;
+    coll.drop();
+
+    assert.commandWorked(coll.createIndex({name:"text"}, {default_language: "ngram", name: "x_ngramtext"}));
+
+    assert.writeOK(coll.insert({ _id: 1, name: "MongoDB 3.6은 6/2일 릴리즈되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 2, name: "MongoDB 3.6은 6-2일 릴리저되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 3, name: "MongoDB 3.6은 6+2일 릴리즈되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 4, name: "MongoDB 3.6은 6*2일 릴리저되었습니다." }));
+
+    var res_count;
+
+    // Single character before and after special character
+    res_count = coll.find({ $text: { $search: "6/2" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyworkd '6/2'");
+
+    res_count = coll.find({ $text: { $search: "6-2" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyworkd '6-2'");
+
+    // Not found
+    res_count = coll.find({ $text: { $search: "6#2" } }).count();
+    assert.eq(0, res_count, "Result count is not matched for keyworkd '6#2'");
+
+
+    // Single character before and after special character & phrase search
+    res_count = coll.find({ $text: { $search: "\"6/2\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"6/2\"'");
+
+    res_count = coll.find({ $text: { $search: "\"6-2\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"6-2\"'");
+
+    res_count = coll.find({ $text: { $search: "\"6+2\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"6+2\"'");
+
+    res_count = coll.find({ $text: { $search: "\"6*2\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for phrase '\"6*2\"'");
+
+    // Not found
+    res_count = coll.find({ $text: { $search: "\"6#2\"" } }).count();
+    assert.eq(0, res_count, "Result count is not matched for phrase '\"6#2\"'");
+
+    // Index meta info
+    const index = coll.getIndexes().find(index => index.name === "x_ngramtext");
+    assert.neq(index, undefined);
+    assert.gte(index.textIndexVersion, 3, tojson(index));
+    assert.eq(index.default_language, "ngram", tojson(index));
+}());

--- a/jstests/core/fts_ngram4.js
+++ b/jstests/core/fts_ngram4.js
@@ -1,0 +1,47 @@
+// This is for ngram fts by matt.lee
+// @tags: [assumes_no_implicit_index_creation]
+(function() {
+    "use strict";
+
+    const coll = db.text1;
+    coll.drop();
+
+    assert.commandWorked(coll.createIndex({name:"text"}, {default_language: "ngram", name: "x_ngramtext"}));
+
+    assert.writeOK(coll.insert({ _id: 1, name: "MongoDB 3.6은 6/2일 릴리즈되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 2, name: "MongoDB 3.6은 6-2일 릴리저되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 3, name: "MongoDB 3.6은 6+2일 릴리즈되었습니다." }));
+    assert.writeOK(coll.insert({ _id: 4, name: "MongoDB 3.6은 6*2일 릴리저되었습니다." }));
+
+    var res_count;
+
+    // Text search for over 2 character keyword
+    res_count = coll.find({ $text: { $search: "Mongo" } }).count();
+    assert.eq(4, res_count, "Result count is not matched for keyword 'Mongo'");
+
+    res_count = coll.find({ $text: { $search: "릴리즈" } }).count();
+    assert.eq(2, res_count, "Result count is not matched for keyword '릴리즈'");
+
+    res_count = coll.find({ $text: { $search: "3.6" } }).count();
+    assert.eq(4, res_count, "Result count is not matched for keyword '3.6'");
+
+    res_count = coll.find({ $text: { $search: "Mongo 3.6" } }).count();
+    assert.eq(4, res_count, "Result count is not matched for keyword 'Mongo 3.6'");
+
+    // Phrase search (Not found)
+    res_count = coll.find({ $text: { $search: "\"Mongo 3.6\"" } }).count();
+    assert.eq(0, res_count, "Result count is not matched for keyword '\"Mongo 3.6\"'");
+
+    // Phrase search (Found)
+    res_count = coll.find({ $text: { $search: "\"MongoDB 3.6\"" } }).count();
+    assert.eq(4, res_count, "Result count is not matched for keyword '\"MongoDB 3.6\"'");
+
+    res_count = coll.find({ $text: { $search: "\"6/2일 릴리즈\"" } }).count();
+    assert.eq(1, res_count, "Result count is not matched for keyword '\"6/2일 릴리즈\"'");
+
+    // Index meta info
+    const index = coll.getIndexes().find(index => index.name === "x_ngramtext");
+    assert.neq(index, undefined);
+    assert.gte(index.textIndexVersion, 3, tojson(index));
+    assert.eq(index.default_language, "ngram", tojson(index));
+}());

--- a/src/mongo/db/fts/SConscript
+++ b/src/mongo/db/fts/SConscript
@@ -45,6 +45,7 @@ baseEnv.Library('base', [
         'fts_basic_tokenizer.cpp',
         'fts_unicode_phrase_matcher.cpp',
         'fts_unicode_tokenizer.cpp',
+        'fts_unicode_ngram_tokenizer.cpp',
         'fts_util.cpp',
         'fts_element_iterator.cpp',
         'stemmer.cpp',

--- a/src/mongo/db/fts/fts_language.cpp
+++ b/src/mongo/db/fts/fts_language.cpp
@@ -28,6 +28,8 @@
  *    it in the license file.
  */
 
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
+
 #include "mongo/db/fts/fts_language.h"
 
 #include <string>
@@ -37,11 +39,13 @@
 #include "mongo/db/fts/fts_basic_tokenizer.h"
 #include "mongo/db/fts/fts_unicode_phrase_matcher.h"
 #include "mongo/db/fts/fts_unicode_tokenizer.h"
+#include "mongo/db/fts/fts_unicode_ngram_tokenizer.h"
 #include "mongo/stdx/memory.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/string_map.h"
 #include "mongo/util/stringutils.h"
+#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -122,9 +126,11 @@ MONGO_INITIALIZER_GROUP(FTSAllLanguagesRegistered, MONGO_NO_PREREQUISITES, MONGO
 #define LANGUAGE_DECLV3(id, name, alias) UnicodeFTSLanguage language##id##V3(name);
 
 BasicFTSLanguage languageNoneV2;
+BasicFTSLanguage languageNgramV2;
 MONGO_FTS_LANGUAGE_LIST(LANGUAGE_DECLV2);
 
 UnicodeFTSLanguage languageNoneV3("none");
+UnicodeFTSLanguage languageNgramV3("ngram");
 MONGO_FTS_LANGUAGE_LIST(LANGUAGE_DECLV3);
 
 // Registers each language and language aliases in the language map.
@@ -143,9 +149,11 @@ MONGO_INITIALIZER_GENERAL(FTSRegisterV2LanguagesAndLater,
                           ("FTSAllLanguagesRegistered"))
 (::mongo::InitializerContext* context) {
     FTSLanguage::registerLanguage("none", TEXT_INDEX_VERSION_2, &languageNoneV2);
+    FTSLanguage::registerLanguage("ngram", TEXT_INDEX_VERSION_2, &languageNgramV2);
     MONGO_FTS_LANGUAGE_LIST(LANGUAGE_INITV2);
 
     FTSLanguage::registerLanguage("none", TEXT_INDEX_VERSION_3, &languageNoneV3);
+    FTSLanguage::registerLanguage("ngram", TEXT_INDEX_VERSION_3, &languageNgramV3);
     MONGO_FTS_LANGUAGE_LIST(LANGUAGE_INITV3);
     return Status::OK();
 }
@@ -309,6 +317,9 @@ const FTSPhraseMatcher& BasicFTSLanguage::getPhraseMatcher() const {
 }
 
 std::unique_ptr<FTSTokenizer> UnicodeFTSLanguage::createTokenizer() const {
+	if("ngram" == str()){
+		return stdx::make_unique<UnicodeNgramFTSTokenizer>(this);
+	}
     return stdx::make_unique<UnicodeFTSTokenizer>(this);
 }
 

--- a/src/mongo/db/fts/fts_language.cpp
+++ b/src/mongo/db/fts/fts_language.cpp
@@ -28,8 +28,6 @@
  *    it in the license file.
  */
 
-#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
-
 #include "mongo/db/fts/fts_language.h"
 
 #include <string>
@@ -45,7 +43,6 @@
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/string_map.h"
 #include "mongo/util/stringutils.h"
-#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -317,9 +314,9 @@ const FTSPhraseMatcher& BasicFTSLanguage::getPhraseMatcher() const {
 }
 
 std::unique_ptr<FTSTokenizer> UnicodeFTSLanguage::createTokenizer() const {
-	if("ngram" == str()){
-		return stdx::make_unique<UnicodeNgramFTSTokenizer>(this);
-	}
+    if("ngram" == str()){
+        return stdx::make_unique<UnicodeNgramFTSTokenizer>(this);
+    }
     return stdx::make_unique<UnicodeFTSTokenizer>(this);
 }
 

--- a/src/mongo/db/fts/fts_matcher.cpp
+++ b/src/mongo/db/fts/fts_matcher.cpp
@@ -28,15 +28,12 @@
 *    it in the license file.
 */
 
-#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
-
 #include "mongo/platform/basic.h"
 
 #include "mongo/db/fts/fts_element_iterator.h"
 #include "mongo/db/fts/fts_matcher.h"
 #include "mongo/db/fts/fts_phrase_matcher.h"
 #include "mongo/db/fts/fts_tokenizer.h"
-#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -48,21 +45,21 @@ FTSMatcher::FTSMatcher(const FTSQueryImpl& query, const FTSSpec& spec)
     : _query(query), _spec(spec) {}
 
 bool FTSMatcher::matches(const BSONObj& obj) const {
-	if(_query.getLanguage()!="ngram"){ // Always doing phrase match for Ngram
-		if (canSkipPositiveTermCheck()) {
-			// We can assume that 'obj' has at least one positive term, and dassert as a sanity
-			// check.
-			dassert(hasPositiveTerm(obj));
-		} else {
-			if (!hasPositiveTerm(obj)) {
-				return false;
-			}
-		}
+    if(_query.getLanguage()!="ngram"){ // Always doing phrase match for Ngram
+        if (canSkipPositiveTermCheck()) {
+            // We can assume that 'obj' has at least one positive term, and dassert as a sanity
+            // check.
+            dassert(hasPositiveTerm(obj));
+        } else {
+            if (!hasPositiveTerm(obj)) {
+                return false;
+            }
+        }
 
-		if (hasNegativeTerm(obj)) {
-			return false;
-		}
-	}
+        if (hasNegativeTerm(obj)) {
+            return false;
+        }
+    }
 
     if (!positivePhrasesMatch(obj)) {
         return false;

--- a/src/mongo/db/fts/fts_matcher.cpp
+++ b/src/mongo/db/fts/fts_matcher.cpp
@@ -28,12 +28,15 @@
 *    it in the license file.
 */
 
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
+
 #include "mongo/platform/basic.h"
 
 #include "mongo/db/fts/fts_element_iterator.h"
 #include "mongo/db/fts/fts_matcher.h"
 #include "mongo/db/fts/fts_phrase_matcher.h"
 #include "mongo/db/fts/fts_tokenizer.h"
+#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -45,19 +48,21 @@ FTSMatcher::FTSMatcher(const FTSQueryImpl& query, const FTSSpec& spec)
     : _query(query), _spec(spec) {}
 
 bool FTSMatcher::matches(const BSONObj& obj) const {
-    if (canSkipPositiveTermCheck()) {
-        // We can assume that 'obj' has at least one positive term, and dassert as a sanity
-        // check.
-        dassert(hasPositiveTerm(obj));
-    } else {
-        if (!hasPositiveTerm(obj)) {
-            return false;
-        }
-    }
+	if(_query.getLanguage()!="ngram"){ // Always doing phrase match for Ngram
+		if (canSkipPositiveTermCheck()) {
+			// We can assume that 'obj' has at least one positive term, and dassert as a sanity
+			// check.
+			dassert(hasPositiveTerm(obj));
+		} else {
+			if (!hasPositiveTerm(obj)) {
+				return false;
+			}
+		}
 
-    if (hasNegativeTerm(obj)) {
-        return false;
-    }
+		if (hasNegativeTerm(obj)) {
+			return false;
+		}
+	}
 
     if (!positivePhrasesMatch(obj)) {
         return false;

--- a/src/mongo/db/fts/fts_query_impl.cpp
+++ b/src/mongo/db/fts/fts_query_impl.cpp
@@ -139,11 +139,11 @@ Status FTSQueryImpl::parse(TextIndexVersion textIndexVersion) {
     std::unique_ptr<FTSTokenizer> tokenizer(ftsLanguage.getValue()->createTokenizer());
 
 	if(isNgram){
-		addTermsForNgram(tokenizer.get(), positiveTermSentence, false);
-		addTermsForNgram(tokenizer.get(), negativeTermSentence, true);
+		_addTermsForNgram(tokenizer.get(), positiveTermSentence, false);
+		_addTermsForNgram(tokenizer.get(), negativeTermSentence, true);
 	}else{
-		addTerms(tokenizer.get(), positiveTermSentence, false);
-		addTerms(tokenizer.get(), negativeTermSentence, true);
+		_addTerms(tokenizer.get(), positiveTermSentence, false);
+		_addTerms(tokenizer.get(), negativeTermSentence, true);
 	}
 
     return Status::OK();
@@ -225,7 +225,7 @@ void FTSQueryImpl::_addTermsForNgram(FTSTokenizer* tokenizer, const string& sent
 		string word = tokenizer->get().toString();
 
 		if (!negated) {
-			termsForBounds.insert(word);
+			_termsForBounds.insert(word);
 		}
 	}
 

--- a/src/mongo/db/fts/fts_query_impl.cpp
+++ b/src/mongo/db/fts/fts_query_impl.cpp
@@ -28,6 +28,8 @@
 *    it in the license file.
 */
 
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
+
 #include "mongo/platform/basic.h"
 
 #include "mongo/db/fts/fts_query_impl.h"
@@ -38,6 +40,7 @@
 #include "mongo/stdx/memory.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/stringutils.h"
+#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -56,6 +59,8 @@ Status FTSQueryImpl::parse(TextIndexVersion textIndexVersion) {
         return ftsLanguage.getStatus();
     }
 
+    bool isNgram = getLanguage()=="ngram";
+
     // Build a space delimited list of words to have the FtsTokenizer tokenize
     string positiveTermSentence;
     string negativeTermSentence;
@@ -67,7 +72,7 @@ Status FTSQueryImpl::parse(TextIndexVersion textIndexVersion) {
 
     FTSQueryParser i(getQuery());
     while (i.more()) {
-        QueryToken t = i.next();
+    	QueryToken t = (isNgram) ? i.nextForNgram() : i.next();
 
         if (t.type == QueryToken::TEXT) {
             string s = t.data.toString();
@@ -133,8 +138,13 @@ Status FTSQueryImpl::parse(TextIndexVersion textIndexVersion) {
 
     std::unique_ptr<FTSTokenizer> tokenizer(ftsLanguage.getValue()->createTokenizer());
 
-    _addTerms(tokenizer.get(), positiveTermSentence, false);
-    _addTerms(tokenizer.get(), negativeTermSentence, true);
+	if(isNgram){
+		addTermsForNgram(tokenizer.get(), positiveTermSentence, false);
+		addTermsForNgram(tokenizer.get(), negativeTermSentence, true);
+	}else{
+		addTerms(tokenizer.get(), positiveTermSentence, false);
+		addTerms(tokenizer.get(), negativeTermSentence, true);
+	}
 
     return Status::OK();
 }
@@ -197,6 +207,45 @@ void FTSQueryImpl::_addTerms(FTSTokenizer* tokenizer, const string& sentence, bo
 
         activeTerms.insert(word);
     }
+}
+
+/**
+ * For NGram, all term search and phrase search syntax are processed as phrase-search.
+ * So, if(NGRAM), add all term to phrase list
+ *
+ *   if(NGRAM), token will be added to phrase list (not term list)
+ *   if(not NGRAM), token will be added to term list
+*/
+void FTSQueryImpl::_addTermsForNgram(FTSTokenizer* tokenizer, const string& sentence, bool negated) {
+									 tokenizer->reset(sentence.c_str(), FTSTokenizer::kFilterStopWords);
+	// First, get all the terms for indexing, ie, lower cased words
+	// If we are case-insensitive, we can also used this for positive, and negative terms
+	// Some terms may be expanded into multiple words in some non-English languages
+	while (tokenizer->moveNext()) {
+		string word = tokenizer->get().toString();
+
+		if (!negated) {
+			termsForBounds.insert(word);
+		}
+	}
+
+	// If NGRAM, then add term to phrase list (not term list)
+	auto& activePhrases = negated ? _negatedPhrases : _positivePhrases;
+
+	// Do not ngram based tokenize even if current tokenizer is NGram mode
+	FTSTokenizer::Options newOptions = FTSTokenizer::kGenerateDelimiterTokensForNGram;
+	if (getCaseSensitive()) {
+		newOptions |= FTSTokenizer::kGenerateCaseSensitiveTokens;
+	}
+	if (getDiacriticSensitive()) {
+		newOptions |= FTSTokenizer::kGenerateDiacriticSensitiveTokens;
+	}
+
+	tokenizer->reset(sentence.c_str(), newOptions);
+	while (tokenizer->moveNext()) {
+		string word = tokenizer->get().toString();
+		activePhrases.push_back(word);
+	}
 }
 
 BSONObj FTSQueryImpl::toBSON() const {

--- a/src/mongo/db/fts/fts_query_impl.h
+++ b/src/mongo/db/fts/fts_query_impl.h
@@ -78,6 +78,7 @@ public:
 
 private:
     void _addTerms(FTSTokenizer* tokenizer, const std::string& tokens, bool negated);
+    void _addTermsForNgram(FTSTokenizer* tokenizer, const std::string& tokens, bool negated);
 
     std::set<std::string> _positiveTerms;
     std::set<std::string> _negatedTerms;

--- a/src/mongo/db/fts/fts_query_parser.cpp
+++ b/src/mongo/db/fts/fts_query_parser.cpp
@@ -26,11 +26,14 @@
 *    it in the license file.
 */
 
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
+
 #include <string>
 
 #include "mongo/db/fts/fts_query_parser.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/stringutils.h"
+#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -68,6 +71,41 @@ QueryToken FTSQueryParser::next() {
     _previousWhiteSpace = skipWhitespace();
 
     return QueryToken(type, ret, start, old);
+}
+
+/**
+ * This method will treat intermediate '-' as TEXT,
+ *   Original FTSQueryParser::next() will ignore intermediate '-'.
+*/
+QueryToken FTSQueryParser::nextForNgram() {
+	if (_pos >= _raw.size())
+		return QueryToken(QueryToken::INVALID, "", 0, false);
+
+	unsigned start = _pos++;
+	QueryToken::Type type = getType(_raw[start]);
+
+	// Query Parser should never land on whitespace
+	if (type == QueryToken::WHITESPACE) {
+		invariant(false);
+	}
+
+	if (type == QueryToken::TEXT) {
+		QueryToken::Type t;
+		while(_pos < _raw.size()){
+			t = getType(_raw[_pos]);
+			if(t==QueryToken::TEXT || (t==QueryToken::DELIMITER && '-'==_raw[_pos])){ // Regarding '-' as part of TEXT (if previous character is not SPACE)
+				pos++;
+			}else{
+				break;
+			}
+		}
+	}
+
+	StringData ret = _raw.substr(start, _pos - start);
+	bool old = _previousWhiteSpace;
+	_previousWhiteSpace = skipWhitespace();
+
+	return QueryToken(type, ret, start, old);
 }
 
 bool FTSQueryParser::skipWhitespace() {

--- a/src/mongo/db/fts/fts_query_parser.cpp
+++ b/src/mongo/db/fts/fts_query_parser.cpp
@@ -94,7 +94,7 @@ QueryToken FTSQueryParser::nextForNgram() {
 		while(_pos < _raw.size()){
 			t = getType(_raw[_pos]);
 			if(t==QueryToken::TEXT || (t==QueryToken::DELIMITER && '-'==_raw[_pos])){ // Regarding '-' as part of TEXT (if previous character is not SPACE)
-				pos++;
+				_pos++;
 			}else{
 				break;
 			}

--- a/src/mongo/db/fts/fts_query_parser.cpp
+++ b/src/mongo/db/fts/fts_query_parser.cpp
@@ -26,14 +26,11 @@
 *    it in the license file.
 */
 
-#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
-
 #include <string>
 
 #include "mongo/db/fts/fts_query_parser.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/stringutils.h"
-#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -78,34 +75,34 @@ QueryToken FTSQueryParser::next() {
  *   Original FTSQueryParser::next() will ignore intermediate '-'.
 */
 QueryToken FTSQueryParser::nextForNgram() {
-	if (_pos >= _raw.size())
-		return QueryToken(QueryToken::INVALID, "", 0, false);
+    if (_pos >= _raw.size())
+        return QueryToken(QueryToken::INVALID, "", 0, false);
 
-	unsigned start = _pos++;
-	QueryToken::Type type = getType(_raw[start]);
+    unsigned start = _pos++;
+    QueryToken::Type type = getType(_raw[start]);
 
-	// Query Parser should never land on whitespace
-	if (type == QueryToken::WHITESPACE) {
-		invariant(false);
-	}
+    // Query Parser should never land on whitespace
+    if (type == QueryToken::WHITESPACE) {
+        invariant(false);
+    }
 
-	if (type == QueryToken::TEXT) {
-		QueryToken::Type t;
-		while(_pos < _raw.size()){
-			t = getType(_raw[_pos]);
-			if(t==QueryToken::TEXT || (t==QueryToken::DELIMITER && '-'==_raw[_pos])){ // Regarding '-' as part of TEXT (if previous character is not SPACE)
-				_pos++;
-			}else{
-				break;
-			}
-		}
-	}
+    if (type == QueryToken::TEXT) {
+        QueryToken::Type t;
+        while(_pos < _raw.size()){
+            t = getType(_raw[_pos]);
+            if(t==QueryToken::TEXT || (t==QueryToken::DELIMITER && '-'==_raw[_pos])){ // Regarding '-' as part of TEXT (if previous character is not SPACE)
+                _pos++;
+            }else{
+                break;
+            }
+        }
+    }
 
-	StringData ret = _raw.substr(start, _pos - start);
-	bool old = _previousWhiteSpace;
-	_previousWhiteSpace = skipWhitespace();
+    StringData ret = _raw.substr(start, _pos - start);
+    bool old = _previousWhiteSpace;
+    _previousWhiteSpace = skipWhitespace();
 
-	return QueryToken(type, ret, start, old);
+    return QueryToken(type, ret, start, old);
 }
 
 bool FTSQueryParser::skipWhitespace() {

--- a/src/mongo/db/fts/fts_query_parser.h
+++ b/src/mongo/db/fts/fts_query_parser.h
@@ -75,6 +75,12 @@ public:
     bool more() const;
     QueryToken next();
 
+	/**
+	 * This method will treat intermediate '-' as TEXT,
+	 *   Original FTSQueryParser::next() will ignore intermediate '-'.
+	 */
+	QueryToken nextForNgram();
+
 private:
     QueryToken::Type getType(char c) const;
     bool skipWhitespace();

--- a/src/mongo/db/fts/fts_query_parser.h
+++ b/src/mongo/db/fts/fts_query_parser.h
@@ -75,11 +75,11 @@ public:
     bool more() const;
     QueryToken next();
 
-	/**
-	 * This method will treat intermediate '-' as TEXT,
-	 *   Original FTSQueryParser::next() will ignore intermediate '-'.
-	 */
-	QueryToken nextForNgram();
+    /**
+     * This method will treat intermediate '-' as TEXT,
+     *   Original FTSQueryParser::next() will ignore intermediate '-'.
+     */
+    QueryToken nextForNgram();
 
 private:
     QueryToken::Type getType(char c) const;

--- a/src/mongo/db/fts/fts_tokenizer.h
+++ b/src/mongo/db/fts/fts_tokenizer.h
@@ -79,7 +79,7 @@ public:
      * Generate delimiter based tokens for N-Gram
      * This is need for phrase search(Everything is compared as phrase search in N-gram)
      */
-    static const Options kGenerateDelimiterTokensForNGram = 1 << 3;
+    static const Options kGenerateDelimiterTokensForNGram = 1 << 7;
 
     /**
      * Process a new document, and discards any previous results.

--- a/src/mongo/db/fts/fts_tokenizer.h
+++ b/src/mongo/db/fts/fts_tokenizer.h
@@ -76,6 +76,12 @@ public:
     static const Options kGenerateDiacriticSensitiveTokens = 1 << 2;
 
     /**
+     * Generate delimiter based tokens for N-Gram
+     * This is need for phrase search(Everything is compared as phrase search in N-gram)
+     */
+    static const Options kGenerateDelimiterTokensForNGram = 1 << 3;
+
+    /**
      * Process a new document, and discards any previous results.
      * May be called multiple times on an instance of an iterator.
      */

--- a/src/mongo/db/fts/fts_unicode_ngram_tokenizer.cpp
+++ b/src/mongo/db/fts/fts_unicode_ngram_tokenizer.cpp
@@ -2,8 +2,6 @@
  * nGram tokenizer implementation for Kakao nGram Search
  */
 
-#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
-
 #include "mongo/platform/basic.h"
 
 #include "mongo/db/fts/fts_unicode_ngram_tokenizer.h"
@@ -16,7 +14,6 @@
 #include "mongo/stdx/memory.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/stringutils.h"
-#include "mongo/util/log.h"
 
 /**
  * NGram token size is always 2
@@ -64,15 +61,15 @@ void UnicodeNgramFTSTokenizer::reset(StringData document, Options options) {
 }
 
 bool UnicodeNgramFTSTokenizer::moveNext() {
-	bool hasToken = false;
+    bool hasToken = false;
 
-	if(_options & kGenerateDelimiterTokensForNGram){
-		hasToken = moveNextForDelimiter();
-	}else{
-		hasToken = moveNextForNgram();
-	}
+    if(_options & kGenerateDelimiterTokensForNGram){
+        hasToken = moveNextForDelimiter();
+    }else{
+        hasToken = moveNextForNgram();
+    }
 
-	return hasToken;
+    return hasToken;
 }
 
 bool UnicodeNgramFTSTokenizer::moveNextForNgram(){
@@ -87,7 +84,7 @@ bool UnicodeNgramFTSTokenizer::moveNextForNgram(){
         while (_pos < _document.size()) {
             if(codepointIsDelimiter(_document[_pos])){
                 // Not sufficient characters for NGRAM_TOKEN_SIZE, Ignore this and move DELIMITER-TOKEN
-            	_skipDelimiters();
+                _skipDelimiters();
                 start = _pos;
                 continue;
             }

--- a/src/mongo/db/fts/fts_unicode_ngram_tokenizer.cpp
+++ b/src/mongo/db/fts/fts_unicode_ngram_tokenizer.cpp
@@ -1,0 +1,182 @@
+/**
+ * nGram tokenizer implementation for Kakao nGram Search
+ */
+
+#define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kDefault
+
+#include "mongo/platform/basic.h"
+
+#include "mongo/db/fts/fts_unicode_ngram_tokenizer.h"
+
+#include "mongo/db/fts/fts_query_impl.h"
+#include "mongo/db/fts/fts_spec.h"
+#include "mongo/db/fts/stemmer.h"
+#include "mongo/db/fts/stop_words.h"
+#include "mongo/db/fts/tokenizer.h"
+#include "mongo/stdx/memory.h"
+#include "mongo/util/mongoutils/str.h"
+#include "mongo/util/stringutils.h"
+#include "mongo/util/log.h"
+
+/**
+ * NGram token size is always 2
+ *   If ngram_token_size is greater than 3, mongodb ngram can't search 2-character term.
+ *   So, ngram_token_size=2 is best choice for general purpose.
+ */
+#define NGRAM_TOKEN_SIZE 2
+
+
+namespace mongo {
+namespace fts {
+
+using std::string;
+
+/**
+ * Regarding only below white-space characters as token delimiter.
+ *
+ * 0x09 : HORIZONTAL-TAB
+ * 0x0a : LINE-FEED (\n)
+ * 0x0b : VERTICAL-TAB
+ * 0x0d : CARRIAGE-RETURN (\r)
+ * 0x20 : SPACE
+ */
+bool codepointIsDelimiter(char32_t codepoint){
+    if (codepoint <= 0x7f) {
+      if(codepoint==0x09 || codepoint==0x0a || codepoint==0x0b || codepoint==0x0d || codepoint==0x20)
+        return true;
+    }
+
+    return false;
+}
+
+UnicodeNgramFTSTokenizer::UnicodeNgramFTSTokenizer(const FTSLanguage* language)
+    : _language(language),
+      _caseFoldMode(_language->str() == "turkish" ? unicode::CaseFoldMode::kTurkish
+                                                  : unicode::CaseFoldMode::kNormal) {}
+
+void UnicodeNgramFTSTokenizer::reset(StringData document, Options options) {
+    _options = options;
+    _pos = 0;
+    _document.resetData(document);  // Validates that document is valid UTF8.
+
+    // Skip any leading delimiters (and handle the case where the document is entirely delimiters).
+    _skipDelimiters();
+}
+
+bool UnicodeNgramFTSTokenizer::moveNext() {
+	bool hasToken = false;
+
+	if(_options & kGenerateDelimiterTokensForNGram){
+		hasToken = moveNextForDelimiter();
+	}else{
+		hasToken = moveNextForNgram();
+	}
+
+	return hasToken;
+}
+
+bool UnicodeNgramFTSTokenizer::moveNextForNgram(){
+    while (true) {
+        if (_pos >= _document.size()) {
+            _word = "";
+            return false;
+        }
+
+        // Traverse through non-delimiters and build the next token.
+        size_t start = _pos;
+        while (_pos < _document.size()) {
+            if(codepointIsDelimiter(_document[_pos])){
+                // Not sufficient characters for NGRAM_TOKEN_SIZE, Ignore this and move DELIMITER-TOKEN
+            	_skipDelimiters();
+                start = _pos;
+                continue;
+            }
+
+            if(_pos - start >= NGRAM_TOKEN_SIZE-1){
+                break;
+            }
+            _pos++;
+        }
+
+        if (_pos >= _document.size()) {
+            _word = "";
+            return false;
+        }
+
+        // set next n-gram token start point
+        _pos = start + 1;
+
+        // Skip the delimiters before the next token.
+        _skipDelimiters();
+
+        if (_options & kGenerateCaseSensitiveTokens) {
+            _word = _document.substrToBuf(&_wordBuf, start, NGRAM_TOKEN_SIZE);
+        }else{
+            _word = _document.toLowerToBuf(&_wordBuf, _caseFoldMode, start, NGRAM_TOKEN_SIZE);
+        }
+
+        if (!(_options & kGenerateDiacriticSensitiveTokens)) {
+            // Can't use _wordbuf for output here because our input _word may point into it.
+            _word = unicode::String::caseFoldAndStripDiacritics(
+                &_finalBuf, _word, unicode::String::kCaseSensitive, _caseFoldMode);
+        }
+
+        return true;
+    }
+}
+
+/**
+ * This method is used for phrase matcher
+ *
+ * And this method is come from UnicodeFTSTokenizer::moveNext() with small changes
+ */
+bool UnicodeNgramFTSTokenizer::moveNextForDelimiter() {
+    while (true) {
+        if (_pos >= _document.size()) {
+            _word = "";
+            return false;
+        }
+
+        // Traverse through non-delimiters and build the next token.
+        size_t start = _pos++;
+        while (_pos < _document.size() &&
+               (!codepointIsDelimiter(_document[_pos]))) {
+            ++_pos;
+        }
+        const size_t len = _pos - start;
+
+        // Skip the delimiters before the next token.
+        _skipDelimiters();
+
+        if (_options & kGenerateCaseSensitiveTokens) {
+            _word = _document.substrToBuf(&_wordBuf, start, len);
+        }else{
+            _word = _document.toLowerToBuf(&_wordBuf, _caseFoldMode, start, len);
+        }
+
+        // No stemming in NGram tokenizer
+        // The stemmer is diacritic sensitive, so stem the word before removing diacritics.
+        // _word = _stemmer.stem(_word);
+
+        if (!(_options & kGenerateDiacriticSensitiveTokens)) {
+            // Can't use _wordbuf for output here because our input _word may point into it.
+            _word = unicode::String::caseFoldAndStripDiacritics(
+                &_finalBuf, _word, unicode::String::kCaseSensitive, _caseFoldMode);
+        }
+
+        return true;
+    }
+}
+
+StringData UnicodeNgramFTSTokenizer::get() const {
+    return _word;
+}
+
+void UnicodeNgramFTSTokenizer::_skipDelimiters() {
+    while (_pos < _document.size() && codepointIsDelimiter(_document[_pos])) {
+        ++_pos;
+    }
+}
+
+}  // namespace fts
+}  // namespace mongo

--- a/src/mongo/db/fts/fts_unicode_ngram_tokenizer.h
+++ b/src/mongo/db/fts/fts_unicode_ngram_tokenizer.h
@@ -1,0 +1,67 @@
+/**
+ * nGram tokenizer implementation for Kakao nGram Search
+ */
+
+#pragma once
+
+#include "mongo/base/disallow_copying.h"
+#include "mongo/base/string_data.h"
+#include "mongo/db/fts/fts_tokenizer.h"
+#include "mongo/db/fts/stemmer.h"
+#include "mongo/db/fts/tokenizer.h"
+#include "mongo/db/fts/unicode/string.h"
+
+namespace mongo {
+namespace fts {
+
+class FTSLanguage;
+class StopWords;
+
+/**
+ * UnicodeFTSTokenizer
+ * A iterator of "documents" where a document contains words delimited by a predefined set of
+ * Unicode delimiters (see gen_delimiter_list.py)
+ * Uses
+ * - A list of Unicode delimiters for tokenizing words (see gen_delimiter_list.py).
+ * - tolower from mongo::unicode, which supports UTF-8 simple and Turkish case folding
+ * - Stemmer (ie, Snowball Stemmer) to stem words.
+ * - Embeded stop word lists for each language in StopWord class
+ *
+ * For each word returns a stem version of a word optimized for full text indexing.
+ * Optionally supports returning case sensitive search terms.
+ */
+class UnicodeNgramFTSTokenizer final : public FTSTokenizer {
+    MONGO_DISALLOW_COPYING(UnicodeNgramFTSTokenizer);
+
+public:
+    UnicodeNgramFTSTokenizer(const FTSLanguage* language);
+
+    void reset(StringData document, Options options) override;
+
+    bool moveNext() override;
+
+    StringData get() const override;
+
+private:
+    /**
+     * Helper that moves the tokenizer past all delimiters that shouldn't be considered part of
+     * tokens.
+     */
+    void _skipDelimiters();
+    bool moveNextForDelimiter();
+    bool moveNextForNgram();
+
+    const FTSLanguage* const _language;
+    const unicode::CaseFoldMode _caseFoldMode;
+
+    unicode::String _document;
+    size_t _pos;
+    StringData _word;
+    Options _options;
+
+    StackBufBuilder _wordBuf;
+    StackBufBuilder _finalBuf;
+};
+
+}  // namespace fts
+}  // namespace mongo

--- a/src/mongo/db/fts/ngram-tokenizer.md
+++ b/src/mongo/db/fts/ngram-tokenizer.md
@@ -1,0 +1,107 @@
+# NGRAM
+
+###1) TOKEN DELIMITER
+Unlike MongoDB native delimiter based tokenizer, NGram use only below 5 characters as tokenizer delimiter.
+```
+0x09 : HORIZONTAL-TAB
+0x0a : LINE-FEED (\n)
+0x0b : VERTICAL-TAB
+0x0d : CARRIAGE-RETURN (\r)
+0x20 : SPACE
+```
+
+In MongoDB native full text search, we should use `phrase search` to search the string which contains "-" character.
+```
+db.collection.find({ $text: { $search: "\"2016-12\"" } })
+```
+
+But using NGram tokenizer, we don't need to use `phrase search` because "-" is not a delimiter in NGram tokenizer.
+```
+db.collection.find({ $text: { $search: "2016-12" } })
+
+```
+
+Exceptionally if you use "-" character at first of search string, then NGram search understand that "-" character as negate sign (like MongoDB native full text search). 
+
+For example, NGram full text search does not regarding "-"(in the middle of string) as either delimiter and negate-sign.
+```
+db.collection.find({ $text: { $search: "6-2" } })
+```
+But below case, NGram full text search will do negate search for string of "6-2".
+```
+db.collection.find({ $text: { $search: "-6-2" } })
+```
+
+###2) Create NGram index
+If you specify `{default_language: "ngram"}` option on `createIndex` command, MongoDB will create NGram full text search index. Without this option, MongoDB will create native `delimiter based full text search` index.
+```
+db.collection.createIndex({name:"text"}, {default_language: "ngram"})
+```
+
+###3) Search with NGram index
+
+####3-1) Basic search test
+```
+-- // Insert test document
+db.coll.remove({})
+db.coll.insert({ _id: 11, name: "MongoDB는 좋은 비관계형 데이터베이스 서버입니다" })
+
+-- // Do test query
+db.coll.find({ $text: { $search: "go" } }).count()     -- // ==> 1
+db.coll.find({ $text: { $search: "od" } }).count()     -- // ==> 1
+db.coll.find({ $text: { $search: "좋은" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "계형" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "데이" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "이터" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "터베" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "베이" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "이스" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "서버" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "버입" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "입니" } }).count()    -- // ==> 1
+db.coll.find({ $text: { $search: "니다" } }).count()    -- // ==> 1
+
+db.coll.find({ $text: { $search: "나다 } }).count()    -- // ==> 0
+```
+
+####3-2) Special character search test
+```
+-- // Insert test document
+db.coll.remove({})
+db.coll.insert({ _id: 11, name: "MongoDB 3.6은 2016/12일 릴리즈되었습니다." })
+db.coll.insert({ _id: 12, name: "MongoDB 3.6은 2016-12일 릴리저되었습니다." })
+db.coll.insert({ _id: 13, name: "MongoDB 3.6은 2016+12일 릴리즈되었습니다." })
+db.coll.insert({ _id: 14, name: "MongoDB 3.6은 2016*12일 릴리저되었습니다." })
+
+-- // Do test query
+db.coll.find({ $text: { $search: "2016" } }).count()        -- // ==> 4
+
+db.coll.find({ $text: { $search: "2016/12" } }).count()     -- // ==> 1
+db.coll.find({ $text: { $search: "2016-12" } }).count()     -- // ==> 1
+db.coll.find({ $text: { $search: "2016+12" } }).count()     -- // ==> 1
+db.coll.find({ $text: { $search: "2016*12" } }).count()     -- // ==> 1
+
+db.coll.find({ $text: { $search: "\"2016/12\"" } }).count() -- // ==> 1
+db.coll.find({ $text: { $search: "\"2016-12\"" } }).count() -- // ==> 1
+db.coll.find({ $text: { $search: "\"2016+12\"" } }).count() -- // ==> 1
+db.coll.find({ $text: { $search: "\"2016*12\"" } }).count() -- // ==> 1
+```
+
+####3-3) String contains special char(Single character before & after special char) search test
+```
+-- // Insert test document
+db.coll.remove({})
+db.coll.insert({ _id: 11, name: "MongoDB 3.6은 6/2일 릴리즈되었습니다." })
+db.coll.insert({ _id: 12, name: "MongoDB 3.6은 6-2일 릴리저되었습니다." })
+db.coll.insert({ _id: 13, name: "MongoDB 3.6은 6+2일 릴리즈되었습니다." })
+db.coll.insert({ _id: 14, name: "MongoDB 3.6은 6*2일 릴리저되었습니다." })
+
+-- // Do test query
+db.coll.find({ $text: { $search: "6/2" } }).count()     // ==> 1
+db.coll.find({ $text: { $search: "6-2" } }).count()     // ==> 1
+
+db.coll.find({ $text: { $search: "\"6/2\"" } }).count() // ==> 1
+db.coll.find({ $text: { $search: "\"6-2\"" } }).count() // ==> 1
+db.coll.find({ $text: { $search: "\"6+2\"" } }).count() // ==> 1
+db.coll.find({ $text: { $search: "\"6*2\"" } }).count() // ==> 1
+```


### PR DESCRIPTION
MongoDB's native full text search is based on delimeter tokenizing & stemming using snow-ball.
But this is useless for CJK (Korean, Chinese, Japanese) language, and snow-ball does not support for stemming of CJK language.

So, I have implemented simple nGram tokenizer and search feature for MongoDB.
Actually nGram search engine need to store a lot of key entry, but this implementation use native delimiter based full text search code. So storing FTS key entry is same code path to MongoDB native FTS. So this feature may not suitable for bigger dataset.

For the detailed nGram index usage, See `src/mongo/db/fts/ngram-tokenizer.md`