### PR TITLE
PSMDB-656 use error code UserNotFound when cannot map user to DN

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -383,7 +383,7 @@ Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
         }
     }
     // we have no successful transformations, return error
-    return Status(ErrorCodes::BadValue,
+    return Status(ErrorCodes::UserNotFound,
                   "Failed to map user '{}' to LDAP DN"_format(user));
 }
 


### PR DESCRIPTION
This is necessary because UserNotFound is hardcoded into authorization session's logic.
See AuthorizationSessionImpl::_refreshUserInfoAsNeeded