### PR TITLE
PSMDB-726 Fix auth bypass in LDAP authentication

### DIFF
--- a/src/mongo/db/auth/external/external_sasl_authentication_session.cpp
+++ b/src/mongo/db/auth/external/external_sasl_authentication_session.cpp
@@ -300,6 +300,12 @@ Status OpenLDAPAuthenticationSession::step(StringData inputData, std::string* ou
         const char* dn = userid + std::strlen(userid) + 1; // authentication id
         const char* pw = dn + std::strlen(dn) + 1; // password
 
+        if(strlen(pw) == 0) {
+            return Status(ErrorCodes::LDAPLibraryError,
+                          "Failed to authenticate '{}'; No password provided."_format(
+                              dn));
+        }
+
         // transform user to DN
         std::string mappedUser;
         {


### PR DESCRIPTION
Issue: the LDAP protocol allows servers to treat an empty password and
any user name as a successful anonymous bind request. This causes
authentication attemps to succeed when they shouldn't, with AD.

Fix: explicitly disable empty passwords with LDAP authentication.