### PR TITLE
change the way of writing audit log to imporve the auditing performance

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -96,6 +96,8 @@ baseSource=[
     'logger/logstream_builder.cpp',
     'logger/message_event_utf8_encoder.cpp',
     'logger/message_log_domain.cpp',
+    'logger/audit_event_utf8_encoder.cpp',
+    'logger/audit_log_domain.cpp',
     'logger/ramlog.cpp',
     'logger/redaction.cpp',
     'logger/rotatable_file_manager.cpp',

--- a/src/mongo/db/audit.h
+++ b/src/mongo/db/audit.h
@@ -336,4 +336,7 @@ void parseAndRemoveImpersonatedRolesField(BSONObj cmdObj,
                                           bool* fieldIsPresent);
 
 }  // namespace audit
+
+void startAuditLogFlusher();
+
 }  // namespace mongo

--- a/src/mongo/logger/appender.h
+++ b/src/mongo/logger/appender.h
@@ -50,6 +50,11 @@ public:
      * Appends "event", returns Status::OK() on success.
      */
     virtual Status append(const Event& event) = 0;
+
+    /**
+     * Flush ostream.
+     */
+    virtual void flush() {}
 };
 
 }  // namespace logger

--- a/src/mongo/logger/audit_event_utf8_encoder.cpp
+++ b/src/mongo/logger/audit_event_utf8_encoder.cpp
@@ -1,4 +1,4 @@
-/*    Copyright 2013 10gen Inc.
+/*    Copyright (C) 2016 10gen Inc.
  *
  *    This program is free software: you can redistribute it and/or  modify
  *    it under the terms of the GNU Affero General Public License, version 3,
@@ -25,44 +25,30 @@
  *    then also delete it in the license file.
  */
 
-#pragma once
+#include "mongo/platform/basic.h"
 
