### PR TITLE
PSMDB-1043: Remove the 'kmipClientKeyFile' option

### DIFF
--- a/src/mongo/db/encryption/encryption_kmip.cpp
+++ b/src/mongo/db/encryption/encryption_kmip.cpp
@@ -41,7 +41,6 @@ kmippp::context kmipCreateContext() {
     return kmippp::context{encryptionGlobalParams.kmipServerName,
                            portStr,
                            encryptionGlobalParams.kmipClientCertificateFile,
-                           encryptionGlobalParams.kmipClientKeyFile,
                            encryptionGlobalParams.kmipServerCAFile};
 }
 

--- a/src/mongo/db/encryption/encryption_options.h
+++ b/src/mongo/db/encryption/encryption_options.h
@@ -52,7 +52,6 @@ struct EncryptionGlobalParams {
     int kmipPort{5696};
     std::string kmipServerCAFile;
     std::string kmipClientCertificateFile;
-    std::string kmipClientKeyFile;
     std::string kmipKeyIdentifier;
     bool kmipRotateMasterKey{false};
 

--- a/src/mongo/db/mongod_options.cpp
+++ b/src/mongo/db/mongod_options.cpp
@@ -498,10 +498,6 @@ Status storeMongodOptions(const moe::Environment& params) {
         encryptionGlobalParams.kmipClientCertificateFile = params["security.kmip.clientCertificateFile"].as<std::string>();
     }
 
-    if (params.count("security.kmip.clientKeyFile")) {
-        encryptionGlobalParams.kmipClientKeyFile = params["security.kmip.clientKeyFile"].as<std::string>();
-    }
-
     if (params.count("security.kmip.keyIdentifier")) {
         encryptionGlobalParams.kmipKeyIdentifier = params["security.kmip.keyIdentifier"].as<std::string>();
     }

--- a/src/mongo/db/mongod_options_encryption.idl
+++ b/src/mongo/db/mongod_options_encryption.idl
@@ -115,7 +115,7 @@ configs:
         description: 'Hostname or IP address of the KMIP server'
         short_name: kmipServerName
         arg_vartype: String
-        requires: [ 'security.enableEncryption', 'security.kmip.clientCertificateFile', 'security.kmip.clientKeyFile', 'security.kmip.keyIdentifier' ]
+        requires: [ 'security.enableEncryption', 'security.kmip.clientCertificateFile', 'security.kmip.keyIdentifier' ]
         conflicts: ['security.encryptionKeyFile', 'security.vault.serverName']
 
     'security.kmip.port':
@@ -137,14 +137,8 @@ configs:
         requires: 'security.kmip.serverName'
 
     'security.kmip.clientCertificateFile':
-        description: 'Path to the KMIP client certificate'
+        description: 'Path to the PEM file with KMIP client private key and certificate chain'
         short_name: kmipClientCertificateFile
-        arg_vartype: String
-        requires: 'security.kmip.serverName'
-
-    'security.kmip.clientKeyFile':
-        description: 'Path to the KMIP client key file'
-        short_name: kmipClientKeyFile
         arg_vartype: String
         requires: 'security.kmip.serverName'
 

--- a/src/mongo/tools/perconadecrypt_options.cpp
+++ b/src/mongo/tools/perconadecrypt_options.cpp
@@ -120,10 +120,6 @@ Status storePerconaDecryptOptions(const moe::Environment& params,
         encryptionGlobalParams.kmipClientCertificateFile = params["kmipClientCertificateFile"].as<std::string>();
     }
 
-    if (params.count("kmipClientKeyFile")) {
-        encryptionGlobalParams.kmipClientKeyFile = params["kmipClientKeyFile"].as<std::string>();
-    }
-
     if (params.count("kmipKeyIdentifier")) {
         encryptionGlobalParams.kmipKeyIdentifier = params["kmipKeyIdentifier"].as<std::string>();
     }

--- a/src/mongo/tools/perconadecrypt_options.idl
+++ b/src/mongo/tools/perconadecrypt_options.idl
@@ -121,7 +121,7 @@ configs:
     description: "hostname or IP address of the KMIP server"
     short_name: kmipServerName
     arg_vartype: String
-    requires: [ kmipClientCertificateFile, kmipClientKeyFile, kmipKeyIdentifier ]
+    requires: [ kmipClientCertificateFile, kmipKeyIdentifier ]
     conflicts: [encryptionKeyFile, vaultServerName]
 
   kmipPort:
@@ -143,14 +143,8 @@ configs:
     requires: kmipServerName
 
   kmipClientCertificateFile:
-    description: Path to the KMIP client certificate
+    description: Path to the PEM file with KMIP client private key and certificate chain
     short_name: kmipClientCertificateFile
-    arg_vartype: String
-    requires: kmipServerName
-
-  kmipClientKeyFile:
-    description: Path to the KMIP client key file
-    short_name: kmipClientKeyFile
     arg_vartype: String
     requires: kmipServerName
 

--- a/src/third_party/libkmip-0ecda33/kmippp/kmippp.cpp
+++ b/src/third_party/libkmip-0ecda33/kmippp/kmippp.cpp
@@ -18,17 +18,14 @@ namespace kmippp {
 context::context(std::string server_address,
                                std::string server_port,
                                std::string client_cert_fn,
-                               std::string client_key_fn,
                                std::string ca_cert_fn) {
     ctx_= SSL_CTX_new(SSLv23_method());
 
-    if(SSL_CTX_use_certificate_file(ctx_, client_cert_fn.c_str(), SSL_FILETYPE_PEM) != 1)
-    {
+    if (SSL_CTX_use_certificate_chain_file(ctx_, client_cert_fn.c_str()) != 1) {
         SSL_CTX_free(ctx_);
         throw std::runtime_error("Loading the client certificate failed");
     }
-    if(SSL_CTX_use_PrivateKey_file(ctx_, client_key_fn.c_str(), SSL_FILETYPE_PEM) != 1)
-    {
+    if (SSL_CTX_use_PrivateKey_file(ctx_, client_cert_fn.c_str(), SSL_FILETYPE_PEM) != 1) {
         SSL_CTX_free(ctx_);
         throw std::runtime_error("Loading the client key failed");
     }

--- a/src/third_party/libkmip-0ecda33/kmippp/kmippp.h
+++ b/src/third_party/libkmip-0ecda33/kmippp/kmippp.h
@@ -21,7 +21,10 @@ namespace kmippp {
       using ids_t = std::vector<std::string>;
       using name_t = std::string;
 
-      context(std::string server_address, std::string server_port, std::string client_cert_fn, std::string client_key_fn, std::string ca_cert_fn);
+      context(std::string server_address,
+              std::string server_port,
+              std::string client_cert_fn,
+              std::string ca_cert_fn);
       ~context();
 
       context(context &&) noexcept = default;


### PR DESCRIPTION
Read both the private key and certificate chain of the
KMIP client from the single PEM file specified by the
'kmipClientCertificateFile' option.