### PR TITLE
PSMDB-832 enable jenkins builds without '--install-mode=legacy' v5.0

### DIFF
--- a/percona-packaging/debian/rules
+++ b/percona-packaging/debian/rules
@@ -42,7 +42,7 @@ compile-mongo-tools:
         export GOBINPATH="/usr/local/go/bin"
 	cd $(PSMSRC)/../src/github.com/mongodb/mongo-tools; \
         sed -i '12d' buildscript/build.go; \
-        sed -i '169,178d' buildscript/build.go; \
+        sed -i '167,176d' buildscript/build.go; \
         sed -i "s:versionStr,:\"$(PSMDB_TOOLS_REVISION)\",:" buildscript/build.go; \
         sed -i "s:gitCommit):\"$(PSMDB_TOOLS_COMMIT_HASH)\"):" buildscript/build.go; \
         ./make build;

--- a/percona-packaging/debian/rules
+++ b/percona-packaging/debian/rules
@@ -23,7 +23,7 @@ override_dh_auto_clean:
 	#rm -fr $(INSTALLDIR)
 	buildscripts/scons.py CC=$(CC) CXX=$(CXX) -C $(PSMSRC) -c --disable-warnings-as-errors --audit --release --ssl --opt -j$(NJOBS) --use-sasl-client CPPPATH=$(INSTALLDIR)/include \
 	LIBPATH=$(INSTALLDIR)/lib LINKFLAGS="$(LINKFLAGS)" --wiredtiger --inmemory --hotbackup $(PSM_TARGETS) || exit $?
-	rm -fr build
+	rm -fr build resmoke.ini
 	find $(PSMSRC) -name '*.pyc' -delete
 
 # Finally PSfMDB

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -167,7 +167,7 @@ cp -r $RPM_BUILD_DIR/%{src_dir}/mongo-tools ${GOPATH}/src/github.com/mongodb
 pushd ${GOPATH}/src/github.com/mongodb/mongo-tools
 . ./set_tools_revision.sh
 sed -i '12d' buildscript/build.go
-sed -i '169,178d' buildscript/build.go
+sed -i '167,176d' buildscript/build.go
 sed -i "s:versionStr,:\"$PSMDB_TOOLS_REVISION\",:" buildscript/build.go
 sed -i "s:gitCommit):\"$PSMDB_TOOLS_COMMIT_HASH\"):" buildscript/build.go
 ./make build

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -156,21 +156,16 @@ popd
 
 # Mongo Tools compilation
 mkdir -p $RPM_BUILD_DIR/%{src_dir}/bin
-pushd $RPM_BUILD_DIR/
-[[ ${PATH} == *"/usr/local/go/bin"* && -x /usr/local/go/bin/go ]] || export PATH=/usr/local/go/bin:${PATH}
-export GOROOT="/usr/local/go/"
-export GOPATH=$(pwd)/
-export PATH="/usr/local/go/bin:$PATH:$GOPATH"
-export GOBINPATH="/usr/local/go/bin"
-mkdir -p $GOPATH/src/github.com/mongodb
-cp -r $RPM_BUILD_DIR/%{src_dir}/mongo-tools ${GOPATH}/src/github.com/mongodb
-pushd ${GOPATH}/src/github.com/mongodb/mongo-tools
+cp -r $(ls | grep -v build_tools) build_tools/src/github.com/mongodb/mongo-tools/
+pushd build_tools/src/github.com/mongodb/mongo-tools
+sed -i 's|VersionStr="$(go run release/release.go get-version)"|VersionStr="$PSMDB_TOOLS_REVISION"|' set_goenv.sh
+sed -i 's|GitCommit="$(git rev-parse HEAD)"|GitCommit="$PSMDB_TOOLS_COMMIT_HASH"|' set_goenv.sh
+sed -i 's|go build|go build -a -x|' build.sh
+sed -i 's|exit $ec||' build.sh
 . ./set_tools_revision.sh
-sed -i '12d' buildscript/build.go
-sed -i '169,178d' buildscript/build.go
-sed -i "s:versionStr,:\"$PSMDB_TOOLS_REVISION\",:" buildscript/build.go
-sed -i "s:gitCommit):\"$PSMDB_TOOLS_COMMIT_HASH\"):" buildscript/build.go
-./make build
+. ./set_goenv.sh
+mkdir -p bin
+. ./build.sh ${TOOLS_TAGS}
 mv bin/* $RPM_BUILD_DIR/%{src_dir}/bin
 popd
 popd

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -148,9 +148,10 @@ mv ${INSTALLDIR_AWS}/lib*/* ${INSTALLDIR}/lib/
 
 # Build PSfMDB with SCons
 pushd $RPM_BUILD_DIR/%{src_dir}
