### PR TITLE
PSMDB-257

### DIFF
--- a/src/mongo/db/auth/SConscript
+++ b/src/mongo/db/auth/SConscript
@@ -286,6 +286,7 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/db/server_options_core',
     ],
 )
 

--- a/src/mongo/db/auth/security_file.cpp
+++ b/src/mongo/db/auth/security_file.cpp
@@ -38,6 +38,7 @@
 #include <sys/stat.h>
 
 #include "mongo/base/status_with.h"
+#include "mongo/db/server_options.h"
 #include "mongo/util/mongoutils/str.h"
 
 namespace mongo {
@@ -55,7 +56,7 @@ StatusWith<std::string> readSecurityFile(const std::string& filename) {
     }
 
 #if !defined(_WIN32)
-    if (stats.st_uid == 0) {
+    if (serverGlobalParams.relaxPermChecks && stats.st_uid == 0) {
         /* In case the owner is root then permission of the key file
          * can be a bit more open than for the non root users. The
          * group read is also permissible values for the file permission.

--- a/src/mongo/db/auth/security_file.cpp
+++ b/src/mongo/db/auth/security_file.cpp
@@ -55,11 +55,30 @@ StatusWith<std::string> readSecurityFile(const std::string& filename) {
     }
 
 #if !defined(_WIN32)
-    // check permissions: must be X00, where X is >= 4
-    if ((stats.st_mode & (S_IRWXG | S_IRWXO)) != 0) {
-        return StatusWith<std::string>(ErrorCodes::InvalidPath,
-                                       str::stream() << "permissions on " << filename
-                                                     << " are too open");
+    if (stats.st_uid == 0) {
+        /* In case the owner is root then permission of the key file
+         * can be a bit more open than for the non root users. The
+         * group read is also permissible values for the file permission.
+         * -rwx--r---- 740 owner read, write and execute and group read
+         * bit.
+         * These remaining bit should not be set for key file.
+         * S_IWGRP -- Group Write.
+         * S_IXGRP -- Group Execute.
+         * S_IRWXO -- Read, Write and Execute for others.
+         * ref: https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
+         */
+        if ((stats.st_mode & (S_IWGRP | S_IXGRP | S_IRWXO)) != 0) {
+            return StatusWith<std::string>(ErrorCodes::InvalidPath,
+                                           str::stream() << "permissions on " << filename
+                                                         << " are too open");
+        }
+    } else {
+        // Check permissions: must be X00, where X is >= 4 in case of non root owner.
+        if ((stats.st_mode & (S_IRWXG | S_IRWXO)) != 0) {
+            return StatusWith<std::string>(ErrorCodes::InvalidPath,
+                                           str::stream() << "permissions on " << filename
+                                                         << " are too open");
+        }
     }
 #endif
 

--- a/src/mongo/db/server_options.h
+++ b/src/mongo/db/server_options.h
@@ -95,6 +95,8 @@ struct ServerGlobalParams {
     std::string pidFile;           // Path to pid file, or empty if none.
     std::string timeZoneInfoPath;  // Path to time zone info directory, or empty if none.
 
+    bool relaxPermChecks = false;  // --relaxPermChecks
+
     std::string logpath;            // Path to log file, if logging to a file; otherwise, empty.
     bool logAppend = false;         // True if logging to a file in append mode.
     bool logRenameOnRotate = true;  // True if logging should rename log files on rotate

--- a/src/mongo/db/server_options_server_helpers.cpp
+++ b/src/mongo/db/server_options_server_helpers.cpp
@@ -215,6 +215,14 @@ Status addGeneralServerOptions(moe::OptionSection* options) {
                                moe::Int,
                                unixSockPermsBuilder.str());
 
+    options
+        ->addOptionChaining("security.relaxPermChecks",
+                            "relaxPermChecks",
+                            moe::Switch,
+                            "allow group read and write flags to be set for files specified with"
+                            " --keyFile and --encryptionKeyFile")
+        .hidden();
+
     options->addOptionChaining(
         "processManagement.fork", "fork", moe::Switch, "fork server process");
 
@@ -666,6 +674,10 @@ Status storeServerOptions(const moe::Environment& params) {
     if (params.count("net.unixDomainSocket.filePermissions")) {
         serverGlobalParams.unixSocketPermissions =
             params["net.unixDomainSocket.filePermissions"].as<int>();
+    }
+    if (params.count("security.relaxPermChecks") &&
+        params["security.relaxPermChecks"].as<bool>() == true) {
+        serverGlobalParams.relaxPermChecks = true;
     }
 
     if ((params.count("processManagement.fork") &&

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -75,6 +75,8 @@ private:
     int store_gcm_iv_reserved();
     int reserve_gcm_iv_range();
 
+    void init_masterkey();
+
     static constexpr int _key_len = 32;
     const std::string _path;
     unsigned char _masterkey[_key_len];


### PR DESCRIPTION
New command line switch --relaxPermChecks is introduced. If it is specified then permission checks on files specified with --keyFile and --encryptionKeyFile are modified:
- if such file is owned by root user then read access for users in the group owner is allowed.
Thus modes like 0440 or 0640 are allowed. (Without --relaxPermChecks or when file is not owned by the root user only modes 0400 or 0600 are allowed).