### PR TITLE
PSMDB-712: Add connection pool support to LDAP auth (v4.2)

### DIFF
--- a/src/mongo/db/auth/external/external_sasl_authentication_session.cpp
+++ b/src/mongo/db/auth/external/external_sasl_authentication_session.cpp
@@ -175,13 +175,6 @@ StatusWith<std::tuple<bool, std::string>> OpenLDAPServerMechanism::stepImpl(
                           "Cannot initialize LDAP structure for {}; LDAP error: {}"_format(
                               uri, ldap_err2string(res)));
         }
-        const int ldap_version = LDAP_VERSION3;
-        res = ldap_set_option(_ld, LDAP_OPT_PROTOCOL_VERSION, &ldap_version);
-        if (res != LDAP_OPT_SUCCESS) {
-            return Status(ErrorCodes::LDAPLibraryError,
-                          "Cannot set LDAP version option; LDAP error: {}"_format(
-                              ldap_err2string(res)));
-        }
 
         Status status = LDAPbind(_ld, dn, pw);
         if (!status.isOK())

--- a/src/mongo/db/ldap/ldap_manager_impl.h
+++ b/src/mongo/db/ldap/ldap_manager_impl.h
@@ -50,19 +50,12 @@ public:
 
     virtual Status mapUserToDN(const std::string& user, std::string& out) override;
 
-    void needReinit() {
-        _reinitPending.store(true);
-    }
-
 private:
-    LDAP* _ldap{nullptr};
     std::unique_ptr<ConnectionPoller> _connPoller;
 
-    AtomicWord<bool> _reinitPending{true};
-    // guard init/reinit of _ldap
-    Mutex _mutex = MONGO_MAKE_LATCH("LDAPManagerImpl::_mutex");
+    LDAP* borrow_search_connection();
+    void return_search_connection(LDAP* ldap);
 
-    Status reinitialize();
     Status execQuery(std::string& ldapurl, std::vector<std::string>& results);
 };
 

--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -62,6 +62,7 @@ struct LDAPGlobalParams {
     synchronized_value<std::string> ldapQueryTemplate;
     AtomicWord<bool> ldapDebug;
     AtomicWord<bool> ldapReferrals;
+    AtomicWord<int>  ldapMaxPoolSize;
 
     std::string logString() const;
 };

--- a/src/mongo/db/ldap_options.idl
+++ b/src/mongo/db/ldap_options.idl
@@ -81,6 +81,10 @@ server_parameters:
         description: "Automatically follow LDAP referrals with the same bind credentials"
         set_at: runtime
         cpp_varname: "ldapGlobalParams.ldapReferrals"
+    ldapMaxPoolSize:
+        description: "Maximum number of connections in the LDAP connection pool"
+        set_at: runtime
+        cpp_varname: "ldapGlobalParams.ldapMaxPoolSize"
 
 configs:
     'security.ldap.servers':
@@ -136,3 +140,8 @@ configs:
         short_name: ldapReferrals
         arg_vartype: Bool
         default: false
+    'security.ldap.maxPoolSize':
+        description: 'Maximum number of connections in the LDAP connection pool'
+        short_name: ldapMaxPoolSize
+        arg_vartype: Int
+        default: 2

--- a/src/mongo/db/ldap_options_init.cpp
+++ b/src/mongo/db/ldap_options_init.cpp
@@ -71,6 +71,9 @@ Status storeLDAPOptions(const moe::Environment& params) {
     if (params.count("security.ldap.follow_referrals")) {
         ldapGlobalParams.ldapReferrals.store(params["security.ldap.follow_referrals"].as<bool>());
     }
+    if (params.count("security.ldap.maxPoolSize")) {
+        ldapGlobalParams.ldapMaxPoolSize.store(params["security.ldap.maxPoolSize"].as<int>());
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
Issue: the ldap query function used a single connection for all queries
with a global mutex. With referral support turned on searches could
take more time, resulting in decreasing login performance.

Fix: this commit changes the single connection ldap manager
implementation to a connection pool, which is able to handle multiple
login attemts at the same time.

To make this configurable, it introduduses a new ldap configuration
variable, "max_pool_size", which limits the number of active ldap
connections. When reaching this limit, the behavior falls back to the
previous one: the authentication attempt will wait until a connection is
available in the pool.