### PR TITLE
ENG-197: [PSMDB42] Introduce linking script 

### DIFF
--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -194,15 +194,18 @@ get_sources(){
 
 get_system(){
     if [ -f /etc/redhat-release ]; then
+        GLIBC_VER_TMP="$(rpm glibc -qa --qf %{VERSION})"
         RHEL=$(rpm --eval %rhel)
         ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
         OS_NAME="el$RHEL"
         OS="rpm"
     else
+        GLIBC_VER_TMP="$(dpkg-query -W -f='${Version}' libc6 | awk -F'-' '{print $1}')"
         ARCH=$(uname -m)
         OS_NAME="$(lsb_release -sc)"
         OS="deb"
     fi
+    export GLIBC_VER=".glibc${GLIBC_VER_TMP}"
     return
 }
 
@@ -326,7 +329,10 @@ install_deps() {
       add_percona_yum_repo
       wget http://jenkins.percona.com/yum-repo/percona-dev.repo
       mv -f percona-dev.repo /etc/yum.repos.d/
+      yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+      percona-release enable tools testing
       yum clean all
+      yum install -y patchelf
       RHEL=$(rpm --eval %rhel)
       if [ x"$RHEL" = x6 ]; then
         yum -y update
@@ -386,8 +392,11 @@ EOL
         rm -f /etc/apt/sources.list.d/stretch.list
         apt-get -y update
       fi
+      wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb && dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+      percona-release enable tools testing
+      apt-get update
       INSTALL_LIST="python3 python3-dev python3-pip valgrind scons liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev dh-systemd libsasl2-dev gcc g++ cmake curl"
-      INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev"
+      INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev patchelf"
       until apt-get -y install dirmngr; do
         sleep 1
         echo "waiting"
@@ -735,13 +744,11 @@ build_tarball(){
     TARBALL_SUFFIX=".dbg"
     fi
     if [ -f /etc/debian_version ]; then
-        export OS_RELEASE="$(lsb_release -sc)"
         set_compiler
     fi
     #
     if [ -f /etc/redhat-release ]; then
     #export OS_RELEASE="centos$(lsb_release -sr | awk -F'.' '{print $1}')"
-        export OS_RELEASE="centos$(rpm --eval %rhel)"
         RHEL=$(rpm --eval %rhel)
         if [ -f /opt/rh/devtoolset-8/enable ]; then
             source /opt/rh/devtoolset-8/enable
@@ -880,16 +887,94 @@ build_tarball(){
     sed -i "s:TARBALL=0:TARBALL=1:" ${PSMDIR_ABS}/percona-packaging/conf/percona-server-mongodb-enable-auth.sh
     cp ${PSMDIR_ABS}/percona-packaging/conf/percona-server-mongodb-enable-auth.sh ${PSMDIR_ABS}/${PSMDIR}/bin
 
+    # Patch needed libraries
+    cd "${PSMDIR_ABS}/${PSMDIR}"
+    if [ ! -d lib/private ]; then
+        mkdir -p lib/private
+    fi
+    LIBLIST="libcrypto.so libssl.so libpcap.so libsasl2.so libcurl.so libldap liblber libssh libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libfreebl3.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so libplds4.so"
+    DIRLIST="bin lib/private"
+
+    LIBPATH=""
+
+    function gather_libs {
+        local elf_path=$1
+        for lib in $LIBLIST; do
+            for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+                IFS=$'\n'
+                for libfromelf in $(ldd $elf | grep $lib | awk '{print $3}'); do
+                    if [ ! -f lib/private/$(basename $(readlink -f $libfromelf)) ] && [ ! -L lib/$(basename $(readlink -f $libfromelf)) ]; then
+                        echo "Copying lib $(basename $(readlink -f $libfromelf))"
+                        cp $(readlink -f $libfromelf) lib/private
+
+                        echo "Symlinking lib $(basename $(readlink -f $libfromelf))"
+                        cd lib
+                        ln -s private/$(basename $(readlink -f $libfromelf)) $(basename $(readlink -f $libfromelf))
+                        cd -
+                        
+                        LIBPATH+=" $(echo $libfromelf | grep -v $(pwd))"
+                    fi
+                done
+                unset IFS
+            done
+        done
+    }
+
+    function set_runpath {
+        # Set proper runpath for bins but check before doing anything
+        local elf_path=$1
+        local r_path=$2
+        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            echo "Checking LD_RUNPATH for $elf"
+            if [ -z $(patchelf --print-rpath $elf) ]; then
+                echo "Changing RUNPATH for $elf"
+                patchelf --set-rpath $r_path $elf
+            fi
+        done
+    }
+
+    function replace_libs {
+        local elf_path=$1
+        for libpath_sorted in $LIBPATH; do
+            for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+                LDD=$(ldd $elf | grep $libpath_sorted|head -n1|awk '{print $1}')
+                if [[ ! -z $LDD  ]]; then
+                    echo "Replacing lib $(basename $(readlink -f $libpath_sorted)) for $elf"
+                    patchelf --replace-needed $LDD $(basename $(readlink -f $libpath_sorted)) $elf
+                fi
+                # Add if present in LDD to NEEDED
+                if [[ ! -z $LDD ]] && [[ -z "$(readelf -d $elf | grep $(basename $libpath_sorted | awk -F'.' '{print $1}'))" ]]; then
+                    patchelf --add-needed $(basename $(readlink -f $libpath_sorted)) $elf
+                fi
+            done
+        done
+    }
+
+    # Gather libs
+    for DIR in $DIRLIST; do
+        gather_libs $DIR
+    done
+
+    # Set proper runpath
+    set_runpath bin '$ORIGIN/../lib/private/'
+    set_runpath lib/private '$ORIGIN/'
+    
+    # Replace libs
+    for DIR in $DIRLIST; do
+        replace_libs $DIR
+    done
+
     cd ${PSMDIR_ABS}
-    tar --owner=0 --group=0 -czf ${WORKDIR}/${PSMDIR}-${OS_RELEASE}-${ARCH}${TARBALL_SUFFIX}.tar.gz ${PSMDIR}
+    mv ${PSMDIR} ${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}
+    tar --owner=0 --group=0 -czf ${WORKDIR}/${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}.tar.gz ${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}
     DIRNAME="tarball"
     if [ "${DEBUG}" = 1 ]; then
     DIRNAME="debug"
     fi
     mkdir -p ${WORKDIR}/${DIRNAME}
     mkdir -p ${CURDIR}/${DIRNAME}
-    cp ${WORKDIR}/${PSMDIR}-${OS_RELEASE}-${ARCH}${TARBALL_SUFFIX}.tar.gz ${WORKDIR}/${DIRNAME}
-    cp ${WORKDIR}/${PSMDIR}-${OS_RELEASE}-${ARCH}${TARBALL_SUFFIX}.tar.gz ${CURDIR}/${DIRNAME}
+    cp ${WORKDIR}/${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}.tar.gz ${WORKDIR}/${DIRNAME}
+    cp ${WORKDIR}/${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}.tar.gz ${CURDIR}/${DIRNAME}
 }
 
 #main

--- a/percona-packaging/scripts/test-build.sh
+++ b/percona-packaging/scripts/test-build.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+function check_libs {
+    for elf in $(find $1 -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+        echo $elf
+        ldd $elf | grep "not found"
+    done
+    return
+}
+
+function prepare {
+    CURDIR=$(pwd)
+
+    mkdir -p $CURDIR/temp
+    TMP_DIR=$CURDIR/temp
+    
+    TARBALL=$(basename $(find . -name "*glibc2.12.tar.gz" | sort))
+}
+
+function install_deps {
+    if [ -f /etc/redhat-release ]; then 
+        yum install -y perl-Time-HiRes perl numactl numactl-libs libaio git libidn || true
+    else
+        apt install -y perl numactl libaio-dev git libidn11 || true
+    fi
+}
+
+main () {
+
+    DIRLIST="bin lib lib/private lib/plugin"
+
+    prepare
+
+    echo "Unpacking tarball"
+    cd $TMP_DIR
+    tar xf $CURDIR/$TARBALL
+    cd ${TARBALL%.tar.gz}
+
+    echo "Checking ELFs for not found"
+    for DIR in $DIRLIST; do
+        check_libs $DIR | tee -a $TMP_DIR/libs_err.log
+    done
+
+    if [[ ! -z $(cat $TMP_DIR/libs_err.log | grep "not found") ]]; then
+        echo "ERROR: There are missing libraries: "
+        cat $TMP_DIR/libs_err.log
+        exit 1
+    fi
+
+    # Run tests
+    mkdir -p $TMP_DIR/db tests
+    wget -O $TMP_DIR/mgodatagen.tar.gz https://github.com/feliixx/mgodatagen/releases/download/v0.8.2/mgodatagen_linux_x86_64.tar.gz
+    wget -O tests/big.json https://raw.githubusercontent.com/feliixx/mgodatagen/master/datagen/testdata/big.json
+    tar -xvf $TMP_DIR/mgodatagen.tar.gz
+
+    ./bin/mongod --dbpath $TMP_DIR/db 2>&1 > status.log &
+    MONGOPID=$(echo $!)
+    ./mgodatagen -f tests/big.json
+    if [ $? -eq 0 ]; then
+        echo "Tests succeeded"
+        kill -2 $MONGOPID
+        echo " == PSMDB Log =="
+        cat status.log
+    else
+        echo "Tests failed"
+        exit 1
+    fi
+}
+
+case "$1" in
+    --install_deps) install_deps ;;
+    --test) main ;;
+    --help|*)
+    cat <<EOF
+Usage: $0 [OPTIONS]
+    The following options may be given :
+        --install_deps
+        --test
+        --help) usage ;;
+Example $0 --install_deps 
+EOF
+    ;;
+esac