-buildscripts/scons.py CC=${CC} CXX=${CXX} --audit --release --ssl --opt=on  \
+buildscripts/scons.py CC=${CC} CXX=${CXX} --disable-warnings-as-errors --audit --release --ssl --opt=on  \
 %{?_smp_mflags} --use-sasl-client CPPPATH=${INSTALLDIR}/include LIBPATH="${INSTALLDIR}/lib ${AWS_LIBS}/lib ${AWS_LIBS}/lib64" \
 --wiredtiger --inmemory --hotbackup ${PSM_TARGETS} || exit $?
+rm -fr resmoke.ini
 popd
 
 # Mongo Tools compilation

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -156,19 +156,24 @@ popd
 
 # Mongo Tools compilation
 mkdir -p $RPM_BUILD_DIR/%{src_dir}/bin
-cp -r $(ls | grep -v build_tools) build_tools/src/github.com/mongodb/mongo-tools/
-pushd build_tools/src/github.com/mongodb/mongo-tools
-sed -i 's|VersionStr="$(go run release/release.go get-version)"|VersionStr="$PSMDB_TOOLS_REVISION"|' set_goenv.sh
-sed -i 's|GitCommit="$(git rev-parse HEAD)"|GitCommit="$PSMDB_TOOLS_COMMIT_HASH"|' set_goenv.sh
-sed -i 's|go build|go build -a -x|' build.sh
-sed -i 's|exit $ec||' build.sh
+pushd $RPM_BUILD_DIR/
+[[ ${PATH} == *"/usr/local/go/bin"* && -x /usr/local/go/bin/go ]] || export PATH=/usr/local/go/bin:${PATH}
+export GOROOT="/usr/local/go/"
+export GOPATH=$(pwd)/
+export PATH="/usr/local/go/bin:$PATH:$GOPATH"
+export GOBINPATH="/usr/local/go/bin"
+mkdir -p $GOPATH/src/github.com/mongodb
+cp -r $RPM_BUILD_DIR/%{src_dir}/mongo-tools ${GOPATH}/src/github.com/mongodb
+pushd ${GOPATH}/src/github.com/mongodb/mongo-tools
 . ./set_tools_revision.sh
