### PR TITLE
PSMDB-1084 fix boost issue preventing build on Ubuntu 22.04

### DIFF
--- a/src/third_party/boost-1.70.0/boost/thread/pthread/thread_data.hpp
+++ b/src/third_party/boost-1.70.0/boost/thread/pthread/thread_data.hpp
@@ -57,7 +57,7 @@ namespace boost
 #else
           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
 #endif
-#if PTHREAD_STACK_MIN > 0
+#ifdef PTHREAD_STACK_MIN
           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
 #endif
           size = ((size+page_size-1)/page_size)*page_size;


### PR DESCRIPTION
the fix is extracted from:
https://github.com/boostorg/thread/issues/364
https://github.com/boostorg/thread/pull/297/files