### PR DESCRIPTION
Libraries which we have to add defined in `LIBS=` variable, without any version with `.so` extension

Mechanism of needed library extraction with version lies in ldd output of each ELF file, in order to copy needed version also checks for symlinks and copies real file instead of symlink

And if binary uses a symlink of shared library `patchelf --replace-needed` replaces needed lib with one can be reached in `lib/private` directory which became `LD_RUNPATH` of all ELF files

#### .so LIBS
|OS     |GLIBC |SASL |OpenSSL |PCAP   |CURL   |LDAP     |
|-------|------|-----|--------|-------|-------|---------|
|el6    |`2.12`|`6.0`|`1.0.1e`|`1.4.0`|`4.1.1`|`2.10.3` |
|el7    |`2.17`|`6.2`|`1.0.2k`|`1.5.3`|`4.3.0`|`2.10.7` |
|el8    |`2.28`|`7.0`|`1.1.1c`|`1.9.0`|`4.5.0`|`2.10.9` |
|deb9   |`2.24`|`7.0`|`1.1`   |`1.8.1`|`4.4.0`|`2.10.7` |
|deb10  |`2.28`|`7.0`|`1.1`   |`1.8.1`|`4.5.0`|`2.10.10`|
|ub16.04|`2.23`|`6.3`|`1.1`   |`1.7.4`|`4.4.0`|`2.10.5` |
|ub18.04|`2.27`|`7.0`|`1.1`   |`1.8.1`|`4.5.0`|`2.10.8` |
|ub20.04|`2.31`|`8.0`|`1.1`   |`1.9.1`|`4.6.0`|`2.10.12`|

