### PR TITLE
PSMDB-1239 Allow the `ScopeGuard` objects to do clean-up

### DIFF
--- a/src/mongo/db/encryption/error_builder.h
+++ b/src/mongo/db/encryption/error_builder.h
@@ -1,0 +1,110 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2023-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+#include "mongo/base/string_data.h"
+#include "mongo/bson/bsonobjbuilder.h"
+#include "mongo/db/encryption/error.h"
+#include "mongo/util/str.h"
+
+namespace mongo::encryption {
+class ErrorBuilder {
+public:
+    ErrorBuilder(const StringData& what, const StringData& reason = StringData()) {
+        _builder.append("what", what);
+        if (!reason.empty()) {
+            _builder.append("reason", reason);
+        }
+    }
+
+    ErrorBuilder(const StringData& what, const Error& reason) {
+        _builder.append("what", what);
+        _builder.append("reason", reason.toBSON());
+    }
+
+    ErrorBuilder& append(const StringData& name, const StringData& value) {
+        _builder.append(name, value);
+        return *this;
+    }
+
+    template <typename T,
+              typename = std::void_t<
+                  decltype(std::declval<T>().serialize(&std::declval<BSONObjBuilder&>()))>>
+    ErrorBuilder& append(const StringData& name, const T& value) {
+        BSONObjBuilder sb = _builder.subobjStart(name);
+        value.serialize(&sb);
+        sb.done();
+        return *this;
+    }
+
+    template <typename Iterator,
+              typename = std::void_t<decltype(std::declval<BSONArrayBuilder>().append(
+                  std::declval<Iterator>(), std::declval<Iterator>()))>>
+    ErrorBuilder& append(const StringData& name, Iterator begin, Iterator end) {
+        BSONArrayBuilder sb = _builder.subarrayStart(name);
+        sb.append(begin, end);
+        sb.done();
+        return *this;
+    }
+
+    Error error() {
+        return Error(_builder.obj());
+    }
+
+private:
+    BSONObjBuilder _builder;
+};
+
+enum class KeyOperationType : std::uint8_t { read, save };
+
+class KeyErrorBuilder : public ErrorBuilder {
+public:
+    KeyErrorBuilder(KeyOperationType opType, const StringData& reason)
+        : ErrorBuilder(str::stream() << "key " << to_string(opType) << " failed", reason) {}
+
+private:
+    static StringData to_string(KeyOperationType opType) {
+        switch (opType) {
+            case KeyOperationType::read:
+                return "reading";
+            case KeyOperationType::save:
+                return "saving";
+        }
+        throw std::invalid_argument(
+            std::to_string(std::underlying_type_t<KeyOperationType>(opType)));
+    }
+};
+}  // namespace mongo::encryption

--- a/src/mongo/db/encryption/key_operations.cpp
+++ b/src/mongo/db/encryption/key_operations.cpp
@@ -34,8 +34,8 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/encryption/encryption_kmip.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/encryption/encryption_vault.h"
+#include "mongo/db/encryption/error_builder.h"
 #include "mongo/db/encryption/key.h"
-#include "mongo/db/encryption/key_error.h"
 #include "mongo/db/encryption/secret_string.h"
 #include "mongo/util/assert_util_core.h"
 

--- a/src/mongo/db/encryption/master_key_provider.cpp
+++ b/src/mongo/db/encryption/master_key_provider.cpp
@@ -33,8 +33,8 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/encryption/master_key_provider.h"
 
 #include "mongo/db/encryption/encryption_options.h"
+#include "mongo/db/encryption/error_builder.h"
 #include "mongo/db/encryption/key.h"
-#include "mongo/db/encryption/key_error.h"
 #include "mongo/db/encryption/key_id.h"
 #include "mongo/db/encryption/key_operations.h"
 #include "mongo/logv2/log.h"
@@ -98,18 +98,11 @@ std::unique_ptr<KeyId> MasterKeyProvider::_saveMasterKey(const SaveKey& save,
     return keyId;
 }
 
