### PR TITLE
PSMDB-712: Implement LDAP referral support, Part 1 (v3.6)

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -48,6 +48,73 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/util/log.h"
 #include "mongo/util/scopeguard.h"
 
+extern "C" {
+
+struct interactionParameters {
+    const char* realm;
+    const char* dn;
+    const char* pw;
+    const char* userid;
+};
+
+static int interaction(unsigned flags, sasl_interact_t *interact, void *defaults) {
+    interactionParameters *params = (interactionParameters*)defaults;
+    const char *dflt = interact->defresult;
+
+    switch (interact->id) {
+    case SASL_CB_GETREALM:
+        dflt = params->realm;
+        break;
+    case SASL_CB_AUTHNAME:
+        dflt = params->dn;
+        break;
+    case SASL_CB_PASS:
+        dflt = params->pw;
+        break;
+    case SASL_CB_USER:
+        dflt = params->userid;
+        break;
+    }
+
+    if (dflt && !*dflt)
+        dflt = NULL;
+
+    if (flags != LDAP_SASL_INTERACTIVE &&
+        (dflt || interact->id == SASL_CB_USER)) {
+        goto use_default;
+    }
+
+    if( flags == LDAP_SASL_QUIET ) {
+        /* don't prompt */
+        return LDAP_OTHER;
+    }
+
+
+use_default:
+    interact->result = (dflt && *dflt) ? dflt : "";
+    interact->len = std::strlen( (char*)interact->result );
+
+    return LDAP_SUCCESS;
+}
+
+static int interactProc(LDAP *ld, unsigned flags, void *defaults, void *in) {
+    sasl_interact_t *interact = (sasl_interact_t*)in;
+
+    if (ld == NULL)
+        return LDAP_PARAM_ERROR;
+
+    while (interact->id != SASL_CB_LIST_END) {
+        int rc = interaction( flags, interact, defaults );
+        if (rc)
+            return rc;
+        interact++;
+    }
+    
+    return LDAP_SUCCESS;
+}
+
+} // extern "C"
+
 namespace mongo {
 
 using namespace fmt::literals;
@@ -66,19 +133,24 @@ public:
         ON_BLOCK_EXIT([] { Client::destroy(); });
 
         LOG(1) << "starting " << name() << " thread";
-        stdx::unique_lock<stdx::mutex> lock{_mutex};
 
         // poller thread will handle disconnection events
         while (!_shuttingDown.load()) {
             MONGO_IDLE_THREAD_BLOCK;
-            _condvar.wait(lock, [this]{return _poll_fd >= 0 || _shuttingDown.load();});
-            if (_poll_fd < 0)
-                continue;
-            LOG(2) << "connection poller received file descriptor: " << _poll_fd;
+
             pollfd fd;
-            fd.fd = _poll_fd;
             fd.events = POLLPRI | POLLRDHUP;
             fd.revents = 0;
+
+            {
+                stdx::unique_lock<std::mutex> lock{_mutex};
+                _condvar.wait(lock, [this]{return _poll_fd >= 0 || _shuttingDown.load();});
+                fd.fd = _poll_fd;
+            }
+            if (fd.fd < 0)
+                continue;
+
+            LOG(2) << "connection poller received file descriptor: " << fd.fd;
             int poll_ret = poll(&fd, 1, -1);
             LOG(2) << "poll() return value is: " << poll_ret;
             if (poll_ret < 0) {
@@ -91,8 +163,13 @@ public:
                 }
                 LOG(2) << "poll() error name: " << errname;
                 //restart LDAP connection
-                _poll_fd = -1;
-                _manager->needReinit();
+                {
+                    stdx::unique_lock<std::mutex> lock{_mutex};
+                    if(_poll_fd == fd.fd) {
+                        _poll_fd = -1;
+                        _manager->needReinit();
+                    }
+                }
             } else if (poll_ret > 0) {
                 static struct {
                     int v;
@@ -115,8 +192,13 @@ public:
                 }
                 if (fd.revents & (POLLRDHUP | POLLERR | POLLHUP | POLLNVAL)) {
                     // need to restart LDAP connection
-                    _poll_fd = -1;
-                    _manager->needReinit();
+                    {
+                        stdx::unique_lock<std::mutex> lock{_mutex};
+                        if(_poll_fd == fd.fd) {
+                          _poll_fd = -1;
+                          _manager->needReinit();
+                        }
+                    }
                 }
             }
         }
