### PR TITLE
 PSMDB - 216 Provide a way to identify MongoDB flavour (MongoDB or PSMDB).

### DIFF
--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -136,7 +136,8 @@ std::string VersionInfoInterface::makeVersionString(StringData binaryName) const
 }
 
 void VersionInfoInterface::appendBuildInfo(BSONObjBuilder* result) const {
-    *result << "version" << version() << "gitVersion" << gitVersion()
+    /* The "PSMDB version" is an additional info to distinguish between MongoDB and PSMDB. */
+    *result << "version" << version() << "PSMDB version" << version() << "gitVersion" << gitVersion()
 #if defined(_WIN32)
             << "targetMinOS" << targetMinOS()
 #endif


### PR DESCRIPTION
Added a new key "PSMDB version" to distinguish between MongoDB and PSMDB.