### PR TITLE
PSMDB-1129: Refuse to start if KMIP keyIdentifier is misconfigured

### DIFF
--- a/src/mongo/db/storage/storage_engine_init.cpp
+++ b/src/mongo/db/storage/storage_engine_init.cpp
@@ -265,7 +265,11 @@ StorageEngine::LastShutdownState initializeStorageEngine(OperationContext* opCtx
                 29113,
                 "The provided (via the command line option or the configuration file) KMIP "
                 "keyIdentifier is not equal to that the system is already configured with. "
-                "Don't provide keyIdentifier or rotate master key.",
+                "If it was intended to rotate the master key, please add the "
+                "`--kmipRotateMasterKey` command line option or the "
+                "`security.kmip.rotateMasterKey` configuration file parameter. "
+                "Otherwise, please omit the `--kmipMasterKeyId` command line option and "
+                "the `security.kmip.keyIdentifier` configuration parameter.",
                 "providedKmipKeyIdentifier"_attr = providedId,
                 "configuredKmipKeyIdentifier"_attr = configuredId);
         }

--- a/src/mongo/db/storage/storage_engine_init.cpp
+++ b/src/mongo/db/storage/storage_engine_init.cpp
@@ -249,9 +249,30 @@ StorageEngine::LastShutdownState initializeStorageEngine(OperationContext* opCtx
         }
     });
 
-    encryptionGlobalParams.kmipKeyIds.encryption = encryptionGlobalParams.kmipKeyIdentifier;
-    encryptionGlobalParams.kmipKeyIds.decryption =
-        metadata ? metadata->getKmipMasterKeyId() : encryptionGlobalParams.kmipKeyIdentifier;
+    if (!encryptionGlobalParams.kmipServerName.empty()) {
+        const std::string& configuredId = metadata ? metadata->getKmipMasterKeyId() : "";
+        const std::string& providedId = encryptionGlobalParams.kmipKeyIdentifier;
+        if (encryptionGlobalParams.kmipRotateMasterKey && configuredId.empty()) {
+            LOGV2_FATAL_NOTRACE(
+                29112,
+                "The system is not configured with a KMIP-managed key but the command line opiton "
+                "or the configuration file asks to rotate the KMIP master key.");
+        }
+        bool keyIdMisconfig = !encryptionGlobalParams.kmipRotateMasterKey &&
+            !configuredId.empty() && !providedId.empty() && configuredId != providedId;
+        if (keyIdMisconfig) {
+            LOGV2_FATAL_NOTRACE(
+                29113,
+                "The provided (via the command line option or the configuration file) KMIP "
+                "keyIdentifier is not equal to that the system is already configured with. "
+                "Don't provide keyIdentifier or rotate master key.",
+                "providedKmipKeyIdentifier"_attr = providedId,
+                "configuredKmipKeyIdentifier"_attr = configuredId);
+        }
+        encryptionGlobalParams.kmipKeyIds.encryption = providedId;
+        encryptionGlobalParams.kmipKeyIds.decryption =
+            configuredId.empty() ? providedId : configuredId;
+    }
     auto& lockFile = StorageEngineLockFile::get(service);
     try {
         if ((initFlags & StorageEngineInitFlags::kForRestart) == StorageEngineInitFlags{}) {


### PR DESCRIPTION
Unless KMIP master key rotation is in progress, don't start mongod if keyIdentifier specified in a config file or CLI is not equal to that an existing DB was encrypted with.

Note. For an existing encrypted DB, the best practise is not to specify keyIdentifier at all because it is already kept in the storage engine metadata.