### PR TITLE
PSMDB-680 do not try to read encrypted rollback files

### DIFF
--- a/jstests/replsets/libs/rollback_files.js
+++ b/jstests/replsets/libs/rollback_files.js
@@ -49,7 +49,7 @@ function checkRollbackFiles(dbPath, nss, expectedDocs) {
 
     // If the rollback BSON file is encrypted, don't try to check the data contents. Checking its
     // existence is sufficient.
-    if (rollbackFile.endsWith(".enc")) {
+    if (rollbackFile.endsWith(".enc") || rollbackFile.endsWith(".aes256-cbc") || rollbackFile.endsWith(".aes256-gcm")) {
         print("Bypassing check of rollback file data since it is encrypted.");
         return;
     }


### PR DESCRIPTION
the same thing upstream does for their encrypted files

(cherry picked from commit 1d6c8ab7f6bc596116b50ef24159b39ff4968271)