### PR TITLE
PSMDB-257 MongoDB will not start with a group-readable keyfile owned as root.

### DIFF
--- a/src/mongo/db/auth/security_file.cpp
+++ b/src/mongo/db/auth/security_file.cpp
@@ -61,14 +61,14 @@ StatusWith<std::string> readSecurityFile(const std::string& filename) {
          * bit.
          * These remaining bit should not be set for key file.
          * S_IWGRP -- Group Write.
-         * S_IXGRP -- group Execute.
-         * S_IRWXO -- Read, Write and Execute of user.
+         * S_IXGRP -- Group Execute.
+         * S_IRWXO -- Read, Write and Execute for others.
          * ref: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
          */
         if ((stats.st_mode & (S_IWGRP | S_IXGRP | S_IRWXO)) != 0) {
             return StatusWith<std::string>(ErrorCodes::InvalidPath,
-                                                      str::stream() << "permissions on " << filename
-                                                                    << " are too open");
+                                           str::stream() << "permissions on " << filename
+                                                         << " are too open");
         }
     } else {
         // Check permissions: must be X00, where X is >= 4 in case of non root owner.


### PR DESCRIPTION

In case the owner is root then permission of the key file
can be a bit more open than for the non root users. The owner
write and group read are also permissible values for the
file permission.
-rw--r---- 640, read and write owner of the file and read
bit of group.
These remaining bit should not be set for key file.
 S_IXUSR -- Owner Execute.
 S_IWGRP -- Group Write.
 S_IXGRP -- group Execute.
 S_IRWXO -- Read, Write and Execute of user.

ref: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html