### PR TITLE
PSMDB-1177 implement BackupBlock output for incremental backups

### DIFF
--- a/src/mongo/db/pipeline/document_source_backup_cursor.h
+++ b/src/mongo/db/pipeline/document_source_backup_cursor.h
@@ -108,6 +108,8 @@ private:
     const StorageEngine::BackupInformation& _backupInformation;
     // Document iterator
     StorageEngine::BackupInformation::const_iterator _docIt;
+    // Block iterator (for incremental backups)
+    std::vector<StorageEngine::BackupBlock>::const_iterator _blockIt;
 };
 
 }  // namespace mongo


### PR DESCRIPTION
Vector of BackupBlocks was correctly populated in case of incremental backups but its content was not output to backup cursor. 