All `.so` libs list:
`libcrypto.so libssl.so libpcap.so libsasl2.so libcurl.so libldap liblber libssh.so libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libhcrypto.so libheimbase.so libcrypt.so libwind.so libhx509.so libasn1.so libheimntlm.so libroken.so"`

* Ubuntu versions have `heimdal-libs` installed by default as dependency for `libcurl.so`


### Issues:

* Same as https://github.com/percona/percona-server/pull/3838 has, needs to be executed with our patchelf

### Tests:

* Cross OS same glibc ver run test:
- Compiled on CentOS 8
- Tested on Debian 10

```
root@debian-10:/mnt/percona-server-mongodb-4.2.6-6/bin# ./mongod
2020-06-01T00:51:06.585-0700 I  CONTROL  [main] Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'
2020-06-01T00:51:06.588-0700 W  ASIO     [main] No TransportLayer configured during NetworkInterface startup
2020-06-01T00:51:06.588-0700 I  CONTROL  [initandlisten] MongoDB starting : pid=1261 port=27017 dbpath=/data/db 64-bit host=debian-10
2020-06-01T00:51:06.588-0700 I  CONTROL  [initandlisten] db version v4.2.6-6
2020-06-01T00:51:06.588-0700 I  CONTROL  [initandlisten] git version: 01b543902d46411b252b0201c72268f198555c97
2020-06-01T00:51:06.588-0700 I  CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.1.1c FIPS  28 May 2019
2020-06-01T00:51:06.589-0700 I  CONTROL  [initandlisten] allocator: tcmalloc
2020-06-01T00:51:06.589-0700 I  CONTROL  [initandlisten] modules: none
2020-06-01T00:51:06.589-0700 I  CONTROL  [initandlisten] build environment:
2020-06-01T00:51:06.589-0700 I  CONTROL  [initandlisten]     distarch: x86_64
2020-06-01T00:51:06.589-0700 I  CONTROL  [initandlisten]     target_arch: x86_64
2020-06-01T00:51:06.589-0700 I  CONTROL  [initandlisten] options: {}
2020-06-01T00:51:06.589-0700 I  STORAGE  [initandlisten]
2020-06-01T00:51:06.589-0700 I  STORAGE  [initandlisten] ** WARNING: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine
2020-06-01T00:51:06.589-0700 I  STORAGE  [initandlisten] **          See http://dochub.mongodb.org/core/prodnotes-filesystem
2020-06-01T00:51:06.589-0700 I  STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=256M,cache_overflow=(file_max=0M),session_max=33000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000,close_scan_interval=10,close_handle_minimum=250),statistics_log=(wait=0),verbose=[recovery_progress,checkpoint_progress],
2020-06-01T00:51:07.022-0700 I  STORAGE  [initandlisten] WiredTiger message [1590997867:22065][1261:0x7fe3a31130c0], txn-recover: Set global recovery timestamp: (0, 0)
2020-06-01T00:51:07.026-0700 I  RECOVERY [initandlisten] WiredTiger recoveryTimestamp. Ts: Timestamp(0, 0)
2020-06-01T00:51:07.032-0700 I  STORAGE  [initandlisten] Timestamp monitor starting
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten]
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] **          You can use percona-server-mongodb-enable-auth.sh to fix it.
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] ** WARNING: You are running this process as the root user, which is not recommended.
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten]
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] ** WARNING: This server is bound to localhost.
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] **          Remote systems will be unable to connect to this server.
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] **          Start the server with --bind_ip <address> to specify which IP
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] **          addresses it should serve responses from, or with --bind_ip_all to
2020-06-01T00:51:07.032-0700 I  CONTROL  [initandlisten] **          bind to all interfaces. If this behavior is desired, start the
2020-06-01T00:51:07.033-0700 I  CONTROL  [initandlisten] **          server with --bind_ip 127.0.0.1 to disable this warning.
2020-06-01T00:51:07.033-0700 I  CONTROL  [initandlisten]
2020-06-01T00:51:07.033-0700 I  CONTROL  [initandlisten]
2020-06-01T00:51:07.033-0700 I  CONTROL  [initandlisten] ** WARNING: /sys/kernel/mm/transparent_hugepage/enabled is 'always'.
2020-06-01T00:51:07.033-0700 I  CONTROL  [initandlisten] **        We suggest setting it to 'never'
2020-06-01T00:51:07.033-0700 I  CONTROL  [initandlisten]
2020-06-01T00:51:07.033-0700 I  STORAGE  [initandlisten] createCollection: admin.system.version with provided UUID: 76a2174b-68e8-42b0-bfe8-ea2914257d2a and options: { uuid: UUID("76a2174b-68e8-42b0-bfe8-ea2914257d2a") }
2020-06-01T00:51:07.037-0700 I  INDEX    [initandlisten] index build: done building index _id_ on ns admin.system.version
2020-06-01T00:51:07.038-0700 I  SHARDING [initandlisten] Marking collection admin.system.version as collection version: <unsharded>
2020-06-01T00:51:07.038-0700 I  COMMAND  [initandlisten] setting featureCompatibilityVersion to 4.2
2020-06-01T00:51:07.038-0700 I  SHARDING [initandlisten] Marking collection local.system.replset as collection version: <unsharded>
2020-06-01T00:51:07.038-0700 I  STORAGE  [initandlisten] Flow Control is enabled on this deployment.
2020-06-01T00:51:07.038-0700 I  SHARDING [initandlisten] Marking collection admin.system.roles as collection version: <unsharded>
2020-06-01T00:51:07.039-0700 I  STORAGE  [initandlisten] createCollection: local.startup_log with generated UUID: f701ede6-c87d-4813-83d1-88e837a2f55a and options: { capped: true, size: 10485760 }
2020-06-01T00:51:07.042-0700 I  INDEX    [initandlisten] index build: done building index _id_ on ns local.startup_log
2020-06-01T00:51:07.043-0700 I  SHARDING [initandlisten] Marking collection local.startup_log as collection version: <unsharded>
2020-06-01T00:51:07.043-0700 I  FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/data/db/diagnostic.data'
2020-06-01T00:51:07.045-0700 I  SHARDING [LogicalSessionCacheRefresh] Marking collection config.system.sessions as collection version: <unsharded>
2020-06-01T00:51:07.046-0700 I  STORAGE  [LogicalSessionCacheRefresh] createCollection: config.system.sessions with provided UUID: 9cef1a92-a13a-4b24-8e0a-992fe0c4ecd0 and options: { uuid: UUID("9cef1a92-a13a-4b24-8e0a-992fe0c4ecd0") }
2020-06-01T00:51:07.048-0700 I  NETWORK  [listener] Listening on /tmp/mongodb-27017.sock
2020-06-01T00:51:07.049-0700 I  NETWORK  [listener] Listening on 127.0.0.1
2020-06-01T00:51:07.050-0700 I  NETWORK  [listener] waiting for connections on port 27017
2020-06-01T00:51:07.051-0700 I  INDEX    [LogicalSessionCacheRefresh] index build: done building index _id_ on ns config.system.sessions
2020-06-01T00:51:07.055-0700 I  INDEX    [LogicalSessionCacheRefresh] index build: starting on config.system.sessions properties: { v: 2, key: { lastUse: 1 }, name: "lsidTTLIndex", ns: "config.system.sessions", expireAfterSeconds: 1800 } using method: Hybrid
2020-06-01T00:51:07.055-0700 I  INDEX    [LogicalSessionCacheRefresh] build may temporarily use up to 200 megabytes of RAM
2020-06-01T00:51:07.056-0700 I  INDEX    [LogicalSessionCacheRefresh] index build: collection scan done. scanned 0 total records in 0 seconds
2020-06-01T00:51:07.057-0700 I  INDEX    [LogicalSessionCacheRefresh] index build: inserted 0 keys from external sorter into index in 0 seconds
2020-06-01T00:51:07.058-0700 I  INDEX    [LogicalSessionCacheRefresh] index build: done building index lsidTTLIndex on ns config.system.sessions
2020-06-01T00:51:07.058-0700 I  SHARDING [LogicalSessionCacheReap] Marking collection config.transactions as collection version: <unsharded>
2020-06-01T00:51:08.001-0700 I  SHARDING [ftdc] Marking collection local.oplog.rs as collection version: <unsharded>
^C2020-06-01T00:51:24.016-0700 I  CONTROL  [signalProcessingThread] got signal 2 (Interrupt), will terminate after current cmd ends
2020-06-01T00:51:24.017-0700 I  NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
2020-06-01T00:51:24.019-0700 I  NETWORK  [listener] removing socket file: /tmp/mongodb-27017.sock
2020-06-01T00:51:24.019-0700 I  -        [signalProcessingThread] Stopping further Flow Control ticket acquisitions.
2020-06-01T00:51:24.020-0700 I  CONTROL  [signalProcessingThread] Shutting down free monitoring
2020-06-01T00:51:24.020-0700 I  FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
2020-06-01T00:51:24.022-0700 I  STORAGE  [signalProcessingThread] Deregistering all the collections
2020-06-01T00:51:24.022-0700 I  STORAGE  [signalProcessingThread] Timestamp monitor shutting down
2020-06-01T00:51:24.022-0700 I  STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
2020-06-01T00:51:24.022-0700 I  STORAGE  [signalProcessingThread] Shutting down session sweeper thread
2020-06-01T00:51:24.023-0700 I  STORAGE  [signalProcessingThread] Finished shutting down session sweeper thread
2020-06-01T00:51:24.023-0700 I  STORAGE  [signalProcessingThread] Shutting down journal flusher thread
2020-06-01T00:51:24.119-0700 I  STORAGE  [signalProcessingThread] Finished shutting down journal flusher thread
2020-06-01T00:51:24.119-0700 I  STORAGE  [signalProcessingThread] Shutting down checkpoint thread
2020-06-01T00:51:24.119-0700 I  STORAGE  [signalProcessingThread] Finished shutting down checkpoint thread
2020-06-01T00:51:24.142-0700 I  STORAGE  [signalProcessingThread] shutdown: removing fs lock...
2020-06-01T00:51:24.142-0700 I  CONTROL  [signalProcessingThread] now exiting
2020-06-01T00:51:24.142-0700 I  CONTROL  [signalProcessingThread] shutting down with code:0
```

