### PR TITLE
PSMDB-583 PSMDB-589 fix thread initialization to restore correct server shutdown

### DIFF
--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -89,6 +89,8 @@
 #include "mongo/db/keys_collection_manager.h"
 #include "mongo/db/kill_sessions.h"
 #include "mongo/db/kill_sessions_local.h"
+#include "mongo/db/ldap/ldap_manager.h"
+#include "mongo/db/ldap_options.h"
 #include "mongo/db/log_process_details.h"
 #include "mongo/db/logical_clock.h"
 #include "mongo/db/logical_session_cache.h"
@@ -455,6 +457,15 @@ ExitCode _initAndListen(int listenPort) {
 
     // Start up health log writer thread.
     HealthLog::get(startupOpCtx.get()).startup();
+
+    auto const globalLDAPManager = LDAPManager::get(serviceContext);
+    if (globalLDAPManager) {
+        Status status = globalLDAPManager->initialize();
+        using namespace fmt::literals;
+        uassertStatusOKWithContext(status,
+            "Cannot initialize LDAP server connection (parameters are: {})"_format(
+                ldapGlobalParams.logString()));
+    }
 
     auto const globalAuthzManager = AuthorizationManager::get(serviceContext);
     uassertStatusOK(globalAuthzManager->initialize(startupOpCtx.get()));

--- a/src/mongo/db/ldap/ldap_manager.cpp
+++ b/src/mongo/db/ldap/ldap_manager.cpp
@@ -71,11 +71,6 @@ ServiceContext::ConstructorActionRegisterer createLDAPManager(
     [](ServiceContext* service) {
         if (!ldapGlobalParams.ldapServers->empty()) {
             auto ldapManager = LDAPManager::create();
-            Status res = ldapManager->initialize();
-            using namespace fmt::literals;
-            uassertStatusOKWithContext(res,
-                "Cannot initialize LDAP server connection (parameters are: {})"_format(
-                    ldapGlobalParams.logString()));
             LDAPManager::set(service, std::move(ldapManager));
         }
     });


### PR DESCRIPTION
New threads were missing ThreadClient instance and thus server could not shutdown properly.
Fix is not trivial because ThreadClient cannot be instantiated on the early stages of server startup - thus thread initialization was moved to the _initAndListen stage.