### PR TITLE
PSMDB-1228: Repair the build for the older platforms

### DIFF
--- a/src/mongo/db/storage/storage_engine_metadata_test.cpp
+++ b/src/mongo/db/storage/storage_engine_metadata_test.cpp
@@ -167,7 +167,7 @@ TEST(StorageEngineMetadataTest, NoOptionsIsOk) {
         ASSERT_OK(metadata.read());
         ASSERT_EQUALS("storageEngine1", metadata.getStorageEngine());
         ASSERT_TRUE(metadata.getStorageEngineOptions().isEmpty());
-        ASSERT_EQUALS(nullptr, metadata.keyId());
+        ASSERT_TRUE(nullptr == metadata.keyId());
     }
 }
 
@@ -185,7 +185,7 @@ TEST(StorageEngineMetadataTest, NoEncryptionOptionsIsOk) {
         ASSERT_OK(metadata.read());
         ASSERT_EQUALS("storageEngine1", metadata.getStorageEngine());
         ASSERT_TRUE(metadata.getStorageEngineOptions().isEmpty());
-        ASSERT_EQUALS(nullptr, metadata.keyId());
+        ASSERT_TRUE(nullptr == metadata.keyId());
     }
 }
 
@@ -229,7 +229,7 @@ TEST(StorageEngineMetadataTest, EmptyEncryptionOptionsIsOk) {
         ASSERT_EQUALS("storageEngine1", metadata.getStorageEngine());
         const auto expectedOpts = BSON("encryption" << BSONObj());
         ASSERT_EQUALS(0, metadata.getStorageEngineOptions().woCompare(expectedOpts));
-        ASSERT_EQUALS(nullptr, metadata.keyId());
+        ASSERT_TRUE(nullptr == metadata.keyId());
     }
 }
 
@@ -274,7 +274,7 @@ TEST(StorageEngineMetadataTest, ValidEncryptionOptionsIsOk) {
         ASSERT_EQUALS(0, metadata.getStorageEngineOptions().woCompare(expectedOpts));
         // For more tests on key id itself, please @see the
         // `src/mongo/db/encryption/key_id_test.cpp` file
-        ASSERT_NOT_EQUALS(nullptr, metadata.keyId());
+        ASSERT_TRUE(nullptr != metadata.keyId());
     }
 }
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_encryption_key_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_encryption_key_test.cpp
@@ -29,8 +29,10 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
     it in the license file.
 ======= */
 
+#include <string.h>    // for `::strerror`
+#include <sys/stat.h>  // for `::chmod`
+
 #include <cstdint>
-#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
@@ -379,8 +381,11 @@ protected:
             FAIL("Can't create the encryption key file");
         }
         f.close();
-        namespace fs = std::filesystem;
-        fs::permissions(fullpath, fs::perms::owner_read | fs::perms::owner_write);
+        if (::chmod(fullpath.c_str(), S_IRUSR | S_IWUSR) != 0) {
+            std::string msg = "Can't set permissions on the encryption key file: ";
+            msg.append(::strerror(errno));
+            FAIL(msg);
+        }
         return fullpath;
     }
 


### PR DESCRIPTION
Not all the platforms Percona Server for MongoDB is currently supported on implement the `std::filesystem::permissions` function in their `libstdc++` library.
Additionally, on some older platforms the output operator for `nullptr` is ambiguous in the unit tests.

The build was broken in the commit
0866013ceb779a6a63c8765bf17f3a08c09a4abb