-#include "mongo/logger/auditlog.h"
-#include "mongo/logger/log_manager.h"
-#include "mongo/logger/message_log_domain.h"
-#include "mongo/logger/rotatable_file_manager.h"
-#include "mongo/logger/audit_log_domain.h"
+#include "mongo/logger/audit_event_utf8_encoder.h"
+
+#include <iostream>
+#include "mongo/db/audit/audit_options.h"
 
 namespace mongo {
 namespace logger {
 
-/**
- * Gets a global singleton instance of RotatableFileManager.
- */
-RotatableFileManager* globalRotatableFileManager();
+AuditEventJSONEncoder::~AuditEventJSONEncoder() {}
 
-/**
- * Gets a global singleton instance of LogManager.
- */
-LogManager* globalLogManager();
-
-/**
- * Gets the global MessageLogDomain associated for the global log manager.
- */
-inline ComponentMessageLogDomain* globalLogDomain() {
-    return globalLogManager()->getGlobalDomain();
-}
-
-/**
- * Sets current audit logger instance.
- */
-//void setAuditLog(AuditLog * const auditLog);
-
-/**
- * Gets the global AuditLogDomain associated for the global log manager.
- */ 
-inline AuditLogDomain* globalAuditLogDomain() {
-    return globalLogManager()->getGlobalAuditDomain();
+std::ostream& AuditEventJSONEncoder::encode(const BSONObj& event,
+                                            std::ostream& os) {
+   // JSON or BSON format
+   if(auditOptions.format == "JSON"){
+       os << event.jsonString();
+   }
+   else{
+       os << event.toString();
+   }
+    
+    os << '\n';
+    return os;
 }
 
 }  // namespace logger

--- a/src/mongo/logger/audit_event_utf8_encoder.h
+++ b/src/mongo/logger/audit_event_utf8_encoder.h
@@ -27,43 +27,23 @@
 
 #pragma once
 
-#include "mongo/logger/auditlog.h"
-#include "mongo/logger/log_manager.h"
-#include "mongo/logger/message_log_domain.h"
-#include "mongo/logger/rotatable_file_manager.h"
-#include "mongo/logger/audit_log_domain.h"
+#include <iosfwd>
+
+#include "mongo/logger/encoder.h"
+#include "mongo/bson/bsonobj.h"
 
 namespace mongo {
 namespace logger {
 
+//class BSONObj;
 /**
- * Gets a global singleton instance of RotatableFileManager.
+ * Encoder that writes log messages of the style that MongoDB writes to console and files.
  */
-RotatableFileManager* globalRotatableFileManager();
-
-/**
- * Gets a global singleton instance of LogManager.
- */
-LogManager* globalLogManager();
-
-/**
- * Gets the global MessageLogDomain associated for the global log manager.
- */
-inline ComponentMessageLogDomain* globalLogDomain() {
-    return globalLogManager()->getGlobalDomain();
-}
-
-/**
- * Sets current audit logger instance.
- */
-//void setAuditLog(AuditLog * const auditLog);
-
-/**
- * Gets the global AuditLogDomain associated for the global log manager.
- */ 
-inline AuditLogDomain* globalAuditLogDomain() {
-    return globalLogManager()->getGlobalAuditDomain();
-}
+class AuditEventJSONEncoder : public Encoder<BSONObj> {
+public:
+    virtual ~AuditEventJSONEncoder();
+    virtual std::ostream& encode(const BSONObj& event, std::ostream& os);
+};
 
 }  // namespace logger
 }  // namespace mongo

--- a/src/mongo/logger/audit_log_domain.cpp
+++ b/src/mongo/logger/audit_log_domain.cpp
@@ -1,4 +1,4 @@
-/*    Copyright 2013 10gen Inc.
+/*    Copyright (C) 2016 Tele-mongo.
  *
  *    This program is free software: you can redistribute it and/or  modify
  *    it under the terms of the GNU Affero General Public License, version 3,
@@ -25,45 +25,16 @@
  *    then also delete it in the license file.
  */
 
-#pragma once
+#include "mongo/platform/basic.h"
 
-#include "mongo/logger/auditlog.h"
-#include "mongo/logger/log_manager.h"
-#include "mongo/logger/message_log_domain.h"
-#include "mongo/logger/rotatable_file_manager.h"
 #include "mongo/logger/audit_log_domain.h"
+
+#include "mongo/logger/log_domain-impl.h"
 
 namespace mongo {
 namespace logger {
 
-/**
- * Gets a global singleton instance of RotatableFileManager.
- */
-RotatableFileManager* globalRotatableFileManager();
-
-/**
- * Gets a global singleton instance of LogManager.
- */
-LogManager* globalLogManager();
-
-/**
- * Gets the global MessageLogDomain associated for the global log manager.
- */
-inline ComponentMessageLogDomain* globalLogDomain() {
-    return globalLogManager()->getGlobalDomain();
-}
-
-/**
- * Sets current audit logger instance.
- */
-//void setAuditLog(AuditLog * const auditLog);
-
-/**
- * Gets the global AuditLogDomain associated for the global log manager.
- */ 
-inline AuditLogDomain* globalAuditLogDomain() {
-    return globalLogManager()->getGlobalAuditDomain();
-}
+template class LogDomain<BSONObj>;
 
 }  // namespace logger
 }  // namespace mongo

--- a/src/mongo/logger/audit_log_domain.h
+++ b/src/mongo/logger/audit_log_domain.h
@@ -1,4 +1,4 @@
-/*    Copyright 2013 10gen Inc.
+/*    Copyright (C) 2016 Tele-mongo.
  *
  *    This program is free software: you can redistribute it and/or  modify
  *    it under the terms of the GNU Affero General Public License, version 3,
@@ -27,43 +27,18 @@
 
 #pragma once
 
-#include "mongo/logger/auditlog.h"
-#include "mongo/logger/log_manager.h"
-#include "mongo/logger/message_log_domain.h"
-#include "mongo/logger/rotatable_file_manager.h"
-#include "mongo/logger/audit_log_domain.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "mongo/logger/log_domain.h"
+#include "mongo/bson/bsonobj.h"
 
 namespace mongo {
 namespace logger {
 
-/**
- * Gets a global singleton instance of RotatableFileManager.
- */
-RotatableFileManager* globalRotatableFileManager();
-
-/**
- * Gets a global singleton instance of LogManager.
- */
-LogManager* globalLogManager();
-
-/**
- * Gets the global MessageLogDomain associated for the global log manager.
- */
-inline ComponentMessageLogDomain* globalLogDomain() {
-    return globalLogManager()->getGlobalDomain();
-}
-
-/**
- * Sets current audit logger instance.
- */
-//void setAuditLog(AuditLog * const auditLog);
-
-/**
- * Gets the global AuditLogDomain associated for the global log manager.
- */ 
-inline AuditLogDomain* globalAuditLogDomain() {
-    return globalLogManager()->getGlobalAuditDomain();
-}
+//class BSONObj;
+typedef LogDomain<BSONObj> AuditLogDomain;
 
 }  // namespace logger
 }  // namespace mongo

--- a/src/mongo/logger/log_domain-impl.h
+++ b/src/mongo/logger/log_domain-impl.h
@@ -68,6 +68,17 @@ Status LogDomain<E>::append(const E& event) {
 }
 
 template <typename E>