@@ -124,11 +206,17 @@ public:
     }
 
     void start_poll(int fd) {
+        bool changed = false;
         {
-            stdx::unique_lock<stdx::mutex> lock{_mutex};
-            _poll_fd = fd;
+            stdx::unique_lock<std::mutex> lock{_mutex};
+            if(_poll_fd < 0) {
+                _poll_fd = fd;
+                changed = true;
+            }
         }
-        _condvar.notify_one();
+        if (changed) {
+            _condvar.notify_one();
+        }
     }
     void shutdown() {
         _shuttingDown.store(true);
@@ -180,15 +268,68 @@ void cb_del(LDAP *ld, Sockbuf *sb, struct ldap_conncb *ctx) {
     LOG(2) << "LDAP disconnect callback";
 }
 
+int rebindproc(LDAP* ld, const char* /* url */, ber_tag_t /* request */, ber_int_t /* msgid */, void* arg) {
+
+    const auto user = ldapGlobalParams.ldapQueryUser.get();
+    const auto password = ldapGlobalParams.ldapQueryPassword.get();
+
+    berval cred;
+    cred.bv_val = const_cast<char*>(password.c_str());
+    cred.bv_len = password.size();
+
+    if (ldapGlobalParams.ldapBindMethod == "simple") {
+        return ldap_sasl_bind_s(ld, const_cast<char*>(user.c_str()), LDAP_SASL_SIMPLE, &cred,
+                                nullptr, nullptr, nullptr);
+    } else if (ldapGlobalParams.ldapBindMethod == "simple") {
+        interactionParameters params;
+        params.userid = const_cast<char*>(user.c_str());
+        params.dn = const_cast<char*>(user.c_str());
+        params.pw = const_cast<char*>(password.c_str());
+        params.realm = nullptr;
+        return ldap_sasl_interactive_bind_s(
+                                            ld,
+                                            nullptr,
+                                            ldapGlobalParams.ldapBindSaslMechanisms.c_str(),
+                                            nullptr,
+                                            nullptr,
+                                            LDAP_SASL_QUIET,
+                                            interactProc,
+                                            &params);
+    } else {
+      return LDAP_INAPPROPRIATE_AUTH;
+    }
+}
 }
 
 Status LDAPManagerImpl::initialize() {
+    const int ldap_version = LDAP_VERSION3;
+    int res = LDAP_OTHER;
     if (!_connPoller) {
         _connPoller = stdx::make_unique<ConnectionPoller>(this);
         _connPoller->go();
+
+        LOG(1) << "Adjusting global LDAP settings";
+
+        res = ldap_set_option(nullptr, LDAP_OPT_PROTOCOL_VERSION, &ldap_version);
+        if (res != LDAP_OPT_SUCCESS) {
+            return Status(ErrorCodes::LDAPLibraryError,
+                          "Cannot set LDAP version option; LDAP error: {}"_format(
+                              ldap_err2string(res)));
+        }
+
+        if (ldapGlobalParams.ldapDebug.load()) {
+            static const unsigned short debug_any = 0xffff;
+            res = ldap_set_option(nullptr, LDAP_OPT_DEBUG_LEVEL, &debug_any);
+            if (res != LDAP_OPT_SUCCESS) {
+                return Status(ErrorCodes::LDAPLibraryError,
+                              "Cannot set LDAP log level; LDAP error: {}"_format(
+                                  ldap_err2string(res)));
+            }
+        }
     }
 
-    int res = LDAP_OTHER;
+    LOG(1) << "Initializing LDAP";
+
     const char* ldapprot = "ldaps";
     if (ldapGlobalParams.ldapTransportSecurity == "none")
         ldapprot = "ldap";
@@ -199,13 +340,17 @@ Status LDAPManagerImpl::initialize() {
                       "Cannot initialize LDAP structure for {}; LDAP error: {}"_format(
                           uri, ldap_err2string(res)));
     }
