### PR TITLE
PSMDB-1229 Fix reading the master key identifier

### DIFF
--- a/src/mongo/db/storage/storage_engine_init.cpp
+++ b/src/mongo/db/storage/storage_engine_init.cpp
@@ -189,6 +189,13 @@ LastStorageEngineShutdownState initializeStorageEngine(ServiceContext* service,
         uassertStatusOK(factory->validateMetadata(*metadata, storageGlobalParams));
     }
 
+    // copy the identifier of the configured key (if any) from the metadata to
+    // the special storage for further use during the `WiredTigerKVEngine`
+    // construction
+    if (auto keyId = metadata ? metadata->keyId() : nullptr; keyId) {
+        encryption::WtKeyIds::instance().configured = keyId->clone();
+    }
+
     auto guard = makeGuard([&] {
         auto& lockFile = StorageEngineLockFile::get(service);
         if (lockFile) {


### PR DESCRIPTION
The bug was introduced while backporting PSMDB-1148 from the `master` branch. Please see the commit
d24c109a1ea6b3292e1137ab3f1f3e7ece7091c8