### PR TITLE
Fix python3 path in libs/python.js and ssl/ssl_ECDHE_suites.js

### DIFF
--- a/jstests/libs/python.js
+++ b/jstests/libs/python.js
@@ -3,7 +3,8 @@
 function getPython3Binary() {
     'use strict';
 
-    let cmd = '/opt/mongodbtoolchain/v3/bin/python3';
+    //let cmd = '/opt/mongodbtoolchain/v3/bin/python3';
+    let cmd = '/usr/bin/python3';
     if (_isWindows()) {
         const paths = ["c:/python36/python.exe", "c:/python/python36/python.exe"];
         for (let p of paths) {

--- a/jstests/ssl/ssl_ECDHE_suites.js
+++ b/jstests/ssl/ssl_ECDHE_suites.js
@@ -37,7 +37,7 @@ load('jstests/ssl/libs/ssl_helpers.js');
     // Use new toolchain python, if it exists
     let python_binary = '/opt/mongodbtoolchain/v3/bin/python3';
     if (runProgram('/bin/sh', '-c', 'ls ' + python_binary) !== 0) {
-        python_binary = '/opt/mongodbtoolchain/v3/bin/python3';
+        python_binary = '/usr/bin/python3';
     }
 
     // Run the tls cipher suite enumerator


### PR DESCRIPTION
This should resolve issue with nopassthrough tests that failed because they couldn't find python3 binary.
This is the run with the fix:
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.2-param/6/testReport/(root)/no_passthrough_wiredTiger/

The error looked like this:
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.2-param/2/testReport/(root)/no_passthrough_wiredTiger/jstests_noPassthrough_configExpand_exec_permissions_js/