-. ./set_goenv.sh
-mkdir -p bin
-. ./build.sh ${TOOLS_TAGS}
+sed -i '12d' buildscript/build.go
+sed -i '169,178d' buildscript/build.go
+sed -i "s:versionStr,:\"$PSMDB_TOOLS_REVISION\",:" buildscript/build.go
+sed -i "s:gitCommit):\"$PSMDB_TOOLS_COMMIT_HASH\"):" buildscript/build.go
+./make build
 mv bin/* $RPM_BUILD_DIR/%{src_dir}/bin
 popd
-popd
+
 
 %install
 #

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -964,6 +964,15 @@ build_tarball(){
         done
     }
 
+    function check_libs {
+        local elf_path=$1
+        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            if ! ldd $elf; then
+                exit 1
+            fi
+        done
+    }
+
     # Gather libs
     for DIR in $DIRLIST; do
         gather_libs $DIR
@@ -976,6 +985,11 @@ build_tarball(){
     # Replace libs
     for DIR in $DIRLIST; do
         replace_libs $DIR
+    done
+
+    # Make final check in order to determine any error after linkage
+    for DIR in $DIRLIST; do
+        check_libs $DIR
     done
 
     cd ${PSMDIR_ABS}

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -387,13 +387,24 @@ install_deps() {
       pip install --upgrade pip
 
     else
+      apt-get -y install lsb-release wget apt-transport-https
       export DEBIAN=$(lsb_release -sc)
       export ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
       wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb && dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+      if [ x"${DEBIAN}" = "xxenial" -o x"${DEBIAN}" = "xbionic" -o x"${DEBIAN}" = "xfocal" ]; then
+        add-apt-repository -y ppa:deadsnakes/ppa
+      elif [ x"${DEBIAN}" = "xstretch" -o x"${DEBIAN}" = "xbuster" ]; then
+        wget https://people.debian.org/~paravoid/python-all/unofficial-python-all.asc
+        mv unofficial-python-all.asc /etc/apt/trusted.gpg.d/
+        echo "deb http://people.debian.org/~paravoid/python-all ${DEBIAN} main" | tee /etc/apt/sources.list.d/python-all.list
+      fi
       percona-release enable tools testing
       apt-get update
-      INSTALL_LIST="python3 python3-dev python3-pip valgrind scons liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev dh-systemd libsasl2-dev gcc g++ cmake curl"
+      INSTALL_LIST="python3.7 python3.7-dev valgrind scons liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev dh-systemd libsasl2-dev gcc g++ cmake curl"
       INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev liblzma-dev patchelf"
+      if [ x"${DEBIAN}" != "xstretch" ]; then
+        INSTALL_LIST="${INSTALL_LIST} python3.7-distutils"
+      fi
       until apt-get -y install dirmngr; do
         sleep 1
         echo "waiting"
@@ -411,9 +422,11 @@ install_deps() {
       install_golang
       install_gcc_8_deb
       wget https://bootstrap.pypa.io/get-pip.py
-      update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+      update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+      ln -sf /usr/bin/python3.7 /usr/bin/python3
       python get-pip.py
       easy_install pip
+      pip install setuptools
     fi
     if [ x"${DEBIAN}" = "xstretch" ]; then
       LIBCURL_DEPS="libidn2-0-dev libldap2-dev libnghttp2-dev libnss3-dev libpsl-dev librtmp-dev libssh2-1-dev libssl1.0-dev"
@@ -649,8 +662,8 @@ build_source_deb(){
     mv ${TARFILE} ${PRODUCT}_${VERSION}.orig.tar.gz
     cd ${BUILDDIR}
     pip install --upgrade pip
-    pip install --user -r etc/pip/dev-requirements.txt
-    pip install --user -r etc/pip/evgtest-requirements.txt
+    pip install -r etc/pip/dev-requirements.txt
+    pip install -r etc/pip/evgtest-requirements.txt
 
     set_compiler
     fix_rules
@@ -701,8 +714,8 @@ build_deb(){
     #
     cd ${PRODUCT}-${VERSION}
     pip install --upgrade pip
-    pip install --user -r etc/pip/dev-requirements.txt
-    pip install --user -r etc/pip/evgtest-requirements.txt
+    pip install -r etc/pip/dev-requirements.txt
+    pip install -r etc/pip/evgtest-requirements.txt
     #
     cp -av percona-packaging/debian/rules debian/
     set_compiler

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -731,6 +731,7 @@ build_deb(){
     sed -i 's|GitCommit="$(git rev-parse HEAD)"|GitCommit="$PSMDB_TOOLS_COMMIT_HASH"|' mongo-tools/set_goenv.sh
     sed -i 's|go build|go build -a -x|' mongo-tools/build.sh
     sed -i 's|exit $ec||' mongo-tools/build.sh
+    . ./mongo-tools/set_tools_revision.sh
     dch -m -D "${DEBIAN}" --force-distribution -v "${VERSION}-${RELEASE}.${DEBIAN}" 'Update distribution'
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     if [ x"${DEBIAN}" = "xstretch" ]; then

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -926,27 +926,36 @@ build_tarball(){
     if [ ! -d lib/private ]; then
         mkdir -p lib/private
     fi
-    LIBLIST="libcrypto.so libssl.so libpcap.so libsasl2.so libcurl.so libldap liblber libssh libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libfreebl3.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so libplds4.so liblzma.so libidn.so"
+    LIBLIST="libcrypto.so libssl.so libsasl2.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so liblzma.so libidn.so"
     DIRLIST="bin lib/private"
 
     LIBPATH=""
 
     function gather_libs {
         local elf_path=$1
-        for lib in $LIBLIST; do
-            for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+        for lib in ${LIBLIST}; do
+            for elf in $(find ${elf_path} -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
                 IFS=$'\n'
-                for libfromelf in $(ldd $elf | grep $lib | awk '{print $3}'); do
-                    if [ ! -f lib/private/$(basename $(readlink -f $libfromelf)) ] && [ ! -L lib/$(basename $(readlink -f $libfromelf)) ]; then
-                        echo "Copying lib $(basename $(readlink -f $libfromelf))"
-                        cp $(readlink -f $libfromelf) lib/private
+                for libfromelf in $(ldd ${elf} | grep ${lib} | awk '{print $3}'); do
+                    lib_realpath="$(readlink -f ${libfromelf})"
+                    lib_realpath_basename="$(basename $(readlink -f ${libfromelf}))"
+                    lib_without_version_suffix=$(echo ${lib_realpath_basename} | awk -F"." 'BEGIN { OFS = "." }{ print $1, $2}')
 
-                        echo "Symlinking lib $(basename $(readlink -f $libfromelf))"
-                        cd lib
-                        ln -s private/$(basename $(readlink -f $libfromelf)) $(basename $(readlink -f $libfromelf))
-                        cd -
+                    if [ ! -f "lib/private/${lib_realpath_basename}" ] && [ ! -L "lib/private/${lib_realpath_basename}" ]; then
+                    
+                        echo "Copying lib ${lib_realpath_basename}"
+                        cp ${lib_realpath} lib/private
 
-                        LIBPATH+=" $(echo $libfromelf | grep -v $(pwd))"
+                        if [ ${lib_realpath_basename} != ${lib_without_version_suffix} ]; then
+                            echo "Symlinking lib from ${lib_realpath_basename} to ${lib_without_version_suffix}"
+                            cd lib/private
+                            ln -s ${lib_realpath_basename} ${lib_without_version_suffix}
+                            cd -
+                        fi
+
+                        patchelf --set-soname ${lib_without_version_suffix} lib/private/${lib_realpath_basename}
+
+                        LIBPATH+=" $(echo ${libfromelf} | grep -v $(pwd))"
                     fi
                 done
                 unset IFS
@@ -958,27 +967,25 @@ build_tarball(){
         # Set proper runpath for bins but check before doing anything
         local elf_path=$1
         local r_path=$2
-        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
-            echo "Checking LD_RUNPATH for $elf"
-            if [ -z $(patchelf --print-rpath $elf) ]; then
-                echo "Changing RUNPATH for $elf"
-                patchelf --set-rpath $r_path $elf
+        for elf in $(find ${elf_path} -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            echo "Checking LD_RUNPATH for ${elf}"
+            if [ -z $(patchelf --print-rpath ${elf}) ]; then
+                echo "Changing RUNPATH for ${elf}"
+                patchelf --set-rpath ${r_path} ${elf}
             fi
         done
     }
 
     function replace_libs {
         local elf_path=$1
-        for libpath_sorted in $LIBPATH; do
-            for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
-                LDD=$(ldd $elf | grep $libpath_sorted|head -n1|awk '{print $1}')
+        for libpath_sorted in ${LIBPATH}; do
+            for elf in $(find ${elf_path} -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+                LDD=$(ldd ${elf} | grep ${libpath_sorted}|head -n1|awk '{print $1}')
+                lib_realpath_basename="$(basename $(readlink -f ${libpath_sorted}))"
+                lib_without_version_suffix="$(echo ${lib_realpath_basename} | awk -F"." 'BEGIN { OFS = "." }{ print $1, $2}')"
                 if [[ ! -z $LDD  ]]; then
-                    echo "Replacing lib $(basename $(readlink -f $libpath_sorted)) for $elf"
-                    patchelf --replace-needed $LDD $(basename $(readlink -f $libpath_sorted)) $elf
-                fi
-                # Add if present in LDD to NEEDED
-                if [[ ! -z $LDD ]] && [[ -z "$(readelf -d $elf | grep $(basename $libpath_sorted | awk -F'.' '{print $1}'))" ]]; then
-                    patchelf --add-needed $(basename $(readlink -f $libpath_sorted)) $elf
+                    echo "Replacing lib ${lib_realpath_basename} to ${lib_without_version_suffix} for ${elf}"
+                    patchelf --replace-needed ${LDD} ${lib_without_version_suffix} ${elf}
                 fi
             done
         done
@@ -986,36 +993,36 @@ build_tarball(){
 
     function create_sparse {
         local elf_path=$1
-        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
-            if [[ ! -f "$elf.sparse" ]]; then
-                echo "Creating sparse file of $(basename $elf)"
-                cp --sparse=always $elf $elf.sparse
+        for elf in $(find ${elf_path} -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            if [[ ! -f "${elf}.sparse" ]]; then
+                echo "Creating sparse file of $(basename ${elf})"
+                cp --sparse=always ${elf} ${elf}.sparse
             fi
         done
     }
 
     function replace_binaries {
         local elf_path=$1
-        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
-            if [[ -f "$elf.sparse" ]]; then
+        for elf in $(find ${elf_path} -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            if [[ -f "${elf}.sparse" ]]; then
                 echo "Replacing binary with sparse file"
-                mv $elf.sparse $elf
+                mv ${elf}.sparse ${elf}
             fi
         done
     }
 
     function check_libs {
         local elf_path=$1
-        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
-            if ! ldd $elf; then
+        for elf in $(find ${elf_path} -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            if ! ldd ${elf}; then
                 exit 1
             fi
         done
     }
 
     # Gather libs
-    for DIR in $DIRLIST; do
-        gather_libs $DIR
+    for DIR in ${DIRLIST}; do
+        gather_libs ${DIR}
     done
 
     # Set proper runpath
@@ -1023,8 +1030,8 @@ build_tarball(){
     set_runpath lib/private '$ORIGIN/'
 
     # Replace libs
-    for DIR in $DIRLIST; do
-        replace_libs $DIR
+    for DIR in ${DIRLIST}; do
+        replace_libs ${DIR}
     done
 
     # Create and replace by sparse file to reduce size
@@ -1032,8 +1039,8 @@ build_tarball(){
     replace_binaries bin
 
     # Make final check in order to determine any error after linkage
-    for DIR in $DIRLIST; do
-        check_libs $DIR
+    for DIR in ${DIRLIST}; do
+        check_libs ${DIR}
     done
 
     cd ${PSMDIR_ABS}

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -926,7 +926,7 @@ build_tarball(){
     if [ ! -d lib/private ]; then
         mkdir -p lib/private
     fi
-    LIBLIST="libcrypto.so libssl.so libsasl2.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so liblzma.so libidn.so"
+    LIBLIST="libcrypto.so libssl.so libsasl2.so librtmp.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so liblzma.so libidn.so"
     DIRLIST="bin lib/private"
 
     LIBPATH=""
@@ -941,7 +941,7 @@ build_tarball(){
                     lib_realpath_basename="$(basename $(readlink -f ${libfromelf}))"
                     lib_without_version_suffix=$(echo ${lib_realpath_basename} | awk -F"." 'BEGIN { OFS = "." }{ print $1, $2}')
 
-                    if [ ! -f "lib/private/${lib_realpath_basename}" ] && [ ! -L "lib/private/${lib_realpath_basename}" ]; then
+                    if [ ! -f "lib/private/${lib_realpath_basename}" ] && [ ! -L "lib/private/${lib_without_version_suffix}" ]; then
                     
                         echo "Copying lib ${lib_realpath_basename}"
                         cp ${lib_realpath} lib/private

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -359,12 +359,16 @@ install_deps() {
         yum -y install epel-release
         yum -y install rpmbuild rpm-build libpcap-devel gcc make cmake gcc-c++ openssl-devel
         yum -y install cyrus-sasl-devel snappy-devel zlib-devel bzip2-devel scons rpmlint
-        yum -y install rpm-build git python-pip python-devel libopcodes libcurl-devel rpmlint e2fsprogs-devel expat-devel lz4-devel
+        yum -y install rpm-build git python-pip python-devel libopcodes libcurl-devel rpmlint e2fsprogs-devel expat-devel lz4-devel which
         yum -y install openldap-devel krb5-devel xz-devel
+        pip install --upgrade pip
+        pip2.7 install --user setuptools --upgrade
+        pip3.6 install --user typing pyyaml regex Cheetah3
+        pip2.7 install --user typing pyyaml regex Cheetah Cheetah3
       else
         yum -y install bzip2-devel libpcap-devel snappy-devel gcc gcc-c++ rpm-build rpmlint
         yum -y install cmake cyrus-sasl-devel make openssl-devel zlib-devel libcurl-devel git
-        yum -y install python2-scons python2-pip python36-devel
+        yum -y install python2-scons python2-pip python36-devel which
         yum -y install redhat-rpm-config python2-devel e2fsprogs-devel expat-devel lz4-devel
         yum -y install openldap-devel krb5-devel xz-devel
       fi
@@ -372,13 +376,13 @@ install_deps() {
         /usr/bin/pip3.6 install --user typing pyyaml regex Cheetah3
         /usr/bin/pip2.7 install --user typing pyyaml regex Cheetah
       fi
-        wget https://curl.se/download/curl-7.66.0.tar.gz
-        tar -xvzf curl-7.66.0.tar.gz
-        cd curl-7.66.0
-          ./configure
-          make
-          make install
-        cd ../
+      wget http://curl.haxx.se/download/curl-7.66.0.tar.gz
+      tar -xvzf curl-7.66.0.tar.gz
+      cd curl-7.66.0
+        ./configure
+        make
+        make install
+      cd ../
 #
       install_golang
       install_gcc_8_centos
@@ -389,7 +393,8 @@ install_deps() {
       pip install --upgrade pip
 
     else
-      apt-get -y install lsb-release wget apt-transport-https
+      apt-get -y update
+      DEBIAN_FRONTEND=noninteractive apt-get -y install curl lsb-release wget apt-transport-https software-properties-common
       export DEBIAN=$(lsb_release -sc)
       export ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
       wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb && dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
@@ -402,7 +407,7 @@ install_deps() {
       fi
       percona-release enable tools testing
       apt-get update
-      INSTALL_LIST="python3.7 python3.7-dev valgrind scons liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev dh-systemd libsasl2-dev gcc g++ cmake curl"
+      INSTALL_LIST="git python3.7 python3.7-dev valgrind scons liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev dh-systemd libsasl2-dev gcc g++ cmake curl"
       INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev liblzma-dev patchelf"
       if [ x"${DEBIAN}" != "xstretch" ]; then
         INSTALL_LIST="${INSTALL_LIST} python3.7-distutils"

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -201,15 +201,18 @@ get_sources(){
 
 get_system(){
     if [ -f /etc/redhat-release ]; then
+        GLIBC_VER_TMP="$(rpm glibc -qa --qf %{VERSION})"
         RHEL=$(rpm --eval %rhel)
         ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
         OS_NAME="el$RHEL"
         OS="rpm"
     else
+        GLIBC_VER_TMP="$(dpkg-query -W -f='${Version}' libc6 | awk -F'-' '{print $1}')"
         ARCH=$(uname -m)
         OS_NAME="$(lsb_release -sc)"
         OS="deb"
     fi
+    export GLIBC_VER=".glibc${GLIBC_VER_TMP}"
     return
 }
 
@@ -332,7 +335,10 @@ install_deps() {
       add_percona_yum_repo
       wget http://jenkins.percona.com/yum-repo/percona-dev.repo
       mv -f percona-dev.repo /etc/yum.repos.d/
+      yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+      percona-release enable tools testing
       yum clean all
+      yum install -y patchelf
       RHEL=$(rpm --eval %rhel)
       if [ x"$RHEL" = x6 ]; then
         yum -y update
@@ -383,8 +389,11 @@ install_deps() {
     else
       export DEBIAN=$(lsb_release -sc)
       export ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
+      wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb && dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+      percona-release enable tools testing
+      apt-get update
       INSTALL_LIST="python3 python3-dev python3-pip valgrind scons liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev dh-systemd libsasl2-dev gcc g++ cmake curl"
-      INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev liblzma-dev"
+      INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev liblzma-dev patchelf"
       until apt-get -y install dirmngr; do
         sleep 1
         echo "waiting"
@@ -756,13 +765,11 @@ build_tarball(){
     TARBALL_SUFFIX=".dbg"
     fi
     if [ -f /etc/debian_version ]; then
-        export OS_RELEASE="$(lsb_release -sc)"
         set_compiler
     fi
     #
     if [ -f /etc/redhat-release ]; then
     #export OS_RELEASE="centos$(lsb_release -sr | awk -F'.' '{print $1}')"
-        export OS_RELEASE="centos$(rpm --eval %rhel)"
         RHEL=$(rpm --eval %rhel)
         if [ -f /opt/rh/devtoolset-8/enable ]; then
             source /opt/rh/devtoolset-8/enable
@@ -894,16 +901,94 @@ build_tarball(){
     sed -i "s:TARBALL=0:TARBALL=1:" ${PSMDIR_ABS}/percona-packaging/conf/percona-server-mongodb-enable-auth.sh
     cp ${PSMDIR_ABS}/percona-packaging/conf/percona-server-mongodb-enable-auth.sh ${PSMDIR_ABS}/${PSMDIR}/bin
 
+    # Patch needed libraries
+    cd "${PSMDIR_ABS}/${PSMDIR}"
+    if [ ! -d lib/private ]; then
+        mkdir -p lib/private
+    fi
+    LIBLIST="libcrypto.so libssl.so libpcap.so libsasl2.so libcurl.so libldap liblber libssh libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libfreebl3.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so libplds4.so liblzma.so"
+    DIRLIST="bin lib/private"
+
+    LIBPATH=""
+
+    function gather_libs {
+        local elf_path=$1
+        for lib in $LIBLIST; do
+            for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+                IFS=$'\n'
+                for libfromelf in $(ldd $elf | grep $lib | awk '{print $3}'); do
+                    if [ ! -f lib/private/$(basename $(readlink -f $libfromelf)) ] && [ ! -L lib/$(basename $(readlink -f $libfromelf)) ]; then
+                        echo "Copying lib $(basename $(readlink -f $libfromelf))"
+                        cp $(readlink -f $libfromelf) lib/private
+
+                        echo "Symlinking lib $(basename $(readlink -f $libfromelf))"
+                        cd lib
+                        ln -s private/$(basename $(readlink -f $libfromelf)) $(basename $(readlink -f $libfromelf))
+                        cd -
+
+                        LIBPATH+=" $(echo $libfromelf | grep -v $(pwd))"
+                    fi
+                done
+                unset IFS
+            done
+        done
+    }
+
+    function set_runpath {
+        # Set proper runpath for bins but check before doing anything
+        local elf_path=$1
+        local r_path=$2
+        for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+            echo "Checking LD_RUNPATH for $elf"
+            if [ -z $(patchelf --print-rpath $elf) ]; then
+                echo "Changing RUNPATH for $elf"
+                patchelf --set-rpath $r_path $elf
+            fi
+        done
+    }
+
+    function replace_libs {
+        local elf_path=$1
+        for libpath_sorted in $LIBPATH; do
+            for elf in $(find $elf_path -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+                LDD=$(ldd $elf | grep $libpath_sorted|head -n1|awk '{print $1}')
+                if [[ ! -z $LDD  ]]; then
+                    echo "Replacing lib $(basename $(readlink -f $libpath_sorted)) for $elf"
+                    patchelf --replace-needed $LDD $(basename $(readlink -f $libpath_sorted)) $elf
+                fi
+                # Add if present in LDD to NEEDED
+                if [[ ! -z $LDD ]] && [[ -z "$(readelf -d $elf | grep $(basename $libpath_sorted | awk -F'.' '{print $1}'))" ]]; then
+                    patchelf --add-needed $(basename $(readlink -f $libpath_sorted)) $elf
+                fi
+            done
+        done
+    }
+
+    # Gather libs
+    for DIR in $DIRLIST; do
+        gather_libs $DIR
+    done
+
+    # Set proper runpath
+    set_runpath bin '$ORIGIN/../lib/private/'
+    set_runpath lib/private '$ORIGIN/'
+
+    # Replace libs
+    for DIR in $DIRLIST; do
+        replace_libs $DIR
+    done
+
     cd ${PSMDIR_ABS}
-    tar --owner=0 --group=0 -czf ${WORKDIR}/${PSMDIR}-${OS_RELEASE}-${ARCH}${TARBALL_SUFFIX}.tar.gz ${PSMDIR}
+    mv ${PSMDIR} ${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}
+    tar --owner=0 --group=0 -czf ${WORKDIR}/${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}.tar.gz ${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}    
     DIRNAME="tarball"
     if [ "${DEBUG}" = 1 ]; then
     DIRNAME="debug"
     fi
     mkdir -p ${WORKDIR}/${DIRNAME}
     mkdir -p ${CURDIR}/${DIRNAME}
-    cp ${WORKDIR}/${PSMDIR}-${OS_RELEASE}-${ARCH}${TARBALL_SUFFIX}.tar.gz ${WORKDIR}/${DIRNAME}
-    cp ${WORKDIR}/${PSMDIR}-${OS_RELEASE}-${ARCH}${TARBALL_SUFFIX}.tar.gz ${CURDIR}/${DIRNAME}
+    cp ${WORKDIR}/${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}.tar.gz ${WORKDIR}/${DIRNAME}
+    cp ${WORKDIR}/${PSMDIR}-${ARCH}${GLIBC_VER}${TARBALL_SUFFIX}.tar.gz ${CURDIR}/${DIRNAME}
 }
 
 #main

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -376,7 +376,7 @@ install_deps() {
         /usr/bin/pip3.6 install --user typing pyyaml regex Cheetah3
         /usr/bin/pip2.7 install --user typing pyyaml regex Cheetah
       fi
-      wget http://curl.haxx.se/download/curl-7.66.0.tar.gz
+      wget https://curl.se/download/curl-7.66.0.tar.gz
       tar -xvzf curl-7.66.0.tar.gz
       cd curl-7.66.0
         ./configure
@@ -910,16 +910,11 @@ build_tarball(){
     cp -r ${WORKDIR}/${TOOLSDIR} ./
     cd mongo-tools
     . ./set_tools_revision.sh
-    sed -i 's|VersionStr="$(go run release/release.go get-version)"|VersionStr="$PSMDB_TOOLS_REVISION"|' set_goenv.sh
-    sed -i 's|GitCommit="$(git rev-parse HEAD)"|GitCommit="$PSMDB_TOOLS_COMMIT_HASH"|' set_goenv.sh
-    . ./set_goenv.sh
-    if [ ${DEBUG} = 0 ]; then
-        sed -i 's|go build|go build -a -x|' build.sh
-    else
-        sed -i 's|go build|go build -a |' build.sh
-    fi
-    sed -i 's|exit $ec||' build.sh
-    . ./build.sh ${TOOLS_TAGS}
+    sed -i '12d' buildscript/build.go
+    sed -i '169,178d' buildscript/build.go
+    sed -i "s:versionStr,:\"$PSMDB_TOOLS_REVISION\",:" buildscript/build.go
+    sed -i "s:gitCommit):\"$PSMDB_TOOLS_COMMIT_HASH\"):" buildscript/build.go
+    ./make build
     # move mongo tools to PSM installation dir
     mv bin/* ${PSMDIR_ABS}/${PSMDIR}/bin
     #

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -912,7 +912,7 @@ build_tarball(){
     cd mongo-tools
     . ./set_tools_revision.sh
     sed -i '12d' buildscript/build.go
-    sed -i '169,178d' buildscript/build.go
+    sed -i '167,176d' buildscript/build.go
     sed -i "s:versionStr,:\"$PSMDB_TOOLS_REVISION\",:" buildscript/build.go
     sed -i "s:gitCommit):\"$PSMDB_TOOLS_COMMIT_HASH\"):" buildscript/build.go
     ./make build

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -919,7 +919,7 @@ build_tarball(){
     if [ ! -d lib/private ]; then
         mkdir -p lib/private
     fi
-    LIBLIST="libcrypto.so libssl.so libpcap.so libsasl2.so libcurl.so libldap liblber libssh libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libfreebl3.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so libplds4.so liblzma.so"
+    LIBLIST="libcrypto.so libssl.so libpcap.so libsasl2.so libcurl.so libldap liblber libssh libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so libkrb5.so libkrb5support.so libk5crypto.so librtmp.so libgssapi.so libfreebl3.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplds4.so libplc4.so libnspr4.so libssl3.so libplds4.so liblzma.so libidn.so"
     DIRLIST="bin lib/private"
 
     LIBPATH=""

--- a/percona-packaging/scripts/test-build.sh
+++ b/percona-packaging/scripts/test-build.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+function check_libs {
+    for elf in $(find $1 -maxdepth 1 -exec file {} \; | grep 'ELF ' | cut -d':' -f1); do
+        echo $elf
+        ldd $elf | grep "not found"
+    done
+    return
+}
+
+function prepare {
+    CURDIR=$(pwd)
+
+    mkdir -p $CURDIR/temp
+    TMP_DIR=$CURDIR/temp
+    
+    TARBALL=$(basename $(find . -name "*glibc2.12.tar.gz" | sort))
+}
+
+function install_deps {
+    if [ -f /etc/redhat-release ]; then 
+        yum install -y perl-Time-HiRes perl numactl numactl-libs libaio git libidn || true
+    else
+        apt install -y perl numactl libaio-dev git libidn11 || true
+    fi
+}
+
+main () {
+
+    DIRLIST="bin lib lib/private lib/plugin"
+
+    prepare
+
+    echo "Unpacking tarball"
+    cd $TMP_DIR
+    tar xf $CURDIR/$TARBALL
+    cd ${TARBALL%.tar.gz}
+
+    echo "Checking ELFs for not found"
+    for DIR in $DIRLIST; do
+        check_libs $DIR | tee -a $TMP_DIR/libs_err.log
+    done
+
+    if [[ ! -z $(cat $TMP_DIR/libs_err.log | grep "not found") ]]; then
+        echo "ERROR: There are missing libraries: "
+        cat $TMP_DIR/libs_err.log
+        exit 1
+    fi
+
+    # Run tests
+    mkdir -p $TMP_DIR/db tests
+    wget -O $TMP_DIR/mgodatagen.tar.gz https://github.com/feliixx/mgodatagen/releases/download/v0.8.2/mgodatagen_linux_x86_64.tar.gz
+    wget -O tests/big.json https://raw.githubusercontent.com/feliixx/mgodatagen/master/datagen/testdata/big.json
+    tar -xvf $TMP_DIR/mgodatagen.tar.gz
+
+    ./bin/mongod --dbpath $TMP_DIR/db 2>&1 > status.log &
+    MONGOPID=$(echo $!)
+    ./mgodatagen -f tests/big.json
+    if [ $? -eq 0 ]; then
+        echo "Tests succeeded"
+        kill -2 $MONGOPID
+        echo " == PSMDB Log =="
+        cat status.log
+    else
+        echo "Tests failed"
+        exit 1
+    fi
+}
+
+case "$1" in
+    --install_deps) install_deps ;;
+    --test) main ;;
+    --help|*)
+    cat <<EOF
+Usage: $0 [OPTIONS]
+    The following options may be given :
+        --install_deps
+        --test
+        --help) usage ;;
+Example $0 --install_deps 
+EOF
+    ;;
+esac

--- a/percona-packaging/scripts/test-build.sh
+++ b/percona-packaging/scripts/test-build.sh
@@ -11,10 +11,19 @@ function check_libs {
 function prepare {
     CURDIR=$(pwd)
 
-    mkdir -p $CURDIR/temp
-    TMP_DIR=$CURDIR/temp
-    
-    TARBALL=$(basename $(find . -name "*glibc2.12.tar.gz" | sort))
+    if [ -f /etc/redhat-release ]; then
+        GLIBC_VER="$(rpm glibc -qa --qf %{VERSION})"
+    else
+        GLIBC_VER="$(dpkg-query -W -f='${Version}' libc6 | awk -F'-' '{print $1}')"
+    fi
+
+    TARBALLS=""
+    for tarball in $(find . -name "*.tar.gz"); do
+        if [[ "$(echo $tarball | grep -o "glibc2.*" | awk -F '.' '{print $2}')" -le "$(echo $GLIBC_VER | awk -F '.' '{print $2}')" ]]; then
+            TARBALLS+=" $(basename $tarball)"
+        fi
+    done
+    DIRLIST="bin lib/private"
 }
 
 function install_deps {


### PR DESCRIPTION
First commit contains changes to psmdb_builder.sh to enable builds without '--install-mode=legacy'.
All other commits were just cherry-picked from v4.4 to made master branch up to date.