### PR TITLE
ENG-925: [PSMDB_3.6] Remove conficting & not-used libs, improve if check

### DIFF
--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -866,7 +866,7 @@ build_tarball(){
     if [ ! -d lib/private ]; then
         mkdir -p lib/private
     fi
-    LIBLIST="libcrypto.so libssl.so libsasl2.so libpcap.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplc4.so libnspr4.so libplds4.so libidn.so"
+    LIBLIST="libcrypto.so libssl.so libsasl2.so libpcap.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplc4.so libnspr4.so libplds4.so libidn.so libbz2.so"
     DIRLIST="bin lib/private"
 
     LIBPATH=""
@@ -881,7 +881,7 @@ build_tarball(){
                     lib_realpath_basename="$(basename $(readlink -f ${libfromelf}))"
                     lib_without_version_suffix=$(echo ${lib_realpath_basename} | awk -F"." 'BEGIN { OFS = "." }{ print $1, $2}')
 
-                    if [ ! -f "lib/private/${lib_realpath_basename}" ] && [ ! -L "lib/private/${lib_realpath_basename}" ]; then
+                    if [ ! -f "lib/private/${lib_realpath_basename}" ] && [ ! -L "lib/private/${lib_without_version_suffix}" ]; then
                     
                         echo "Copying lib ${lib_realpath_basename}"
                         cp ${lib_realpath} lib/private

--- a/percona-packaging/scripts/test-build.sh
+++ b/percona-packaging/scripts/test-build.sh
@@ -17,9 +17,17 @@ function prepare {
     mkdir -p "$CURDIR"/temp
     mkdir -p "$TMP_DIR"/db "$TMP_DIR"/tests
 
+    if [ -f /etc/redhat-release ]; then
+        GLIBC_VER="$(rpm glibc -qa --qf %{VERSION})"
+    else
+        GLIBC_VER="$(dpkg-query -W -f='${Version}' libc6 | awk -F'-' '{print $1}')"
+    fi
+
     TARBALLS=""
     for tarball in $(find . -name "*.tar.gz"); do
-        TARBALLS+=" $(basename $tarball)"
+        if [[ "$(echo $tarball | grep -o "glibc2.*" | awk -F '.' '{print $2}')" -le "$(echo $GLIBC_VER | awk -F '.' '{print $2}')" ]]; then
+            TARBALLS+=" $(basename $tarball)"
+        fi
     done
     DIRLIST="bin lib/private"
 }


### PR DESCRIPTION
* Also update tests to handle two tarballs

The *krb5.so* libs are not used according to "readelf -d $ELF" output and creating conflicts while building on ubuntu

Builds: https://rel.cd.percona.com/job/psmdb-36-bintar/30/
Tests: https://rel.cd.percona.com/job/psmdb-36-test/31/