### PR TITLE
PSMDB-1231 Bring the KMIP integration into line with the standard

### DIFF
--- a/src/mongo/db/encryption/encryption_kmip.cpp
+++ b/src/mongo/db/encryption/encryption_kmip.cpp
@@ -68,21 +68,19 @@ kmippp::context kmipCreateContext() {
 
 }  // namespace
 
-std::string kmipReadKey(const std::string& keyId) {
+std::vector<std::uint8_t> kmipReadKey(const std::string& keyId) {
     auto ctx = kmipCreateContext();
     const auto key = ctx.op_get(keyId);
 
     if (key.empty()) {
         LOGV2_DEBUG(29045, 4, "No key is found on the KMIP server");
-        return "";
     }
-
-    return std::string(key.begin(), key.end());
+    return key;
 }
 
-std::string kmipWriteKey(std::string const& keyData) {
+std::string kmipWriteKey(const std::vector<std::uint8_t>& keyData) {
     auto ctx = kmipCreateContext();
-    return ctx.op_register("", "", kmippp::context::key_t(keyData.begin(), keyData.end()));
+    return ctx.op_register(keyData);
 }
 
 }  // namespace mongo::encryption::detail

--- a/src/mongo/db/encryption/encryption_kmip.h
+++ b/src/mongo/db/encryption/encryption_kmip.h
@@ -31,7 +31,9 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 /// The code in this namespace is not intended to be called from outside
 /// the `mongo::encryption` namespace
@@ -41,21 +43,21 @@ namespace mongo::encryption::detail {
 ///
 /// @param keyId Identifier of the key to read
 ///
-/// @returns Key data if the reading succeeds or an empty string if no key data
+/// @returns Key data if the reading succeeds or an empty vector if no key data
 ///     is associated with the key identifier
 ///
 /// @throws std::runtime_error if the server can't connect to any of the KMIP
 ///     servers listed in the configuration
-std::string kmipReadKey(const std::string& keyId);
+std::vector<std::uint8_t> kmipReadKey(const std::string& keyId);
 
 /// @brief Writes the key to the KMIP server specified in the configuration.
 ///
-/// @param keyData The key data, should be base64-encoded
+/// @param keyData The key data
 ///
 /// @returns Key identifier if the writing succeeds or an empty string otherwise.
 ///
 /// @throws std::runtime_error if the server can't connect to any of the KMIP
 ///     servers listed in the configuration
-std::string kmipWriteKey(std::string const& keyData);
+std::string kmipWriteKey(const std::vector<std::uint8_t>& keyData);
 
 }  // namespace mongo::encryption::detail

--- a/src/mongo/db/encryption/key.cpp
+++ b/src/mongo/db/encryption/key.cpp
@@ -52,14 +52,21 @@ Key::Key() {
     SecureRandom().fill(data(), size());
 }
 
-Key::Key(const std::string& base64EncodedKey) {
-    std::string decodedKey = base64::decode(base64EncodedKey);
-    if (decodedKey.size() != size()) {
+Key::Key(const std::uint8_t* keyData, std::size_t keyDataSize) {
+    StringData s(reinterpret_cast<const char*>(keyData), keyDataSize);
+    if (keyDataSize == base64::encodedLength(kLength) && base64::validate(s)) {
+        std::string decodedKey = base64::decode(s);
+        std::memcpy(data(), decodedKey.c_str(), kLength);
+        return;
+    } else if (keyDataSize == kLength) {
+        std::memcpy(data(), keyData, kLength);
+        return;
+    } else {
         std::ostringstream msg;
-        msg << "encryption key length should be " << size() << " bytes";
+        msg << "invalid data for an encryption key: it must be a byte string of length " << kLength
+            << " in either raw or base64-encoded form";
         throw std::runtime_error(msg.str());
     }
-    std::memcpy(data(), decodedKey.c_str(), size());
 }
 
 std::string Key::base64() const {

--- a/src/mongo/db/encryption/key_operations.cpp
+++ b/src/mongo/db/encryption/key_operations.cpp
@@ -41,8 +41,8 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 
 namespace mongo::encryption {
 std::optional<KeyKeyIdPair> ReadKeyFile::operator()() const try {
-    return KeyKeyIdPair{Key(detail::SecretString::readFromFile(_path.toString(), "encryption key")),
-                        _path.clone()};
+    auto s = detail::SecretString::readFromFile(_path.toString(), "encryption key");
+    return KeyKeyIdPair{Key(static_cast<const std::string&>(s)), _path.clone()};
 } catch (const std::runtime_error& e) {
     std::ostringstream msg;
     msg << "reading the master key from the encryption key file failed: " << e.what();
@@ -74,8 +74,8 @@ std::unique_ptr<KeyId> SaveVaultSecret::operator()(const Key& k) const try {
 }
 
 std::optional<KeyKeyIdPair> ReadKmipKey::operator()() const try {
-    if (auto encodedKey = detail::kmipReadKey(_id.toString()); !encodedKey.empty()) {
-        return KeyKeyIdPair{Key(encodedKey), _id.clone()};
+    if (auto rawKeyData = detail::kmipReadKey(_id.toString()); !rawKeyData.empty()) {
+        return KeyKeyIdPair{Key(rawKeyData), _id.clone()};
     }
     return std::nullopt;
 } catch (const std::runtime_error& e) {
@@ -85,7 +85,9 @@ std::optional<KeyKeyIdPair> ReadKmipKey::operator()() const try {
 }
 
 std::unique_ptr<KeyId> SaveKmipKey::operator()(const Key& k) const try {
-    return std::make_unique<KmipKeyId>(detail::kmipWriteKey(k.base64()));
+    std::vector<std::uint8_t> rawKeyData(k.size(), 0);
+    std::copy(k.data(), k.data() + k.size(), rawKeyData.begin());
+    return std::make_unique<KmipKeyId>(detail::kmipWriteKey(rawKeyData));
 } catch (const std::runtime_error& e) {
     std::ostringstream msg;
     msg << "saving the master key to the KMIP server failed: " << e.what();

--- a/src/third_party/libkmip-0ecda33/kmippp/kmippp.cpp
+++ b/src/third_party/libkmip-0ecda33/kmippp/kmippp.cpp
@@ -8,6 +8,7 @@
 #include <time.h>
 
 #include <array>
+#include <cstddef>  // for std::size_t
 #include <sstream>
 #include <utility>
 
@@ -439,7 +440,7 @@ context::id_t context::op_create(const name_t& name, const name_t& group) {
     return ret;
 }
 
-context::id_t context::op_register(const name_t& name, const name_t& group, const key_t& key) {
+context::id_t context::op_register(const key_t& key) {
     KMIP ctx = {0};
     kmip_init(&ctx, nullptr, 0, KMIP_1_0);
     scope_guard guard([&ctx]() {
@@ -447,8 +448,8 @@ context::id_t context::op_register(const name_t& name, const name_t& group, cons
         kmip_destroy(&ctx);
     });
 
-    Attribute a[5];
-    for(int i = 0; i < 5; i++) {
+    Attribute a[3];
+    for (std::size_t i = 0; i < ARRAY_LENGTH(a); i++) {
         kmip_init_attribute(&a[i]);
     }
 
@@ -463,21 +464,6 @@ context::id_t context::op_register(const name_t& name, const name_t& group, cons
     int32 mask = KMIP_CRYPTOMASK_ENCRYPT | KMIP_CRYPTOMASK_DECRYPT;
     a[2].type = KMIP_ATTR_CRYPTOGRAPHIC_USAGE_MASK;
     a[2].value = &mask;
-
-    Name ts;
-    TextString ts2 = {0,0};
-    ts2.value = const_cast<char*>(name.c_str());
-    ts2.size = kmip_strnlen_s(ts2.value, 250);
-    ts.value = &ts2;
-    ts.type = KMIP_NAME_UNINTERPRETED_TEXT_STRING;
-    a[3].type = KMIP_ATTR_NAME;
-    a[3].value = &ts;
-
-    TextString gs2 = {0,0};
-    gs2.value = const_cast<char*>(group.c_str());
-    gs2.size = kmip_strnlen_s(gs2.value, 250);
-    a[4].type = KMIP_ATTR_OBJECT_GROUP;
-    a[4].value = &gs2;
 
     TemplateAttribute ta = {0};
     ta.attributes = a;

--- a/src/third_party/libkmip-0ecda33/kmippp/kmippp.h
+++ b/src/third_party/libkmip-0ecda33/kmippp/kmippp.h
@@ -56,7 +56,7 @@ namespace kmippp {
       id_t op_create(const name_t& name, const name_t& group);
 
       // KMIP::register operation, stores an existing symmetric key on the server
-      id_t op_register(const name_t& name, const name_t& group, const key_t& k);
+      id_t op_register(const key_t& k);
 
       // KMIP::get operation, retrieve a symmetric key by id
       key_t op_get(const id_t& id);

--- a/src/third_party/libkmip-0ecda33/libkmip/src/kmip_bio.c
+++ b/src/third_party/libkmip-0ecda33/libkmip/src/kmip_bio.c
@@ -1314,7 +1314,6 @@ int kmip_bio_register_symmetric_key_with_context(KMIP *ctx, BIO *bio,
     crp.object.key_block = &kb;
     kmip_init_key_block(crp.object.key_block);
     crp.object.key_block->key_format_type = KMIP_KEYFORMAT_RAW;
-    crp.object.key_block->key_compression_type = KMIP_KEYCOMP_EC_PUB_UNCOMPRESSED;
 
     ByteString bs;
     bs.value = (unsigned char*)key;


### PR DESCRIPTION
1. Register a symmetric key in the unencoded form.
2. Don't associate the `name` and the `group` attributes with a symmetric key.
3. Don't use the `EC Public Key Uncompressed` compression type value with a symmetric key.
4. Implement backward compatibility with base64-encoded keys.