### PR TITLE
PSMDB-712: Implement LDAP referral support, Part 1 (v4.0)

### DIFF
--- a/src/mongo/db/ldap_options.cpp
+++ b/src/mongo/db/ldap_options.cpp
@@ -136,6 +136,22 @@ Status addLDAPOptions(moe::OptionSection* options) {
         .setSources(moe::SourceYAMLCLI)
         .setDefault(moe::Value{"[{match: \"(.+)\", substitution: \"{0}\"}]"});
 
+    options
+        ->addOptionChaining("security.ldap.debug",
+                            "debug",
+                            moe::Bool,
+                            "Print debug information for LDAP connections")
+        .setSources(moe::SourceAll)
+        .setDefault(moe::Value{false});
+
+    options
+        ->addOptionChaining("security.ldap.follow_referrals",
+                            "follow_referrals",
+                            moe::Bool,
+                            "Automatically follow LDAP referrals with the same bind credentials")
+        .setSources(moe::SourceAll)
+        .setDefault(moe::Value{false});
+
     return Status::OK();
 }
 
@@ -248,6 +264,12 @@ Status storeLDAPOptions(const moe::Environment& params) {
             return ret;
         ldapGlobalParams.ldapUserToDNMapping = new_value;
     }
+    if (params.count("security.ldap.debug")) {
+        ldapGlobalParams.ldapDebug.store(params["security.ldap.debug"].as<bool>());
+    }
+    if (params.count("security.ldap.follow_referrals")) {
+        ldapGlobalParams.ldapReferrals.store(params["security.ldap.follow_referrals"].as<bool>());
+    }
     return Status::OK();
 }
 
@@ -287,6 +309,14 @@ ExportedServerParameter<bool, ServerParameterType::kStartupOnly> ldapUseConnecti
 ExportedServerParameter<int, ServerParameterType::kStartupAndRuntime> ldapUserCacheInvalidationIntervalParam{
     ServerParameterSet::getGlobal(), "ldapUserCacheInvalidationInterval",
     &ldapGlobalParams.ldapUserCacheInvalidationInterval};
+
+ExportedServerParameter<bool, ServerParameterType::kRuntimeOnly> ldapDebugParam{
+    ServerParameterSet::getGlobal(), "ldapDebug",
+    &ldapGlobalParams.ldapDebug};
+
+ExportedServerParameter<bool, ServerParameterType::kRuntimeOnly> ldapFollowReferralsParam{
+    ServerParameterSet::getGlobal(), "ldapFollowReferralsParam",
+    &ldapGlobalParams.ldapReferrals};
 
 }  // namespace
 

--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -61,6 +61,8 @@ struct LDAPGlobalParams {
     AtomicInt32 ldapUserCacheInvalidationInterval{30};
     // ldapQueryTemplate does not exist in mongos, so it should be handled differently
     boost::synchronized_value<std::string> ldapQueryTemplate;
+    AtomicWord<bool> ldapDebug;
+    AtomicWord<bool> ldapReferrals;
 
     std::string logString() const;
 };


### PR DESCRIPTION
Issue: ActiveDirectory servers return referrals in LDAP queries in their
default LDAP port (389). To use AD for authentication, clients either
have to specify the global catalog port in the configuration (3268), or
the software has to support following referrals with authentication.

Fix:

 * LDAPv3 support was set incorrectly after the connection was already
   established. LDAPv2 doesn't support referrals. Moved version
   specification before the first connection is initialized.
 * Added a new boolean config variable, security.ldap.debug. Turning on
   this setting enables the debug output of the ldap client library,
   printing communication related debug options to standard error.
 * Added a new boolean config variable, security.ldap.follow_referrals,
   which defaults to false. LDAPv3 allows referrals by default, but since
   we have to supply authentication information for the additional AD
   servers, blindly following them would be a security issue. This
   setting should only be turned on when mongodb has to use an AD server
   on its default LDAP port.
 * Modified the connection polling code so it doesn't hold the polling
   mutex continously. When following referrals, the LDAP client will
   connect/disconnect to several servers, and holding this mutex would
   result in a deadlock.