-Key MasterKeyProvider::readMasterKey() const try {
+Key MasterKeyProvider::readMasterKey() const {
     return _readMasterKey(*_factory->createRead(_wtKeyIds.configured.get())).key;
-} catch (const KeyError& e) {
-    LOGV2_FATAL_OPTIONS(29117,
-                        logv2::LogOptions(_logComponent, logv2::FatalMode::kAssertNoTrace),
-                        "Key operation failed",
-                        "error"_attr = e);
-    throw;  // suppress the `control reaches end of non-void function` warning
 }
 
-std::pair<Key, std::unique_ptr<KeyId>>
-MasterKeyProvider::obtainMasterKey(bool saveKey, bool raiseOnError) const try {
+std::pair<Key, std::unique_ptr<KeyId>> MasterKeyProvider::obtainMasterKey(bool saveKey) const {
     if (auto read = _factory->createProvidedRead(); read) {
         auto keyKeyId = _readMasterKey(*read, false);
         if (keyKeyId.keyId->needsSerializationToStorageEngineEncryptionOptions()) {
@@ -124,15 +117,6 @@ MasterKeyProvider::obtainMasterKey(bool saveKey, bool raiseOnError) const try {
         keyId = _saveMasterKey(*_factory->createSave(_wtKeyIds.configured.get()), key);
     }
     return {key, std::move(keyId)};
-} catch (const KeyError& e) {
-    if (raiseOnError) {
-        throw;
-    }
-    LOGV2_FATAL_OPTIONS(29118,
-                        logv2::LogOptions(_logComponent, logv2::FatalMode::kAssertNoTrace),
-                        "Key operation failed",
-                        "error"_attr = e);
-    throw;  // suppress the `control reaches end of non-void function` warning
 }
 
 void MasterKeyProvider::saveMasterKey(const Key& key) const {

--- a/src/mongo/db/encryption/master_key_provider.h
+++ b/src/mongo/db/encryption/master_key_provider.h
@@ -70,10 +70,10 @@ public:
     /// Intended to be called for retrieving the master key for an _existing_
     /// encyption key database.
     ///
-    /// Initiates a graceful exit from the program if can't unambiguously read
-    /// the master encryption key.
+    /// @returns the master encryption key
     ///
-    /// @return the master encryption key
+    /// @throws `encryption::Error` if can't unambiguously read the key from
+    /// the key management facility
     Key readMasterKey() const;
 
     /// @brief Reads an existing master key from a key management factility or
@@ -81,11 +81,6 @@ public:
     ///
     /// Intendend to be called for obtaining the master key for
     /// a _just created_ encryption key database.
-    ///
-    /// If the function can't unambiguously read the key from or save the key
-    /// to the key management facility, it either initiates a graceful exit from
-    /// the program or throws a `KeyError` exception depending on the value
-    /// of the `raiseOnError` argument.
     ///
     /// @param saveKey if true, the generated key is immediately saved
     ///                to the key management facility
@@ -96,15 +91,16 @@ public:
     /// @returns the read or generated encryption key and its identifier;
     ///          the latter is not `nullptr` if `saveKey` is `true`
     ///
-    /// @throw `KeyError` @see above
-    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true,
-                                                           bool raiseOnError = false) const;
+    /// @throws `encryption::Error` if can't unambiguously read the key from or
+    /// save the key to the key management facility
+    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true) const;
 
     /// @brief Saves the master key to a key manageent facitlity.
     ///
     /// @param key an encryption key to be saves
     ///
-    /// @throws `KeyError` if can't unambiguously save the master encryption key.
+    /// @throws `encryption::Error` if can't unambiguously save the key to
+    /// the key management facility
     void saveMasterKey(const Key& key) const;
 
 private:

--- a/src/mongo/db/mongod_main.cpp
+++ b/src/mongo/db/mongod_main.cpp
@@ -80,6 +80,7 @@
 #include "mongo/db/dbdirectclient.h"
 #include "mongo/db/dbhelpers.h"
 #include "mongo/db/dbmessage.h"
+#include "mongo/db/encryption/error.h"
 #include "mongo/db/exec/working_set_common.h"
 #include "mongo/db/fcv_op_observer.h"
 #include "mongo/db/fle_crud.h"
@@ -171,6 +172,7 @@
 #include "mongo/db/storage/encryption_hooks.h"
 #include "mongo/db/storage/flow_control.h"
 #include "mongo/db/storage/flow_control_parameters_gen.h"
+#include "mongo/db/storage/master_key_rotation_completed.h"
 #include "mongo/db/storage/storage_engine.h"
 #include "mongo/db/storage/storage_engine_init.h"
 #include "mongo/db/storage/storage_engine_lock_file.h"
@@ -435,7 +437,21 @@ ExitCode _initAndListen(ServiceContext* serviceContext, int listenPort) {
     // initialized, a noop recovery unit is used until the initialization is complete.
     auto startupOpCtx = serviceContext->makeOperationContext(&cc());
 
-    auto lastShutdownState = initializeStorageEngine(startupOpCtx.get(), StorageEngineInitFlags{});
+    auto lastShutdownState = [&startupOpCtx]() {
+        try {
+            return initializeStorageEngine(startupOpCtx.get(), StorageEngineInitFlags{});
+        } catch (const MasterKeyRotationCompleted&) {
+            exitCleanly(EXIT_CLEAN);
+        } catch (const encryption::Error& e) {
+            LOGV2_FATAL_OPTIONS(
+                29120,
+                logv2::LogOptions(logv2::LogComponent::kStorage, logv2::FatalMode::kContinue),
+                "Data-at-Rest Encryption Error",
+                "error"_attr = e);
+            exitCleanly(EXIT_PERCONA_DATA_AT_REST_ENCRYPTION_ERROR);
+        }
+        throw;  // suppress the `control reaches end of non-void function` warning
+    }();
     StorageControl::startStorageControls(serviceContext);
 
 #ifdef MONGO_CONFIG_WIREDTIGER_ENABLED

--- a/src/mongo/db/storage/master_key_rotation_completed.h
+++ b/src/mongo/db/storage/master_key_rotation_completed.h
@@ -40,7 +40,8 @@ namespace mongo {
 /// @todo Try to refactor the code so that thre is no need in throwing an exception
 /// in case of successfull execution.
 struct MasterKeyRotationCompleted : std::runtime_error {
-    explicit MasterKeyRotationCompleted(const char* msg) : std::runtime_error(msg) {}
+    explicit MasterKeyRotationCompleted()
+        : std::runtime_error("master key rotation finished successfully") {}
 };
 
 }  // namespace mongo

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
@@ -270,7 +270,7 @@ void EncryptionKeyDB::init() {
     LOGV2(29039, "Encryption keys DB is initialized successfully");
 }
 
-void EncryptionKeyDB::import_data_from(EncryptionKeyDB* proto) {
+void EncryptionKeyDB::import_data_from(const EncryptionKeyDB* proto) {
     // not doing any synchronization here because key rotation process is single threaded
     try {
         // copy parameters table
@@ -313,7 +313,7 @@ void EncryptionKeyDB::import_data_from(EncryptionKeyDB* proto) {
 }
 
 std::unique_ptr<EncryptionKeyDB> EncryptionKeyDB::clone(const std::string& path,
-                                                        const encryption::Key& masterKey) {
+                                                        const encryption::Key& masterKey) const {
     std::unique_ptr<EncryptionKeyDB> duplicate(new EncryptionKeyDB(path, masterKey, true));
     duplicate->init();
     duplicate->import_data_from(this);

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -79,7 +79,7 @@ public:
     /// @throws std::runtime_error if can't craete a key database new one at the specified path or
     /// can't copy the data to the just created database.
     std::unique_ptr<EncryptionKeyDB> clone(const std::string& path,
-                                           const encryption::Key& masterKey);
+                                           const encryption::Key& masterKey) const;
 
     // returns encryption key from keys DB
     // create key if it does not exists
@@ -120,6 +120,10 @@ public:
         return _masterkey;
     }
 
+    const std::string& path() const noexcept {
+        return _path;
+    }
+
 private:
     typedef boost::multiprecision::uint128_t _gcm_iv_type;
 
@@ -133,7 +137,7 @@ private:
     int _openWiredTiger(const std::string& path, const std::string& wtOpenConfig);
 
     // during rotation copies data from provided instance
-    void import_data_from(EncryptionKeyDB* proto);
+    void import_data_from(const EncryptionKeyDB* proto);
 
     StatusWith<std::deque<BackupBlock>> _disableIncrementalBackup();
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -80,8 +80,9 @@
 #include "mongo/db/concurrency/exception_util.h"
 #include "mongo/db/concurrency/locker.h"
 #include "mongo/db/encryption/encryption_options.h"
+#include "mongo/db/encryption/error.h"
+#include "mongo/db/encryption/error_builder.h"
 #include "mongo/db/encryption/key.h"
-#include "mongo/db/encryption/key_error.h"
 #include "mongo/db/encryption/key_id.h"
 #include "mongo/db/encryption/master_key_provider.h"
 #include "mongo/db/global_settings.h"
@@ -323,9 +324,9 @@ std::string toString(const StorageEngine::OldestActiveTransactionTimestampResult
 }
 
 namespace {
-constexpr auto keydbDir = "key.db";
-constexpr auto rotationDir = "key.db.rotation";
-constexpr auto keydbBackupDir = "key.db.rotated";
+constexpr auto kKeyDbDirBasename = "key.db";
+constexpr auto kRotationKeyDbDirBasename = "key.db.rotation";
+constexpr auto kBackupKeyDbDirBasename = "key.db.rotated";
 }  // namespace
 
 // Copy files and fill vectors for remove copied files and empty dirs
@@ -386,7 +387,7 @@ StatusWith<std::deque<BackupBlock>> getBackupBlocksFromBackupCursor(
     const char* filename;
     const auto directoryPath = boost::filesystem::path(dbPath);
     const auto wiredTigerLogFilePrefix = "WiredTigerLog";
-    const auto isKeyDB = directoryPath.filename() == keydbDir;
+    const auto isKeyDB = directoryPath.filename() == kKeyDbDirBasename;
     while ((wtRet = cursor->next(cursor)) == 0) {
         invariantWTOK(cursor->get_key(cursor, &filename), session);
 
@@ -485,11 +486,86 @@ StatusWith<std::deque<BackupBlock>> getBackupBlocksFromBackupCursor(
     return backupBlocks;
 }
 
-void validateRotationIsPossible(const std::string& keyDbPath,
-                                bool keyDbPathIsJustCreated,
+
+/// Prepares directory for the encryption key database.
+///
+/// If the directory at `keyDbPath` exists, the function does nothing.
+/// Otherwise, tries to reuse the data from the `betaKeyDbPath` if the latter
+/// exists. If not, creates the directory at `keyDbpath`.
+///
+/// @param keyDbDir      the directory for encryption key database
+/// @param betaKeyDbDir  the directory to import existing encryption key
+///                      database files from
+///
+/// @returns `true` if fresh new directory has been created and `false` if
+///           existing key database files are imported
+/// @throws `encryption::Error` in case of any error
+bool prepareKeyDbDir(const boost::filesystem::path& keyDbDir,
+                     const boost::filesystem::path& betaKeyDbDir,
+                     bool directoryPerDb) {
+    namespace fs = boost::filesystem;
+    if (fs::exists(keyDbDir)) {
+        return false;
+    }
+    if (!fs::exists(betaKeyDbDir)) {
+        try {
+            fs::create_directory(keyDbDir);
+            return true;
+        } catch (std::exception& e) {
+            throw encryption::ErrorBuilder("Can't create the encryption key database directory",
+                                           e.what())
+                .append("encryptionKeyDatabaseDirectory", keyDbDir.string())
+                .error();
+        }
+    }
+
+    if (!directoryPerDb) {
+        // --directoryperdb is not specified - just rename
+        try {
+            fs::rename(betaKeyDbDir, keyDbDir);
+            return false;
+        } catch (std::exception& e) {
+            throw encryption::ErrorBuilder("Can't rename the encryption key database directory",
+                                           e.what())
+                .append("oldName", betaKeyDbDir.string())
+                .append("newName", keyDbDir.string())
+                .error();
+        }
+    }
+    // --directoryperdb specified - there are chances betaKeyDbPath contains
+    // user data from 'keydb' database
+    // move everything except
+    //   collection-*.wt
+    //   index-*.wt
+    //   collection/*.wt
+    //   index/*.wt
+    try {
+        std::vector<fs::path> emptyDirs;
+        std::vector<fs::path> copiedFiles;
+        copy_keydb_files(betaKeyDbDir, keyDbDir, emptyDirs, copiedFiles);
+        for (auto&& file : copiedFiles) {
+            fs::remove(file);
+        }
+        for (auto&& dir : emptyDirs) {
+            fs::remove(dir);
+        }
+        return false;
+    } catch (std::exception& e) {
+        throw encryption::ErrorBuilder(
+            "Can't move encryption key database files from the old location to the new one",
+            e.what())
+            .append("oldLocation", betaKeyDbDir.string())
+            .append("newLocation", keyDbDir.string())
+            .error();
+    }
+}
+
+void validateRotationIsPossible(const std::string& keyDbDir,
+                                bool keyDbDirIsFresh,
+                                const std::string& dbPath,
                                 bool vaultRotateMasterKey,
                                 bool kmipRotateMasterKey) {
-    const char* kDbPathMsg =
+    const char* kDbDirMsg =
         "For opening an existing encrypted database, check correctness of the `--dbPath` command "
         "line option or the `storage.dbPath` configuration parameter";
     const char* kRemoveVaultRotatationMsg =
@@ -499,18 +575,143 @@ void validateRotationIsPossible(const std::string& keyDbPath,
         "For creating a new empty encrypted database, remove the `--kmipRotateMasterKey` command "
         "line option and the `security.kmip.rotateMasterKey` configuration parameter.";
 
-    if (keyDbPathIsJustCreated && (vaultRotateMasterKey || kmipRotateMasterKey)) {
+    if (keyDbDirIsFresh && (vaultRotateMasterKey || kmipRotateMasterKey)) {
         std::array<const char*, 2u> actions = {
-            {kDbPathMsg,
+            {kDbDirMsg,
              (vaultRotateMasterKey ? kRemoveVaultRotatationMsg : kRemoveKmipRotationMsg)}};
-        LOGV2_FATAL_NOTRACE(
-            29114,
-            "Master key rotation is in effect but there is no existing encryption key database.",
-            "encryptionKeyDatabasePath"_attr = keyDbPath,
-            "possibleRemediationActions"_attr = actions);
+
+        throw encryption::ErrorBuilder(
+            "Master key rotation is in effect but there is no existing encryption key database.")
+            .append("dbPath", dbPath)
+            .append("encryptionKeyDatabaseDirectory", keyDbDir)
+            .append("possibleRemediationActions", actions.begin(), actions.end())
+            .error();
     }
 }
 
+template <typename KeyDbDirHook>
+std::unique_ptr<EncryptionKeyDB> createKeyDb(const boost::filesystem::path& dbPath,
+                                             KeyDbDirHook keyDbDirHook,
+                                             const encryption::MasterKeyProvider& keyProvider,
+                                             bool directoryPerDb) {
+    namespace fs = boost::filesystem;
+    fs::path keyDbDir = dbPath / kKeyDbDirBasename;
+    bool keyDbDirIsFresh = prepareKeyDbDir(keyDbDir, dbPath / "keydb", directoryPerDb);
+
+    // It is required to remove the data in the `keyDbDir` directory if that
+    // data has been created by a failed call to the `EncryptionKeyDB::create`
+    // function (see below) and keep the data if it existed before the call.
+    // Since we need to detect existing data in advance, we can't simply call
+    // `boost::filesystem::is_empty` in the scope guard's functor.
+    ScopeGuard keyDbDirGuard([&keyDbDir, keyDbDirIsFresh] {
+        if (keyDbDirIsFresh) {
+            fs::remove_all(keyDbDir);
+        }
+    });
+
+    keyDbDirHook(keyDbDir.string(), keyDbDirIsFresh);
+
+    try {
+        auto keyDb = EncryptionKeyDB::create(keyDbDir.string(),
+                                             keyDbDirIsFresh ? keyProvider.obtainMasterKey().first
+                                                             : keyProvider.readMasterKey());
+        keyDbDirGuard.dismiss();
+        return keyDb;
+    } catch (const encryption::Error& e) {
+        throw encryption::ErrorBuilder("Can't create encryption key database", e)
+            .append("encryptionKeyDatabaseDirectory", keyDbDir.string())
+            .error();
+    } catch (const std::exception& e) {
+        throw encryption::ErrorBuilder("Can't create encryption key database", e.what())
+            .append("encryptionKeyDatabaseDirectory", keyDbDir.string())
+            .error();
+    }
+}
+
+void keyDbRotateMasterKey(std::unique_ptr<const EncryptionKeyDB> keyDb,
+                          const boost::filesystem::path& dbPath,
+                          const encryption::MasterKeyProvider& keyProvider) try {
+    namespace fs = boost::filesystem;
+    fs::path rotationKeyDbDir = dbPath / kRotationKeyDbDirBasename;
+    if (fs::exists(rotationKeyDbDir)) {
+        throw encryption::ErrorBuilder("Rotation key database directory already exists")
+            .append("rotationKeyDatabaseDirectory", rotationKeyDbDir.string())
+            .error();
+    }
+    try {
+        fs::create_directory(rotationKeyDbDir);
+    } catch (std::exception& e) {
+        throw encryption::ErrorBuilder("Can't create rotation key database directory")
+            .append("rotationKeyDatabaseDirectory", rotationKeyDbDir.string())
+            .error();
+    }
+    ScopeGuard rotationKeyDbDirGuard([&] { fs::remove_all(rotationKeyDbDir); });
+
+    auto [masterKey, masterKeyId] = keyProvider.obtainMasterKey(/* saveKey = */ false);
+    std::unique_ptr<EncryptionKeyDB> rotationKeyDb =
+        keyDb->clone(rotationKeyDbDir.string(), masterKey);
+    if (!masterKeyId) {
+        keyProvider.saveMasterKey(masterKey);
+    }
+    rotationKeyDbDirGuard.dismiss();
+
+    // close key db instances and rename dirs
+    fs::path keyDbDir(keyDb->path());
+    fs::path backupKeyDbDir = dbPath / kBackupKeyDbDirBasename;
+    rotationKeyDb.reset(nullptr);
+    keyDb.reset(nullptr);
+    fs::remove_all(backupKeyDbDir);
+    fs::rename(keyDbDir, backupKeyDbDir);
+    fs::rename(rotationKeyDbDir, keyDbDir);
+} catch (const encryption::Error& e) {
+    throw encryption::ErrorBuilder("Can't rotate master encryption key", e).error();
+} catch (const std::exception& e) {
+    throw encryption::ErrorBuilder("Can't rotate master encryption key", e.what()).error();
+}
+
+void setUpWiredTigerEncryption(const std::string& cipherMode, EncryptionKeyDB* keyDb) {
+    // add Percona encryption extension
+    std::stringstream ss;
+    ss << "local=(entry=percona_encryption_extension_init,early_load=true,config=(cipher="
+       << cipherMode << "))";
+    WiredTigerExtensions::get(getGlobalServiceContext())->addExtension(ss.str());
+
+    // setup encryption hooks
+    // WiredTigerEncryptionHooks instance should be created after EncryptionKeyDB (depends on it)
+    std::unique_ptr<WiredTigerEncryptionHooks> hooks;
+    if (cipherMode == "AES256-CBC") {
+        hooks = std::make_unique<WiredTigerEncryptionHooksCBC>(keyDb);
+    } else {  // AES256-GCM
+        hooks = std::make_unique<WiredTigerEncryptionHooksGCM>(keyDb);
+    }
+    EncryptionHooks::set(getGlobalServiceContext(), std::move(hooks));
+}
+
+/// Creates encryption key database and sets up wiredtiger add-ons
+std::unique_ptr<EncryptionKeyDB> setUpDataAtRestEncryption(
+    const EncryptionGlobalParams& params,
+    const boost::filesystem::path& dbPath,
+    const encryption::MasterKeyProviderFactory& keyProviderFactory,
+    bool directoryPerDb) {
+    if (!params.enableEncryption) {
+        return nullptr;
+    }
+
+    auto keyProvider = keyProviderFactory(params, logv2::LogComponent::kStorage);
+    invariant(keyProvider);
+
+    auto hook = [&dbPath, vault = params.vaultRotateMasterKey, kmip = params.kmipRotateMasterKey](
+                    const std::string& keyDbDir, bool keyDbDirIsFresh) {
+        validateRotationIsPossible(keyDbDir, keyDbDirIsFresh, dbPath.string(), vault, kmip);
+    };
+    auto keyDb = createKeyDb(dbPath, hook, *keyProvider, directoryPerDb);
+    if (params.shouldRotateMasterKey()) {
+        keyDbRotateMasterKey(std::move(keyDb), dbPath, *keyProvider);
+        throw MasterKeyRotationCompleted();
+    }
+    setUpWiredTigerEncryption(params.encryptionCipherMode, keyDb.get());
+    return keyDb;
+}
 }  // namespace
 
 StringData WiredTigerKVEngine::kTableUriPrefix = "table:"_sd;
@@ -525,7 +726,11 @@ WiredTigerKVEngine::WiredTigerKVEngine(
     bool ephemeral,
     bool repair,
     const encryption::MasterKeyProviderFactory& keyProviderFactory)
-    : _clockSource(cs),
+    : _encryptionKeyDB(setUpDataAtRestEncryption(encryptionGlobalParams,
+                                                 boost::filesystem::path(path),
+                                                 keyProviderFactory,
+                                                 storageGlobalParams.directoryperdb)),
+      _clockSource(cs),
       _oplogManager(std::make_unique<WiredTigerOplogManager>()),
       _canonicalName(canonicalName),
       _path(path),
@@ -552,141 +757,6 @@ WiredTigerKVEngine::WiredTigerKVEngine(
     }
 
     _previousCheckedDropsQueued.store(_clockSource->now().toMillisSinceEpoch());
-
-    if (encryptionGlobalParams.enableEncryption) {
-        namespace fs = boost::filesystem;
-        bool just_created{false};
-        fs::path keyDBPath = path;
-        keyDBPath /= keydbDir;
-        ScopeGuard keyDBPathGuard([&] {
-            if (just_created)
-                fs::remove_all(keyDBPath);
-        });
-        if (!fs::exists(keyDBPath)) {
-            fs::path betaKeyDBPath = path;
-            betaKeyDBPath /= "keydb";
-            if (!fs::exists(betaKeyDBPath)) {
-                try {
-                    fs::create_directory(keyDBPath);
-                    just_created = true;
-                } catch (std::exception& e) {
-                    LOGV2(29007, "error creating KeyDB dir {path} {what}",
-                          "path"_attr = keyDBPath.string(),
-                          "what"_attr = e.what());
-                    throw;
-                }
-            } else if (!storageGlobalParams.directoryperdb) {
-                // --directoryperdb is not specified - just rename
-                try {
-                    fs::rename(betaKeyDBPath, keyDBPath);
-                } catch (std::exception& e) {
-                    LOGV2(29008, "error renaming KeyDB directory from {path1} to {path2} {what}",
-                          "path1"_attr = betaKeyDBPath.string(),
-                          "path2"_attr = keyDBPath.string(),
-                          "what"_attr = e.what());
-                    throw;
-                }
-            } else {
-                // --directoryperdb specified - there are chances betaKeyDBPath contains
-                // user data from 'keydb' database
-                // move everything except
-                //   collection-*.wt
-                //   index-*.wt
-                //   collection/*.wt
-                //   index/*.wt
-                try {
-                    std::vector<fs::path> emptyDirs;
-                    std::vector<fs::path> copiedFiles;
-                    copy_keydb_files(betaKeyDBPath, keyDBPath, emptyDirs, copiedFiles);
-                    for (auto&& file : copiedFiles)
-                        fs::remove(file);
-                    for (auto&& dir : emptyDirs)
-                        fs::remove(dir);
-                } catch (std::exception& e) {
-                    LOGV2(29009, "error moving KeyDB files from {path1} to {path2} {what}",
-                          "path1"_attr = betaKeyDBPath.string(),
-                          "path2"_attr = keyDBPath.string(),
-                          "what"_attr = e.what());
-                    throw;
-                }
-            }
-        }
-
-        validateRotationIsPossible(keyDBPath.string(),
-                                   just_created,
-                                   encryptionGlobalParams.vaultRotateMasterKey,
-                                   encryptionGlobalParams.kmipRotateMasterKey);
-        auto keyProvider =
-            keyProviderFactory(encryptionGlobalParams, logv2::LogComponent::kStorage);
-        auto encryptionKeyDB = EncryptionKeyDB::create(
-            keyDBPath.string(),
-            just_created ? keyProvider->obtainMasterKey().first : keyProvider->readMasterKey());
-        keyDBPathGuard.dismiss();
-        // do master key rotation if necessary
-        if (encryptionGlobalParams.shouldRotateMasterKey()) {
-            fs::path newKeyDBPath = path;
-            newKeyDBPath /= rotationDir;
-            if (fs::exists(newKeyDBPath)) {
-                std::stringstream ss;
-                ss << "Cannot do master key rotation. ";
-                ss << "Rotation directory '" << newKeyDBPath << "' already exists.";
-                throw std::runtime_error(ss.str());
-            }
-            try {
-                fs::create_directory(newKeyDBPath);
-            } catch (std::exception& e) {
-                LOGV2(29010, "error creating rotation directory {path} {what}",
-                      "path"_attr = newKeyDBPath.string(),
-                      "what"_attr = e.what());
-                throw;
-            }
-
-            std::unique_ptr<EncryptionKeyDB> rotationKeyDB;
-            try {
-                auto [masterKey, masterKeyId] = keyProvider->obtainMasterKey(
-                    /* saveKey = */ false, /* raiseOnError = */ true);
-                rotationKeyDB = encryptionKeyDB->clone(newKeyDBPath.string(), masterKey);
-                if (!masterKeyId) {
-                    keyProvider->saveMasterKey(masterKey);
-                }
-            } catch (const encryption::KeyError& e) {
-                fs::remove_all(newKeyDBPath);
-                LOGV2_FATAL_CONTINUE(29120,
-                                     "Failed to rotate master encrypion key: key operation failed",
-                                     "error"_attr = e);
-                exitCleanly(EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR);
-            } catch (const std::runtime_error& e) {
-                fs::remove_all(newKeyDBPath);
-                LOGV2_FATAL_CONTINUE(
-                    29121, "Failed to rotate master encrypion key", "reason"_attr = e.what());
-                exitCleanly(EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR);
-            }
-            // close key db instances and rename dirs
-            encryptionKeyDB.reset(nullptr);
-            rotationKeyDB.reset(nullptr);
-            fs::path backupKeyDBPath = path;
-            backupKeyDBPath /= keydbBackupDir;
-            fs::remove_all(backupKeyDBPath);
-            fs::rename(keyDBPath, backupKeyDBPath);
-            fs::rename(newKeyDBPath, keyDBPath);
-            throw MasterKeyRotationCompleted("master key rotation finished successfully");
-        }
-        _encryptionKeyDB = std::move(encryptionKeyDB);
-        // add Percona encryption extension
-        std::stringstream ss;
-        ss << "local=(entry=percona_encryption_extension_init,early_load=true,config=(cipher=" << encryptionGlobalParams.encryptionCipherMode << "))";
-        WiredTigerExtensions::get(getGlobalServiceContext())->addExtension(ss.str());
-        // setup encryption hooks
-        // WiredTigerEncryptionHooks instance should be created after EncryptionKeyDB (depends on it)
-        if (encryptionGlobalParams.encryptionCipherMode == "AES256-CBC")
-            EncryptionHooks::set(
-                getGlobalServiceContext(),
-                std::make_unique<WiredTigerEncryptionHooksCBC>(_encryptionKeyDB.get()));
-        else // AES256-GCM
-            EncryptionHooks::set(
-                getGlobalServiceContext(),
-                std::make_unique<WiredTigerEncryptionHooksGCM>(_encryptionKeyDB.get()));
-    }
 
     std::stringstream ss;
     ss << "create,";
@@ -1943,7 +2013,8 @@ Status WiredTigerKVEngine::_hotBackupPopulateLists(OperationContext* opCtx,
         if (ret != 0) {
             return wtRCToStatus(ret, s);
         }
-        dbList.emplace_back(fs::path{_path} / keydbDir, destPath / keydbDir, session, c);
+        dbList.emplace_back(
+            fs::path{_path} / kKeyDbDirBasename, destPath / kKeyDbDirBasename, session, c);
     }
 
     // Populate list of files to copy

--- a/src/mongo/util/exit_code.h
+++ b/src/mongo/util/exit_code.h
@@ -64,7 +64,7 @@ enum ExitCode : int {
     EXIT_AUDIT_ROTATE_ERROR = 102,  // The startup rotation of audit logs failed
 
     // Percona specific exit codes
-    EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR = 1001
+    EXIT_PERCONA_DATA_AT_REST_ENCRYPTION_ERROR = 1001
 };
 
 }  // namespace mongo


### PR DESCRIPTION
Don't prematurely finish the process with the `quickExit` or the `exitCleanly` functions so that each `ScopeGuard` object can do a clean-up job assigned to its destructor.