### PR TITLE
PSMDB-1229 Fix reading the master key identifier

### DIFF
--- a/src/mongo/db/storage/storage_engine_init.cpp
+++ b/src/mongo/db/storage/storage_engine_init.cpp
@@ -188,6 +188,13 @@ StorageEngine::LastShutdownState initializeStorageEngine(OperationContext* opCtx
         uassertStatusOK(factory->validateMetadata(*metadata, storageGlobalParams));
     }
 
+    // copy the identifier of the configured key (if any) from the metadata to
+    // the special storage for further use during the `WiredTigerKVEngine`
+    // construction
+    if (auto keyId = metadata ? metadata->keyId() : nullptr; keyId) {
+        encryption::WtKeyIds::instance().configured = keyId->clone();
+    }
+
     auto guard = makeGuard([&] {
         auto& lockFile = StorageEngineLockFile::get(service);
         if (lockFile) {


### PR DESCRIPTION
The bug was introduced while backporting PSMDB-1148 from the `master` branch. Please see the commit
b988c5193627296fb52b4494235b86c5a7e5f88a