### PR TITLE
PSMDB-1211: Do a clean-up after failed master key rotation

### DIFF
--- a/src/mongo/db/encryption/key_error.h
+++ b/src/mongo/db/encryption/key_error.h
@@ -31,8 +31,10 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonobj.h"
@@ -61,9 +63,23 @@ private:
     BSONObj _info;
 };
 
+enum class KeyOperationType : std::uint8_t {
+    read,
+    save
+};
+
+inline StringData to_string(KeyOperationType opType) {
+    switch (opType) {
+        case KeyOperationType::read: return "read";
+        case KeyOperationType::save: return "save";
+    }
+    throw std::invalid_argument(std::to_string(std::underlying_type_t<KeyOperationType>(opType)));
+}
+
 class KeyErrorBuilder {
 public:
-    explicit KeyErrorBuilder(const StringData& reason) {
+    KeyErrorBuilder(KeyOperationType opType, const StringData& reason) {
+        _builder.append("failedOperation", to_string(opType));
         _builder.append("reason", reason.empty() ? StringData("") : reason);
     }
 

--- a/src/mongo/db/encryption/master_key_provider.h
+++ b/src/mongo/db/encryption/master_key_provider.h
@@ -82,22 +82,29 @@ public:
     /// Intendend to be called for obtaining the master key for
     /// a _just created_ encryption key database.
     ///
-    /// Initiates a graceful exit from the program if can't unambiguously
-    /// read the key from or save the key to the key management facility.
+    /// If the function can't unambiguously read the key from or save the key
+    /// to the key management facility, it either initiates a graceful exit from
+    /// the program or throws a `KeyError` exception depending on the value
+    /// of the `raiseOnError` argument.
     ///
     /// @param saveKey if true, the generated key is immediately saved
     ///                to the key management facility
+    /// @param raiseOnError if true, throws a `KeyError` exception when
+    ///                     operation on the key fails; otherwise initiates
+    ///                     a graceful exit from the program.
     ///
     /// @returns the read or generated encryption key and its identifier;
     ///          the latter is not `nullptr` if `saveKey` is `true`
-    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true) const;
+    ///
+    /// @throw `KeyError` @see above
+    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true,
+                                                           bool raiseOnError = false) const;
 
     /// @brief Saves the master key to a key manageent facitlity.
     ///
-    /// Initiates a graceful exit from the program if can't unambiguously save
-    /// the master encryption key.
-    ///
     /// @param key an encryption key to be saves
+    ///
+    /// @throws `KeyError` if can't unambiguously save the master encryption key.
     void saveMasterKey(const Key& key) const;
 
 private:

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -82,6 +82,7 @@
 #include "mongo/db/concurrency/write_conflict_exception.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/encryption/key.h"
+#include "mongo/db/encryption/key_error.h"
 #include "mongo/db/encryption/key_id.h"
 #include "mongo/db/encryption/master_key_provider.h"
 #include "mongo/db/global_settings.h"
@@ -119,6 +120,7 @@
 #include "mongo/util/concurrency/ticketholder.h"
 #include "mongo/util/debug_util.h"
 #include "mongo/util/exit.h"
+#include "mongo/util/exit_code.h"
 #include "mongo/util/log_and_backoff.h"
 #include "mongo/util/processinfo.h"
 #include "mongo/util/quick_exit.h"
@@ -628,10 +630,25 @@ WiredTigerKVEngine::WiredTigerKVEngine(
                 throw;
             }
 
-            auto [masterKey, masterKeyId] = keyProvider->obtainMasterKey(/* saveKey = */ false);
-            auto rotationKeyDB = encryptionKeyDB->clone(newKeyDBPath.string(), masterKey);
-            if (!masterKeyId) {
-                keyProvider->saveMasterKey(masterKey);
+            std::unique_ptr<EncryptionKeyDB> rotationKeyDB;
+            try {
+                auto [masterKey, masterKeyId] = keyProvider->obtainMasterKey(
+                    /* saveKey = */ false, /* raiseOnError = */ true);
+                rotationKeyDB = encryptionKeyDB->clone(newKeyDBPath.string(), masterKey);
+                if (!masterKeyId) {
+                    keyProvider->saveMasterKey(masterKey);
+                }
+            } catch (const encryption::KeyError& e) {
+                fs::remove_all(newKeyDBPath);
+                LOGV2_FATAL_CONTINUE(29120,
+                                     "Failed to rotate master encrypion key: key operation failed",
+                                     "error"_attr = e);
+                exitCleanly(EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR);
+            } catch (const std::runtime_error& e) {
+                fs::remove_all(newKeyDBPath);
+                LOGV2_FATAL_CONTINUE(
+                    29121, "Failed to rotate master encrypion key", "reason"_attr = e.what());
+                exitCleanly(EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR);
             }
             // close key db instances and rename dirs
             encryptionKeyDB.reset(nullptr);

--- a/src/mongo/util/exit_code.h
+++ b/src/mongo/util/exit_code.h
@@ -60,7 +60,10 @@ enum ExitCode : int {
     EXIT_PROCESS_HEALTH_CHECK = 67,  // Process health check triggered the crash.
     EXIT_AUDIT_ERROR = 70,
     EXIT_UNCAUGHT = 100,             // top level exception that wasn't caught
-    EXIT_TEST = 101
+    EXIT_TEST = 101,
+
+    // Percona specific exit codes
+    EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR = 1001
 };
 
 }  // namespace mongo


### PR DESCRIPTION
While doing data-at-rest master encryption key rotation, `mongod` creates the auxiliary directory under `dbPath` and removes it after the rotation finishes. However, in case of the failed rotation, the directory persisted, which blocked further rotation attempts. Now, `mongod` does a clean-up even after failed rotation.