### PR TITLE
PSMDB-1204 LDAP fix userToDNMapping/ldapQuery

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.h
+++ b/src/mongo/db/ldap/ldap_manager_impl.h
@@ -58,7 +58,9 @@ private:
     LDAP* borrow_search_connection();
     void return_search_connection(LDAP* ldap);
 
-    Status execQuery(std::string& ldapurl, std::vector<std::string>& results);
+    Status execQuery(const std::string& ldapurl,
+                     bool entitiesonly,
+                     std::vector<std::string>& results);
 };
 
 // bind either simple or sasl using global LDAP parameters


### PR DESCRIPTION
- attributes part of 'ldapQuery' should be ignored during user to DN mapping
- fixed libldap's resource handling in LDAPManagerImpl::execQuery (memory allocated by ldap_first_attribute/ldap_next_attribute was not correctly freed. This affected set of roles assigned to user when security.ldap.authz.queryTemplate contained more than one attribute)