### PR TITLE
PSMDB-600 fix dhandle->session_inuse counter leak in __evict_walk

### DIFF
--- a/src/third_party/wiredtiger/src/evict/evict_lru.c
+++ b/src/third_party/wiredtiger/src/evict/evict_lru.c
@@ -1547,6 +1547,11 @@ retry:	while (slot < max_entries) {
 err:	if (dhandle_locked)
 		__wt_readunlock(session, &conn->dhandle_lock);
 
+	if (incr) {
+		WT_ASSERT(session, dhandle->session_inuse > 0);
+		(void)__wt_atomic_subi32(&dhandle->session_inuse, 1);
+	}
+
 	/*
 	 * If we didn't find any entries on a walk when we weren't interrupted,
 	 * let our caller know.


### PR DESCRIPTION
In __evict_walk, the dhandle->session_inuse counter is increased and decreased to walk the tree but in case of errors, the code jumps over the code that decreases the counter and basically leaves the dhandle as in-use so it never gets deleted during sweeps.

This patch adds a fix to decrease the counter even in case of errors.