### PR TITLE
PSMDB-766 Redirect ldap debug output to the log file (v4.4)

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -36,6 +36,7 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include <regex>
 
 #include <poll.h>
+#include <lber.h>
 
 #include <fmt/format.h>
 #include <sasl/sasl.h>
@@ -382,6 +383,10 @@ void cb_del(LDAP *ld, Sockbuf *sb, struct ldap_conncb *ctx) {
     LOGV2_DEBUG(29070, 2, "LDAP disconnect callback");
 }
 
+void cb_log(LDAP_CONST char* data) {
+  LOGV2_DEBUG(29090, 2, "(LDAP debugging)", "msg"_attr = data);
+}
+
 int rebindproc(LDAP* ld, const char* /* url */, ber_tag_t /* request */, ber_int_t /* msgid */, void* arg) {
 
     const auto user = ldapGlobalParams.ldapQueryUser.get();
@@ -453,6 +458,7 @@ Status LDAPManagerImpl::initialize() {
         if (res != LDAP_OPT_SUCCESS) {
           LOGV2_DEBUG(1, 29089, "Cannot set LDAP log level; LDAP error: {err}", "err"_attr = ldap_err2string(res));
         }
+        ber_set_option(nullptr, LBER_OPT_LOG_PRINT_FN, reinterpret_cast<const void*>(cb_log));
     }
 
     return Status::OK();


### PR DESCRIPTION
Just cherry-picked from v4.2 and changed LOG(2) to LOGV2_DEBUG(...)