### PR TITLE
PSMDB-957 Fix crash in LDAP authentication

### DIFF
--- a/src/mongo/logv2/log.h
+++ b/src/mongo/logv2/log.h
@@ -299,6 +299,20 @@ namespace mongo {
                         FMTSTR_MESSAGE,                                                   \
                         ##__VA_ARGS__)
 
+/**
+ * Log with custom severity.
+ *
+ * SEVERITY is an object of the `::mongo::logv2::LogSeverity` class
+ *
+ * See LOGV2() for documentation of the other parameters
+ */
+#define LOGV2_SEVERITY(ID, SEVERITY, FMTSTR_MESSAGE, ...)                        \
+    LOGV2_IMPL(ID,                                                               \
+               SEVERITY,                                                         \
+               ::mongo::logv2::LogOptions{MongoLogV2DefaultComponent_component}, \
+               FMTSTR_MESSAGE,                                                   \
+               ##__VA_ARGS__)
+
 inline bool shouldLog(logv2::LogComponent logComponent, logv2::LogSeverity severity) {
     return logv2::LogManager::global().getGlobalSettings().shouldLog(logComponent, severity);
 }


### PR DESCRIPTION
Prevent crash which occurred at mongod startup if the
'security.ldap.servers' config parameter contained a prefix before
the server host, e.g. the 'ldaps://' protocol specification.