### PR TITLE
PSMDB-627 strip build suffix in version numbers for multiversion tests

### DIFF
--- a/jstests/multiVersion/libs/verify_versions.js
+++ b/jstests/multiVersion/libs/verify_versions.js
@@ -7,6 +7,12 @@ var Mongo, assert;
     "use strict";
     Mongo.prototype.getBinVersion = function() {
         var result = this.getDB("admin").runCommand({serverStatus: 1});
+        // strip Percona build suffix
+        var ret = result.version;
+        var i = ret.indexOf("-");
+        if (i != -1) {
+            return ret.substring(0, i);
+        }
         return result.version;
     };
 


### PR DESCRIPTION
multiversion tests don't care about build numbers so we can safely
ignore them