-    const int ldap_version = LDAP_VERSION3;
-    res = ldap_set_option(_ldap, LDAP_OPT_PROTOCOL_VERSION, &ldap_version);
-    if (res != LDAP_OPT_SUCCESS) {
-        return Status(ErrorCodes::LDAPLibraryError,
-                      "Cannot set LDAP version option; LDAP error: {}"_format(
-                          ldap_err2string(res)));
+
+    if (!ldapGlobalParams.ldapReferrals.load()) {
+        LOG(2) << "Disabling referrals";
+        res = ldap_set_option(_ldap, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
+        if (res != LDAP_OPT_SUCCESS) {
+            return Status(ErrorCodes::LDAPLibraryError,
+                          "Cannot disable LDAP referrals; LDAP error: {}"_format(
+                              ldap_err2string(res)));
+        }
     }
+
     static ldap_conncb conncb;
     conncb.lc_add = cb_add;
     conncb.lc_del = cb_del;
@@ -227,6 +372,7 @@ Status LDAPManagerImpl::initialize() {
 }
 
 Status LDAPManagerImpl::reinitialize() {
+    LOG(2) << "Reinitializing ldap connection";
     if (_ldap) {
         ldap_unbind_ext(_ldap, nullptr, nullptr);
         _ldap = nullptr;
@@ -421,75 +567,10 @@ Status LDAPManagerImpl::queryUserRoles(const UserName& userName, stdx::unordered
     return status;
 }
 
-
-extern "C" {
-
-struct interactionParameters {
-    const char* realm;
-    const char* dn;
-    const char* pw;
-    const char* userid;
-};
-
-static int interaction(unsigned flags, sasl_interact_t *interact, void *defaults) {
-    interactionParameters *params = (interactionParameters*)defaults;
-    const char *dflt = interact->defresult;
-
-    switch (interact->id) {
-    case SASL_CB_GETREALM:
-        dflt = params->realm;
-        break;
-    case SASL_CB_AUTHNAME:
-        dflt = params->dn;
-        break;
-    case SASL_CB_PASS:
-        dflt = params->pw;
-        break;
-    case SASL_CB_USER:
-        dflt = params->userid;
-        break;
-    }
-
-    if (dflt && !*dflt)
-        dflt = NULL;
-
-    if (flags != LDAP_SASL_INTERACTIVE &&
-        (dflt || interact->id == SASL_CB_USER)) {
-        goto use_default;
-    }
-
-    if( flags == LDAP_SASL_QUIET ) {
-        /* don't prompt */
-        return LDAP_OTHER;
-    }
-
-
-use_default:
-    interact->result = (dflt && *dflt) ? dflt : "";
-    interact->len = std::strlen( (char*)interact->result );
-
-    return LDAP_SUCCESS;
-}
-
-static int interactProc(LDAP *ld, unsigned flags, void *defaults, void *in) {
-    sasl_interact_t *interact = (sasl_interact_t*)in;
-
-    if (ld == NULL)
-        return LDAP_PARAM_ERROR;
-
-    while (interact->id != SASL_CB_LIST_END) {
-        int rc = interaction( flags, interact, defaults );
-        if (rc)
-            return rc;
-        interact++;
-    }
-    
-    return LDAP_SUCCESS;
-}
-
-} // extern "C"
-
 Status LDAPbind(LDAP* ld, const char* usr, const char* psw) {
+    if (ldapGlobalParams.ldapReferrals.load()) {
+      ldap_set_rebind_proc( ld, rebindproc, (void *)usr );
+    }
     if (ldapGlobalParams.ldapBindMethod == "simple") {
         // ldap_simple_bind_s was deprecated in favor of ldap_sasl_bind_s
         berval cred;

--- a/src/mongo/db/ldap_options.cpp
+++ b/src/mongo/db/ldap_options.cpp
@@ -136,6 +136,22 @@ Status addLDAPOptions(moe::OptionSection* options) {
         .setSources(moe::SourceAll)
         .setDefault(moe::Value{"[{match: \"(.+)\", substitution: \"{0}\"}]"});
 
+    options
+        ->addOptionChaining("security.ldap.debug",
+                            "debug",
+                            moe::Bool,
+                            "Print debug information for LDAP connections")
+        .setSources(moe::SourceAll)
+        .setDefault(moe::Value{false});
+
+    options
+        ->addOptionChaining("security.ldap.follow_referrals",
+                            "follow_referrals",
+                            moe::Bool,
+                            "Automatically follow LDAP referrals with the same bind credentials")
+        .setSources(moe::SourceAll)
+        .setDefault(moe::Value{false});
+
     return Status::OK();
 }
 
@@ -248,6 +264,12 @@ Status storeLDAPOptions(const moe::Environment& params) {
             return ret;
         ldapGlobalParams.ldapUserToDNMapping = new_value;
     }
+    if (params.count("security.ldap.debug")) {
+        ldapGlobalParams.ldapDebug.store(params["security.ldap.debug"].as<bool>());
+    }
+    if (params.count("security.ldap.follow_referrals")) {
+        ldapGlobalParams.ldapReferrals.store(params["security.ldap.follow_referrals"].as<bool>());
+    }
     return Status::OK();
 }
 
@@ -287,6 +309,14 @@ ExportedServerParameter<bool, ServerParameterType::kStartupOnly> ldapUseConnecti
 ExportedServerParameter<int, ServerParameterType::kStartupAndRuntime> ldapUserCacheInvalidationIntervalParam{
     ServerParameterSet::getGlobal(), "ldapUserCacheInvalidationInterval",
     &ldapGlobalParams.ldapUserCacheInvalidationInterval};
+
+ExportedServerParameter<bool, ServerParameterType::kRuntimeOnly> ldapDebugParam{
+    ServerParameterSet::getGlobal(), "ldapDebug",
+    &ldapGlobalParams.ldapDebug};
+
+ExportedServerParameter<bool, ServerParameterType::kRuntimeOnly> ldapFollowReferralsParam{
+    ServerParameterSet::getGlobal(), "ldapFollowReferralsParam",
+    &ldapGlobalParams.ldapReferrals};
 
 }  // namespace
 

--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -61,6 +61,8 @@ struct LDAPGlobalParams {
     AtomicInt32 ldapUserCacheInvalidationInterval{30};
     // ldapQueryTemplate does not exist in mongos, so it should be handled differently
     boost::synchronized_value<std::string> ldapQueryTemplate;
+    AtomicWord<bool> ldapDebug;
+    AtomicWord<bool> ldapReferrals;
 
     std::string logString() const;
 };


### PR DESCRIPTION
Issue: ActiveDirectory servers return referrals in LDAP queries in their
default LDAP port (389). To use AD for authentication, clients either
have to specify the global catalog port in the configuration (3268), or
the software has to support following referrals with authentication.

Fix:

 * LDAPv3 support was set incorrectly after the connection was already
   established. LDAPv2 doesn't support referrals. Moved version
   specification before the first connection is initialized.
 * Added a new boolean config variable, security.ldap.debug. Turning on
   this setting enables the debug output of the ldap client library,
   printing communication related debug options to standard error.
 * Added a new boolean config variable, security.ldap.follow_referrals,
   which defaults to false. LDAPv3 allows referrals by default, but since
   we have to supply authentication information for the additional AD
   servers, blindly following them would be a security issue. This
   setting should only be turned on when mongodb has to use an AD server
   on its default LDAP port.
 * Modified the connection polling code so it doesn't hold the polling
   mutex continously. When following referrals, the LDAP client will
   connect/disconnect to several servers, and holding this mutex would
   result in a deadlock.