+void LogDomain<E>::flush() {
+    for (typename AppenderVector::const_iterator iter = _appenders.begin();
+         iter != _appenders.end();
+         ++iter) {
+        if (*iter) {
+            (*iter)->flush();
+        }
+    }
+}
+
+template <typename E>
 typename LogDomain<E>::AppenderHandle LogDomain<E>::attachAppender(
     typename LogDomain<E>::AppenderAutoPtr appender) {
     typename AppenderVector::iterator iter =

--- a/src/mongo/logger/log_domain.h
+++ b/src/mongo/logger/log_domain.h
@@ -97,6 +97,11 @@ public:
     Status append(const Event& event);
 
     /**
+     * Flush all attached appenders.
+     */
+    void flush();
+    
+    /**
      * Gets the state of the abortOnFailure flag.
      */
     bool getAbortOnFailure() const {

--- a/src/mongo/logger/log_manager.h
+++ b/src/mongo/logger/log_manager.h
@@ -33,6 +33,7 @@
 #include "mongo/logger/component_message_log_domain.h"
 #include "mongo/logger/rotatable_file_writer.h"
 #include "mongo/platform/unordered_map.h"
+#include "mongo/logger/audit_log_domain.h"
 
 namespace mongo {
 namespace logger {
@@ -61,11 +62,19 @@ public:
      */
     MessageLogDomain* getNamedDomain(const std::string& name);
 
+    /**
+     * Gets the global audit domain for this manager.  It has no name.
+     */
+    AuditLogDomain* getGlobalAuditDomain() {
+        return &_globalAuditDomain;
+    }
+
 private:
     typedef unordered_map<std::string, MessageLogDomain*> DomainsByNameMap;
 
     DomainsByNameMap _domains;
     ComponentMessageLogDomain _globalDomain;
+    AuditLogDomain _globalAuditDomain;
 };
 
 }  // namespace logger

--- a/src/mongo/logger/logger.cpp
+++ b/src/mongo/logger/logger.cpp
@@ -58,10 +58,10 @@ MONGO_INITIALIZER_GENERAL(GlobalLogManager, ("ValidateLocale"), ("default"))(Ini
     globalLogManager();
     return Status::OK();
 }
-
+/*
 void setAuditLog(AuditLog * const auditLog) {
     globalRotatableFileManager()->setAuditLog(auditLog);
-}
+}*/
 
 }  // namespace logger
 }  // namespace mongo

--- a/src/mongo/logger/rotatable_file_manager.cpp
+++ b/src/mongo/logger/rotatable_file_manager.cpp
@@ -35,7 +35,7 @@
 namespace mongo {
 namespace logger {
 
-RotatableFileManager::RotatableFileManager() : _auditLog(0) {}
+RotatableFileManager::RotatableFileManager() {}
 
 RotatableFileManager::~RotatableFileManager() {
     for (WriterByNameMap::iterator iter = _writers.begin(); iter != _writers.end(); ++iter) {
@@ -72,15 +72,15 @@ RotatableFileManager::FileNameStatusPairVector RotatableFileManager::rotateAll(
             badStatuses.push_back(std::make_pair(iter->first, status));
         }
     }
-    if (_auditLog) {
+   /* if (_auditLog) {
         _auditLog->rotate();
-    }
+    }*/
     return badStatuses;
 }
-
+/*
 void RotatableFileManager::setAuditLog(AuditLog * const auditLog) {
     _auditLog = auditLog;
-}
+}*/
 
 }  // namespace logger
 }  // namespace mongo

--- a/src/mongo/logger/rotatable_file_manager.h
+++ b/src/mongo/logger/rotatable_file_manager.h
@@ -86,13 +86,13 @@ public:
     /**
      * Set AuditLog instance for rotating.
      */
-    void setAuditLog(AuditLog * const auditLog);
+ //   void setAuditLog(AuditLog * const auditLog);
 
 private:
     typedef unordered_map<std::string, RotatableFileWriter*> WriterByNameMap;
 
     WriterByNameMap _writers;
-    AuditLog * _auditLog;
+//    AuditLog * _auditLog;
 };
 
 }  // namespace logger


### PR DESCRIPTION
The old way of writing audit log is not effective.  If we enable audit log,  it will cause the mongod server  performance drop significantly. It makes the auditing module not practical.  This commit significantly imporves the auditing performance by changing the way of writing audit log , imitating the way of writing error log but in an asynchronous way. Besides,  the json format audit log performance is much lower than the bson format.  You will need this commit to fix it. https://github.com/mongodb/mongo/commit/f10f21467c2c0ae7586c5c9d327f2328f09d655c#diff-e0d97d4d1451686d353bffaa551848e7