### PR TITLE
PSMDB-755 cleanup LDAP-related server parameters

### DIFF
--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -61,8 +61,8 @@ struct LDAPGlobalParams {
     AtomicWord<int> ldapUserCacheInvalidationInterval;
     synchronized_value<std::string> ldapQueryTemplate;
     AtomicWord<bool> ldapDebug;
-    AtomicWord<bool> ldapReferrals;
-    AtomicWord<int>  ldapMaxPoolSize;
+    AtomicWord<bool> ldapFollowReferrals;
+    AtomicWord<int>  ldapConnectionPoolSizePerHost;
 
     std::string logString() const;
 };

--- a/src/mongo/db/ldap_options.idl
+++ b/src/mongo/db/ldap_options.idl
@@ -75,16 +75,21 @@ server_parameters:
         default: 30
     ldapDebug:
         description: "Print debug information for LDAP connections"
-        set_at: runtime
+        set_at: [startup, runtime]
         cpp_varname: "ldapGlobalParams.ldapDebug"
-    ldapReferrals:
+        default: false
+    ldapFollowReferrals:
         description: "Automatically follow LDAP referrals with the same bind credentials"
-        set_at: runtime
-        cpp_varname: "ldapGlobalParams.ldapReferrals"
-    ldapMaxPoolSize:
+        set_at: [startup, runtime]
+        cpp_varname: "ldapGlobalParams.ldapFollowReferrals"
+        default: false
+    ldapConnectionPoolSizePerHost:
         description: "Maximum number of connections in the LDAP connection pool"
-        set_at: runtime
-        cpp_varname: "ldapGlobalParams.ldapMaxPoolSize"
+        set_at: [startup, runtime]
+        cpp_varname: "ldapGlobalParams.ldapConnectionPoolSizePerHost"
+        default: 2
+        validator:
+          gt: 0
 
 configs:
     'security.ldap.servers':
@@ -130,18 +135,3 @@ configs:
         arg_vartype: String
         validator:
             callback: validateLDAPUserToDNMapping
-    'security.ldap.debug':
-        description: 'Print debug information for LDAP connections'
-        short_name: ldapDebug
-        arg_vartype: Bool
-        default: false
-    'security.ldap.follow_referrals':
-        description: 'Automatically follow LDAP referrals with the same bind credentials'
-        short_name: ldapReferrals
-        arg_vartype: Bool
-        default: false
-    'security.ldap.maxPoolSize':
-        description: 'Maximum number of connections in the LDAP connection pool'
-        short_name: ldapMaxPoolSize
-        arg_vartype: Int
-        default: 2

--- a/src/mongo/db/ldap_options_init.cpp
+++ b/src/mongo/db/ldap_options_init.cpp
@@ -65,15 +65,6 @@ Status storeLDAPOptions(const moe::Environment& params) {
     if (params.count("security.ldap.userToDNMapping")) {
         ldapGlobalParams.ldapUserToDNMapping = params["security.ldap.userToDNMapping"].as<std::string>();
     }
-    if (params.count("security.ldap.debug")) {
-        ldapGlobalParams.ldapDebug.store(params["security.ldap.debug"].as<bool>());
-    }
-    if (params.count("security.ldap.follow_referrals")) {
-        ldapGlobalParams.ldapReferrals.store(params["security.ldap.follow_referrals"].as<bool>());
-    }
-    if (params.count("security.ldap.maxPoolSize")) {
-        ldapGlobalParams.ldapMaxPoolSize.store(params["security.ldap.maxPoolSize"].as<int>());
-    }
     return Status::OK();
 }
 


### PR DESCRIPTION
- remove ldapDebug, ldapReferrals, ldapMaxPoolSize as command line
  switches and config file parameters. Leave them as server parameters.
- rename server parameters:
    ldapMaxPoolSize => ldapConnectionPoolSizePerHost
    ldapReferrals => ldapFollowReferrals