* LDD output of `mongo` ELF:
```
	linux-vdso.so.1 (0x00007fff65b8e000)
	libk5crypto.so.3.1 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libk5crypto.so.3.1 (0x00007f35a5312000)
	libkrb5support.so.0.1 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libkrb5support.so.0.1 (0x00007f35a50fe000)
	libkrb5.so.3.3 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libkrb5.so.3.3 (0x00007f35a4df8000)
	libgssapi_krb5.so.2.2 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libgssapi_krb5.so.2.2 (0x00007f35a4b99000)
	libbrotlicommon.so.1.0.6 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libbrotlicommon.so.1.0.6 (0x00007f35a4978000)
	libbrotlidec.so.1.0.6 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libbrotlidec.so.1.0.6 (0x00007f35a476a000)
	libssh.so.4.8.1 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libssh.so.4.8.1 (0x00007f35a44cb000)
	liblber-2.4.so.2.10.9 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/liblber-2.4.so.2.10.9 (0x00007f35a42b9000)
	libldap-2.4.so.2.10.9 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libldap-2.4.so.2.10.9 (0x00007f35a405c000)
	libsasl2.so.3.0.0 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libsasl2.so.3.0.0 (0x00007f35a3e35000)
	libcurl.so.4.5.0 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libcurl.so.4.5.0 (0x00007f35a3b83000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007f35a396c000)
	libcrypto.so.1.1.1c => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libcrypto.so.1.1.1c (0x00007f35a346d000)
	libssl.so.1.1.1c => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libssl.so.1.1.1c (0x00007f35a31ce000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f35a2fca000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f35a2dc1000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f35a2a2c000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f35a26aa000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f35a2492000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f35a2272000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f35a1eaf000)
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 (0x00007f35a1cab000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007f35a1a80000)
	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007f35a187c000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f35a1665000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f35ab53c000)
	libcrypt.so.1.1.0 => /mnt/percona-server-mongodb-4.2.6-6/bin/../lib/private/libcrypt.so.1.1.0 (0x00007f35a143b000)
	libnghttp2.so.14 => /lib64/libnghttp2.so.14 (0x00007f35a1215000)
	libidn2.so.0 => /lib64/libidn2.so.0 (0x00007f35a0ff7000)
	libpsl.so.5 => /lib64/libpsl.so.5 (0x00007f35a0de6000)
	libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007f35a0b62000)
	libunistring.so.2 => /lib64/libunistring.so.2 (0x00007f35a07e1000)
```

