### PR TITLE
PSMDB-257 MongoDB will not start with a group-readable keyfile owned as root.

### DIFF
--- a/src/mongo/db/auth/security_file.cpp
+++ b/src/mongo/db/auth/security_file.cpp
@@ -55,11 +55,30 @@ StatusWith<std::string> readSecurityFile(const std::string& filename) {
     }
 
 #if !defined(_WIN32)
-    // check permissions: must be X00, where X is >= 4
-    if ((stats.st_mode & (S_IRWXG | S_IRWXO)) != 0) {
-        return StatusWith<std::string>(ErrorCodes::InvalidPath,
-                                       str::stream() << "permissions on " << filename
-                                                     << " are too open");
+    if (stats.st_uid == 0) {
+        /* In case the owner is root then permission of the key file
+         * can be a bit more open than for the non root users. The
+         * group read is also permissible values for the file permission.
+         * -rwx--r---- 740 owner read, write and execute and group read
+         * bit.
+         * These remaining bit should not be set for key file.
+         * S_IWGRP -- Group Write.
+         * S_IXGRP -- Group Execute.
+         * S_IRWXO -- Read, Write and Execute for others.
+         * ref: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
+         */
+        if ((stats.st_mode & (S_IWGRP | S_IXGRP | S_IRWXO)) != 0) {
+            return StatusWith<std::string>(ErrorCodes::InvalidPath,
+                                           str::stream() << "permissions on " << filename
+                                                         << " are too open");
+        }
+    } else {
+        // Check permissions: must be X00, where X is >= 4 in case of non root owner.
+        if ((stats.st_mode & (S_IRWXG | S_IRWXO)) != 0) {
+            return StatusWith<std::string>(ErrorCodes::InvalidPath,
+                                           str::stream() << "permissions on " << filename
+                                                         << " are too open");
+        }
     }
 #endif
 


### PR DESCRIPTION
In case the owner is root then permission of the key file
can be a bit more open than for the non root users. The group
read is also permissible values for the file permission.

-rwx--r---- 740, X/R/W bits for owner, and read bit of group.

These remaining bit should not be set for key file.
S_IWGRP -- Group Write.
S_IXGRP -- Group Execute.
S_IRWXO -- Read, Write and Execute for others.

ref: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html