### PR TITLE
PSMDB-1211: Do a clean-up after failed master key rotation

### DIFF
--- a/src/mongo/db/encryption/key_error.h
+++ b/src/mongo/db/encryption/key_error.h
@@ -31,8 +31,10 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonobj.h"
@@ -61,9 +63,23 @@ private:
     BSONObj _info;
 };
 
+enum class KeyOperationType : std::uint8_t {
+    read,
+    save
+};
+
+inline StringData to_string(KeyOperationType opType) {
+    switch (opType) {
+        case KeyOperationType::read: return "read";
+        case KeyOperationType::save: return "save";
+    }
+    throw std::invalid_argument(std::to_string(std::underlying_type_t<KeyOperationType>(opType)));
+}
+
 class KeyErrorBuilder {
 public:
-    explicit KeyErrorBuilder(const StringData& reason) {
+    KeyErrorBuilder(KeyOperationType opType, const StringData& reason) {
+        _builder.append("failedOperation", to_string(opType));
         _builder.append("reason", reason.empty() ? StringData("") : reason);
     }
 

--- a/src/mongo/db/encryption/master_key_provider.h
+++ b/src/mongo/db/encryption/master_key_provider.h
@@ -82,22 +82,29 @@ public:
     /// Intendend to be called for obtaining the master key for
     /// a _just created_ encryption key database.
     ///
-    /// Initiates a graceful exit from the program if can't unambiguously
-    /// read the key from or save the key to the key management facility.
+    /// If the function can't unambiguously read the key from or save the key
+    /// to the key management facility, it either initiates a graceful exit from
+    /// the program or throws a `KeyError` exception depending on the value
+    /// of the `raiseOnError` argument.
     ///
     /// @param saveKey if true, the generated key is immediately saved
     ///                to the key management facility
+    /// @param raiseOnError if true, throws a `KeyError` exception when
+    ///                     operation on the key fails; otherwise initiates
+    ///                     a graceful exit from the program.
     ///
     /// @returns the read or generated encryption key and its identifier;
     ///          the latter is not `nullptr` if `saveKey` is `true`
-    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true) const;
+    ///
+    /// @throw `KeyError` @see above
+    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true,
+                                                           bool raiseOnError = false) const;
 
     /// @brief Saves the master key to a key manageent facitlity.
     ///
-    /// Initiates a graceful exit from the program if can't unambiguously save
-    /// the master encryption key.
-    ///
     /// @param key an encryption key to be saves
+    ///
+    /// @throws `KeyError` if can't unambiguously save the master encryption key.
     void saveMasterKey(const Key& key) const;
 
 private:

--- a/src/mongo/util/exit_code.h
+++ b/src/mongo/util/exit_code.h
@@ -61,7 +61,10 @@ enum ExitCode : int {
     EXIT_AUDIT_ERROR = 70,
     EXIT_UNCAUGHT = 100,             // top level exception that wasn't caught
     EXIT_TEST = 101,
-    EXIT_AUDIT_ROTATE_ERROR = 102  // The startup rotation of audit logs failed
+    EXIT_AUDIT_ROTATE_ERROR = 102,  // The startup rotation of audit logs failed
+
+    // Percona specific exit codes
+    EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR = 1001
 };
 
 }  // namespace mongo


### PR DESCRIPTION
While doing data-at-rest master encryption key rotation, `mongod` creates the auxiliary directory under `dbPath` and removes it after the rotation finishes. However, in case of the failed rotation, the directory persisted, which blocked further rotation attempts. Now, `mongod` does a clean-up even after failed rotation.