### PR TITLE
PSMDB-1116: Correctly exit mongod after master key rotation

### DIFF
--- a/src/mongo/db/storage/storage_engine_init.cpp
+++ b/src/mongo/db/storage/storage_engine_init.cpp
@@ -33,6 +33,7 @@
 
 #include "mongo/db/storage/storage_engine_init.h"
 
+#include <cstdlib>
 #include <map>
 #include <memory>
 
@@ -56,6 +57,7 @@
 #include "mongo/logv2/log.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/concurrency/ticketholder.h"
+#include "mongo/util/quick_exit.h"
 #include "mongo/util/str.h"
 
 namespace mongo {
@@ -272,7 +274,15 @@ StorageEngine::LastShutdownState initializeStorageEngine(OperationContext* opCtx
                       storageGlobalParams,
                       encryptionGlobalParams.kmipKeyIds.encryption,
                       initFlags);
-        throw;
+        if (!encryptionGlobalParams.kmipServerName.empty()) {
+            LOGV2(29111,
+                  "Rotated master encryption key",
+                  "oldMasterKeyId"_attr = encryptionGlobalParams.kmipKeyIds.decryption,
+                  "newMasterKeyId"_attr = encryptionGlobalParams.kmipKeyIds.encryption);
+        } else {
+            LOGV2(29111, "Rotated master encryption key");
+        }
+        quickExit(EXIT_SUCCESS);
     }
 
     if (lockFile) {


### PR DESCRIPTION
Use proper severity for logging successful master key rotation and finish mongod process with zero exit code.