### PR TITLE
PSMDB-1203 Gracefully exit if a key can't be saved to a KMIP server

### DIFF
--- a/src/mongo/db/encryption/encryption_kmip.cpp
+++ b/src/mongo/db/encryption/encryption_kmip.cpp
@@ -82,7 +82,7 @@ std::string kmipWriteKey(std::string const& keyData) {
     auto keyId = ctx.op_register("", "", kmippp::context::key_t(keyData.begin(), keyData.end()));
 
     if (keyId.empty()) {
-        log() << "Couldn't save encryption key on KMIP server.";
+        throw std::runtime_error("Couldn't save encryption key on KMIP server.");
     }
 
     return keyId;


### PR DESCRIPTION
The thrown exception is caught in the `initAndListen` function and gracefull terminatin is initiated.