* Cross OS family (deb to rpm unsupported) same glibc ver run test:
- Compiled on Ubuntu 18.04
- Tested on Fedora 28

```
[root@test-fedora-28 percona-server-mongodb-4.2.6-6]# ./bin/mongod
2020-06-01T02:13:06.861-0600 I  CONTROL  [main] Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'
2020-06-01T02:13:06.864-0600 W  ASIO     [main] No TransportLayer configured during NetworkInterface startup
2020-06-01T02:13:06.865-0600 I  CONTROL  [initandlisten] MongoDB starting : pid=2282 port=27017 dbpath=/data/db 64-bit host=test-fedora-28
2020-06-01T02:13:06.865-0600 I  CONTROL  [initandlisten] db version v4.2.6-6
2020-06-01T02:13:06.865-0600 I  CONTROL  [initandlisten] git version: 01b543902d46411b252b0201c72268f198555c97
2020-06-01T02:13:06.865-0600 I  CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.1.1  11 Sep 2018
2020-06-01T02:13:06.865-0600 I  CONTROL  [initandlisten] allocator: tcmalloc
2020-06-01T02:13:06.865-0600 I  CONTROL  [initandlisten] modules: none
2020-06-01T02:13:06.866-0600 I  CONTROL  [initandlisten] build environment:
2020-06-01T02:13:06.866-0600 I  CONTROL  [initandlisten]     distarch: x86_64
2020-06-01T02:13:06.866-0600 I  CONTROL  [initandlisten]     target_arch: x86_64
2020-06-01T02:13:06.866-0600 I  CONTROL  [initandlisten] options: {}
2020-06-01T02:13:06.867-0600 I  STORAGE  [initandlisten]
2020-06-01T02:13:06.867-0600 I  STORAGE  [initandlisten] ** WARNING: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine
2020-06-01T02:13:06.867-0600 I  STORAGE  [initandlisten] **          See http://dochub.mongodb.org/core/prodnotes-filesystem
2020-06-01T02:13:06.867-0600 I  STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=256M,cache_overflow=(file_max=0M),session_max=33000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000,close_scan_interval=10,close_handle_minimum=250),statistics_log=(wait=0),verbose=[recovery_progress,checkpoint_progress],
2020-06-01T02:13:07.306-0600 I  STORAGE  [initandlisten] WiredTiger message [1590999187:306420][2282:0x7f6b4b7dab40], txn-recover: Set global recovery timestamp: (0, 0)
2020-06-01T02:13:07.313-0600 I  RECOVERY [initandlisten] WiredTiger recoveryTimestamp. Ts: Timestamp(0, 0)
2020-06-01T02:13:07.317-0600 I  STORAGE  [initandlisten] Timestamp monitor starting
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten]
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] **          You can use percona-server-mongodb-enable-auth.sh to fix it.
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] ** WARNING: You are running this process as the root user, which is not recommended.
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten]
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] ** WARNING: This server is bound to localhost.
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] **          Remote systems will be unable to connect to this server.
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] **          Start the server with --bind_ip <address> to specify which IP
2020-06-01T02:13:07.318-0600 I  CONTROL  [initandlisten] **          addresses it should serve responses from, or with --bind_ip_all to
2020-06-01T02:13:07.319-0600 I  CONTROL  [initandlisten] **          bind to all interfaces. If this behavior is desired, start the
2020-06-01T02:13:07.319-0600 I  CONTROL  [initandlisten] **          server with --bind_ip 127.0.0.1 to disable this warning.
2020-06-01T02:13:07.319-0600 I  CONTROL  [initandlisten]
2020-06-01T02:13:07.319-0600 I  STORAGE  [initandlisten] createCollection: admin.system.version with provided UUID: 2eb82a0f-74d8-42c5-bba4-68f7a31f4233 and options: { uuid: UUID("2eb82a0f-74d8-42c5-bba4-68f7a31f4233") }
2020-06-01T02:13:07.323-0600 I  INDEX    [initandlisten] index build: done building index _id_ on ns admin.system.version
2020-06-01T02:13:07.323-0600 I  SHARDING [initandlisten] Marking collection admin.system.version as collection version: <unsharded>
2020-06-01T02:13:07.323-0600 I  COMMAND  [initandlisten] setting featureCompatibilityVersion to 4.2
2020-06-01T02:13:07.324-0600 I  SHARDING [initandlisten] Marking collection local.system.replset as collection version: <unsharded>
2020-06-01T02:13:07.324-0600 I  STORAGE  [initandlisten] Flow Control is enabled on this deployment.
2020-06-01T02:13:07.324-0600 I  SHARDING [initandlisten] Marking collection admin.system.roles as collection version: <unsharded>
2020-06-01T02:13:07.324-0600 I  STORAGE  [initandlisten] createCollection: local.startup_log with generated UUID: 626f77ba-e7ce-4ad1-8762-af87f9b2fa7d and options: { capped: true, size: 10485760 }
2020-06-01T02:13:07.327-0600 I  INDEX    [initandlisten] index build: done building index _id_ on ns local.startup_log
2020-06-01T02:13:07.328-0600 I  SHARDING [initandlisten] Marking collection local.startup_log as collection version: <unsharded>
2020-06-01T02:13:07.328-0600 I  FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/data/db/diagnostic.data'
2020-06-01T02:13:07.330-0600 I  SHARDING [LogicalSessionCacheRefresh] Marking collection config.system.sessions as collection version: <unsharded>
2020-06-01T02:13:07.330-0600 I  STORAGE  [LogicalSessionCacheRefresh] createCollection: config.system.sessions with provided UUID: 955acc36-eb66-49e1-bf04-f536a45431c9 and options: { uuid: UUID("955acc36-eb66-49e1-bf04-f536a45431c9") }
2020-06-01T02:13:07.332-0600 I  NETWORK  [listener] Listening on /tmp/mongodb-27017.sock
2020-06-01T02:13:07.333-0600 I  NETWORK  [listener] Listening on 127.0.0.1
2020-06-01T02:13:07.335-0600 I  NETWORK  [listener] waiting for connections on port 27017
2020-06-01T02:13:07.335-0600 I  INDEX    [LogicalSessionCacheRefresh] index build: done building index _id_ on ns config.system.sessions
2020-06-01T02:13:07.338-0600 I  INDEX    [LogicalSessionCacheRefresh] index build: starting on config.system.sessions properties: { v: 2, key: { lastUse: 1 }, name: "lsidTTLIndex", ns: "config.system.sessions", expireAfterSeconds: 1800 } using method: Hybrid
2020-06-01T02:13:07.338-0600 I  INDEX    [LogicalSessionCacheRefresh] build may temporarily use up to 200 megabytes of RAM
2020-06-01T02:13:07.338-0600 I  INDEX    [LogicalSessionCacheRefresh] index build: collection scan done. scanned 0 total records in 0 seconds
2020-06-01T02:13:07.339-0600 I  INDEX    [LogicalSessionCacheRefresh] index build: inserted 0 keys from external sorter into index in 0 seconds
2020-06-01T02:13:07.340-0600 I  INDEX    [LogicalSessionCacheRefresh] index build: done building index lsidTTLIndex on ns config.system.sessions
2020-06-01T02:13:07.340-0600 I  SHARDING [LogicalSessionCacheReap] Marking collection config.transactions as collection version: <unsharded>
2020-06-01T02:13:08.001-0600 I  SHARDING [ftdc] Marking collection local.oplog.rs as collection version: <unsharded>
^C2020-06-01T02:13:11.573-0600 I  CONTROL  [signalProcessingThread] got signal 2 (Interrupt), will terminate after current cmd ends
2020-06-01T02:13:11.573-0600 I  NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
2020-06-01T02:13:11.573-0600 I  NETWORK  [listener] removing socket file: /tmp/mongodb-27017.sock
2020-06-01T02:13:11.574-0600 I  -        [signalProcessingThread] Stopping further Flow Control ticket acquisitions.
2020-06-01T02:13:11.574-0600 I  CONTROL  [signalProcessingThread] Shutting down free monitoring
2020-06-01T02:13:11.574-0600 I  FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
2020-06-01T02:13:11.575-0600 I  STORAGE  [signalProcessingThread] Deregistering all the collections
2020-06-01T02:13:11.575-0600 I  STORAGE  [signalProcessingThread] Timestamp monitor shutting down
2020-06-01T02:13:11.575-0600 I  STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
2020-06-01T02:13:11.576-0600 I  STORAGE  [signalProcessingThread] Shutting down session sweeper thread
2020-06-01T02:13:11.576-0600 I  STORAGE  [signalProcessingThread] Finished shutting down session sweeper thread
2020-06-01T02:13:11.576-0600 I  STORAGE  [signalProcessingThread] Shutting down journal flusher thread
2020-06-01T02:13:11.634-0600 I  STORAGE  [signalProcessingThread] Finished shutting down journal flusher thread
2020-06-01T02:13:11.634-0600 I  STORAGE  [signalProcessingThread] Shutting down checkpoint thread
2020-06-01T02:13:11.634-0600 I  STORAGE  [signalProcessingThread] Finished shutting down checkpoint thread
2020-06-01T02:13:11.656-0600 I  STORAGE  [signalProcessingThread] shutdown: removing fs lock...
2020-06-01T02:13:11.656-0600 I  CONTROL  [signalProcessingThread] now exiting
2020-06-01T02:13:11.656-0600 I  CONTROL  [signalProcessingThread] shutting down with code:0
```
