### PR TITLE
PSMDB-755 cleanup LDAP-related server parameters

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -286,7 +286,8 @@ public:
                 return slot->conn;
             }
 
-            if (ldapGlobalParams.ldapMaxPoolSize.load() < _poll_fds.size()) {
+            if (static_cast<unsigned>(ldapGlobalParams.ldapConnectionPoolSizePerHost.load())
+                    < _poll_fds.size()) {
                 // pool is full, wait until we have a free slot
                 _condvar_pool.wait(lock,
                                    [this] { return find_free_slot() || _shuttingDown.load(); });
@@ -339,7 +340,7 @@ public:
             return nullptr;
         }
 
-        if (!ldapGlobalParams.ldapReferrals.load()) {
+        if (!ldapGlobalParams.ldapFollowReferrals.load()) {
             LOG(2) << "Disabling referrals";
             res = ldap_set_option(ldap, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
             if (res != LDAP_OPT_SUCCESS) {
@@ -684,7 +685,7 @@ Status LDAPManagerImpl::queryUserRoles(const UserName& userName,
 }
 
 Status LDAPbind(LDAP* ld, const char* usr, const char* psw) {
-    if (ldapGlobalParams.ldapReferrals.load()) {
+    if (ldapGlobalParams.ldapFollowReferrals.load()) {
         ldap_set_rebind_proc(ld, rebindproc, (void*)usr);
     }
     if (ldapGlobalParams.ldapBindMethod == "simple") {

--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -61,9 +61,9 @@ struct LDAPGlobalParams {
     AtomicInt32 ldapUserCacheInvalidationInterval{30};
     // ldapQueryTemplate does not exist in mongos, so it should be handled differently
     boost::synchronized_value<std::string> ldapQueryTemplate;
-    AtomicWord<bool> ldapDebug;
-    AtomicWord<bool> ldapReferrals;
-    AtomicWord<int>  ldapMaxPoolSize;
+    AtomicBool ldapDebug{false};
+    AtomicBool ldapFollowReferrals{false};
+    AtomicInt32  ldapConnectionPoolSizePerHost{2};
 
     std::string logString() const;
 };


### PR DESCRIPTION
- remove ldapDebug, ldapReferrals, ldapMaxPoolSize as command line
  switches and config file parameters. Leave them as server parameters.
- rename server parameters:
    ldapMaxPoolSizeParam => ldapConnectionPoolSizePerHost
    ldapFollowReferralsParam => ldapFollowReferrals