### PR TITLE
PSMDB-726: Fix auth bypass in LDAP authentication

### DIFF
--- a/src/mongo/db/auth/external/external_sasl_authentication_session.cpp
+++ b/src/mongo/db/auth/external/external_sasl_authentication_session.cpp
@@ -156,6 +156,12 @@ StatusWith<std::tuple<bool, std::string>> OpenLDAPServerMechanism::stepImpl(
         const char* authn_id = authz_id + std::strlen(authz_id) + 1; // authentication id
         const char* pw = authn_id + std::strlen(authn_id) + 1; // password
 
+        if(strlen(pw) == 0) {
+            return Status(ErrorCodes::LDAPLibraryError,
+                          "Failed to authenticate '{}'; No password provided."_format(
+                              authn_id));
+        }
+
         // transform user to DN
         std::string mappedUser;
         {


### PR DESCRIPTION
Issue: the LDAP protocol allows servers to treat an empty password and
any user name as a successful anonymous bind request. This causes
authentication attemps to succeed when they shouldn't, with AD.

Fix: explicitly disable empty passwords with LDAP authentication.