### PR TITLE
PSMDB-979 Respect config while rotating audit log

### DIFF
--- a/src/mongo/logger/auditlog.h
+++ b/src/mongo/logger/auditlog.h
@@ -34,12 +34,14 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include "mongo/base/string_data.h"
+
 namespace mongo {
 namespace logger {
 
     class AuditLog {
     public:
-        virtual void rotate() {};
+        virtual void rotate(bool rename, StringData renameSuffix){};
         virtual ~AuditLog() {};
     };
 

--- a/src/mongo/logger/rotatable_file_manager.cpp
+++ b/src/mongo/logger/rotatable_file_manager.cpp
@@ -76,7 +76,7 @@ RotatableFileManager::FileNameStatusPairVector RotatableFileManager::rotateAll(
         }
     }
     if (_auditLog) {
-        _auditLog->rotate();
+        _auditLog->rotate(renameFiles, renameTargetSuffix);
     }
     return badStatuses;
 }


### PR DESCRIPTION
Previously, audit log was rotated in the 'rename' mode regardless
of what was specified in the 'systemLog.logRotate' config setting.