### PR TITLE
PSMDB-979 Respect config while rotating audit log

### DIFF
--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -114,7 +114,7 @@ namespace audit {
                 appendMatched(obj, affects_durable_state);
             }
         }
-        virtual void rotate() override {
+        virtual void rotate(bool rename, StringData renameSuffix) override {
             // No need to override this method if there is nothing to rotate
             // like it is for 'console' and 'syslog' destinations
         }
@@ -194,22 +194,22 @@ namespace audit {
             invariant(_membuf.write(adapter->data(), adapter->size()));
         }
 
-        virtual void rotate() override {
+        virtual void rotate(bool rename, StringData renameSuffix) override {
             stdx::lock_guard<SimpleMutex> lck(_mutex);
 
             // Close the current file.
             _file.reset();
 
-            // Rename the current file
-            // Note: we append a timestamp to the file name.
-            std::stringstream ss;
-            ss << _fileName << "." << terseCurrentTime(false);
-            std::string s = ss.str();
-            int r = std::rename(_fileName.c_str(), s.c_str());
-            if (r != 0) {
-                error() << "Could not rotate audit log, but continuing normally "
-                        << "(error desc: " << errnoWithDescription() << ")"
-                        << std::endl;
+            if (rename) {
+                // Rename the current file
+                // Note: we append a timestamp to the file name.
+                std::string s = _fileName + renameSuffix;
+                int r = std::rename(_fileName.c_str(), s.c_str());
+                if (r != 0) {
+                    error() << "Could not rotate audit log, but continuing normally "
+                            << "(error desc: " << errnoWithDescription() << ")"
+                            << std::endl;
+                }
             }
 
             // Open a new file, with the same name as the original.

--- a/src/mongo/logger/auditlog.h
+++ b/src/mongo/logger/auditlog.h
@@ -34,12 +34,14 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include "mongo/base/string_data.h"
+
 namespace mongo {
 namespace logger {
 
     class AuditLog {
     public:
-        virtual void rotate() {};
+        virtual void rotate(bool rename, StringData renameSuffix){};
         virtual ~AuditLog() {};
     };
 

--- a/src/mongo/logger/rotatable_file_manager.cpp
+++ b/src/mongo/logger/rotatable_file_manager.cpp
@@ -75,7 +75,7 @@ RotatableFileManager::FileNameStatusPairVector RotatableFileManager::rotateAll(
         }
     }
     if (_auditLog) {
-        _auditLog->rotate();
+        _auditLog->rotate(renameFiles, renameTargetSuffix);
     }
     return badStatuses;
 }


### PR DESCRIPTION
Previously, audit log was rotated in the 'rename' mode regardless
of what was specified in the 'systemLog.logRotate' config setting.