### PR TITLE
PSMDB-755 cleanup LDAP-related server parameters

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -286,7 +286,8 @@ public:
                 return slot->conn;
             }
 
-            if (ldapGlobalParams.ldapMaxPoolSize.load() < _poll_fds.size()) {
+            if (static_cast<unsigned>(ldapGlobalParams.ldapConnectionPoolSizePerHost.load())
+                    < _poll_fds.size()) {
                 // pool is full, wait until we have a free slot
                 _condvar_pool.wait(lock,
                                    [this] { return find_free_slot() || _shuttingDown.load(); });
@@ -339,7 +340,7 @@ public:
             return nullptr;
         }
 
-        if (!ldapGlobalParams.ldapReferrals.load()) {
+        if (!ldapGlobalParams.ldapFollowReferrals.load()) {
             LOG(2) << "Disabling referrals";
             res = ldap_set_option(ldap, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
             if (res != LDAP_OPT_SUCCESS) {
@@ -684,7 +685,7 @@ Status LDAPManagerImpl::queryUserRoles(const UserName& userName,
 }
 
 Status LDAPbind(LDAP* ld, const char* usr, const char* psw) {
-    if (ldapGlobalParams.ldapReferrals.load()) {
+    if (ldapGlobalParams.ldapFollowReferrals.load()) {
         ldap_set_rebind_proc(ld, rebindproc, (void*)usr);
     }
     if (ldapGlobalParams.ldapBindMethod == "simple") {

--- a/src/mongo/db/ldap_options.cpp
+++ b/src/mongo/db/ldap_options.cpp
@@ -136,22 +136,6 @@ Status addLDAPOptions(moe::OptionSection* options) {
         .setSources(moe::SourceYAMLCLI)
         .setDefault(moe::Value{"[{match: \"(.+)\", substitution: \"{0}\"}]"});
 
-    options
-        ->addOptionChaining("security.ldap.debug",
-                            "debug",
-                            moe::Bool,
-                            "Print debug information for LDAP connections")
-        .setSources(moe::SourceAll)
-        .setDefault(moe::Value{false});
-
-    options
-        ->addOptionChaining("security.ldap.follow_referrals",
-                            "follow_referrals",
-                            moe::Bool,
-                            "Automatically follow LDAP referrals with the same bind credentials")
-        .setSources(moe::SourceAll)
-        .setDefault(moe::Value{false});
-
     return Status::OK();
 }
 
@@ -271,15 +255,6 @@ Status storeLDAPOptions(const moe::Environment& params) {
             return ret;
         ldapGlobalParams.ldapUserToDNMapping = new_value;
     }
-    if (params.count("security.ldap.debug")) {
-        ldapGlobalParams.ldapDebug.store(params["security.ldap.debug"].as<bool>());
-    }
-    if (params.count("security.ldap.follow_referrals")) {
-        ldapGlobalParams.ldapReferrals.store(params["security.ldap.follow_referrals"].as<bool>());
-    }
-    if (params.count("security.ldap.maxPoolSize")) {
-        ldapGlobalParams.ldapMaxPoolSize.store(params["security.ldap.maxPoolSize"].as<int>());
-    }
     return Status::OK();
 }
 
@@ -319,14 +294,29 @@ ExportedServerParameter<int, ServerParameterType::kStartupAndRuntime>
                                            "ldapUserCacheInvalidationInterval",
                                            &ldapGlobalParams.ldapUserCacheInvalidationInterval};
 
-ExportedServerParameter<bool, ServerParameterType::kRuntimeOnly> ldapDebugParam{
+ExportedServerParameter<bool, ServerParameterType::kStartupAndRuntime> ldapDebugParam{
     ServerParameterSet::getGlobal(), "ldapDebug", &ldapGlobalParams.ldapDebug};
 
-ExportedServerParameter<bool, ServerParameterType::kRuntimeOnly> ldapFollowReferralsParam{
-    ServerParameterSet::getGlobal(), "ldapFollowReferralsParam", &ldapGlobalParams.ldapReferrals};
+ExportedServerParameter<bool, ServerParameterType::kStartupAndRuntime> ldapFollowReferralsParam{
+    ServerParameterSet::getGlobal(), "ldapFollowReferrals", &ldapGlobalParams.ldapFollowReferrals};
 
-ExportedServerParameter<int, ServerParameterType::kRuntimeOnly> ldapMaxPoolSizeParam{
-    ServerParameterSet::getGlobal(), "ldapMaxPoolSizeParam", &ldapGlobalParams.ldapMaxPoolSize};
+class LDAPConnectionPoolSizePerHostParameter
+    : public ExportedServerParameter<int, ServerParameterType::kStartupAndRuntime> {
+public:
+    LDAPConnectionPoolSizePerHostParameter()
+        : ExportedServerParameter<int, ServerParameterType::kStartupAndRuntime>(
+              ServerParameterSet::getGlobal(),
+              "ldapConnectionPoolSizePerHost",
+              &ldapGlobalParams.ldapConnectionPoolSizePerHost) {}
+
+    virtual Status validate(const int& potentialNewValue) override {
+        if (potentialNewValue < 1) {
+            return Status(ErrorCodes::BadValue, "ldapConnectionPoolSizePerHost has to be >= 1");
+        }
+
+        return Status::OK();
+    }
+} ldapConnectionPoolSizePerHostParam;
 
 }  // namespace
 

--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -61,9 +61,9 @@ struct LDAPGlobalParams {
     AtomicInt32 ldapUserCacheInvalidationInterval{30};
     // ldapQueryTemplate does not exist in mongos, so it should be handled differently
     boost::synchronized_value<std::string> ldapQueryTemplate;
-    AtomicWord<bool> ldapDebug;
-    AtomicWord<bool> ldapReferrals;
-    AtomicWord<int>  ldapMaxPoolSize;
+    AtomicBool ldapDebug{false};
+    AtomicBool ldapFollowReferrals{false};
+    AtomicInt32  ldapConnectionPoolSizePerHost{2};
 
     std::string logString() const;
 };


### PR DESCRIPTION
- remove ldapDebug, ldapReferrals, ldapMaxPoolSize as command line
  switches and config file parameters. Leave them as server parameters.
- rename server parameters:
    ldapMaxPoolSizeParam => ldapConnectionPoolSizePerHost
    ldapFollowReferralsParam => ldapFollowReferrals