### PR TITLE
PSMDB-1239 Allow the `ScopeGuard` objects to do clean-up

### DIFF
--- a/src/mongo/db/encryption/error_builder.h
+++ b/src/mongo/db/encryption/error_builder.h
@@ -1,0 +1,110 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2023-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+#include "mongo/base/string_data.h"
+#include "mongo/bson/bsonobjbuilder.h"
+#include "mongo/db/encryption/error.h"
+#include "mongo/util/str.h"
+
+namespace mongo::encryption {
+class ErrorBuilder {
+public:
+    ErrorBuilder(const StringData& what, const StringData& reason = StringData()) {
+        _builder.append("what", what);
+        if (!reason.empty()) {
+            _builder.append("reason", reason);
+        }
+    }
+
+    ErrorBuilder(const StringData& what, const Error& reason) {
+        _builder.append("what", what);
+        _builder.append("reason", reason.toBSON());
+    }
+
+    ErrorBuilder& append(const StringData& name, const StringData& value) {
+        _builder.append(name, value);
+        return *this;
+    }
+
+    template <typename T,
+              typename = std::void_t<
+                  decltype(std::declval<T>().serialize(&std::declval<BSONObjBuilder&>()))>>
+    ErrorBuilder& append(const StringData& name, const T& value) {
+        BSONObjBuilder sb = _builder.subobjStart(name);
+        value.serialize(&sb);
+        sb.done();
+        return *this;
+    }
+
+    template <typename Iterator,
+              typename = std::void_t<decltype(std::declval<BSONArrayBuilder>().append(
+                  std::declval<Iterator>(), std::declval<Iterator>()))>>
+    ErrorBuilder& append(const StringData& name, Iterator begin, Iterator end) {
+        BSONArrayBuilder sb = _builder.subarrayStart(name);
+        sb.append(begin, end);
+        sb.done();
+        return *this;
+    }
+
+    Error error() {
+        return Error(_builder.obj());
+    }
+
+private:
+    BSONObjBuilder _builder;
+};
+
+enum class KeyOperationType : std::uint8_t { read, save };
+
+class KeyErrorBuilder : public ErrorBuilder {
+public:
+    KeyErrorBuilder(KeyOperationType opType, const StringData& reason)
+        : ErrorBuilder(str::stream() << "key " << to_string(opType) << " failed", reason) {}
+
+private:
+    static StringData to_string(KeyOperationType opType) {
+        switch (opType) {
+            case KeyOperationType::read:
+                return "reading";
+            case KeyOperationType::save:
+                return "saving";
+        }
+        throw std::invalid_argument(
+            std::to_string(std::underlying_type_t<KeyOperationType>(opType)));
+    }
+};
+}  // namespace mongo::encryption

--- a/src/mongo/db/encryption/key_operations.cpp
+++ b/src/mongo/db/encryption/key_operations.cpp
@@ -34,8 +34,8 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/encryption/encryption_kmip.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/encryption/encryption_vault.h"
+#include "mongo/db/encryption/error_builder.h"
 #include "mongo/db/encryption/key.h"
-#include "mongo/db/encryption/key_error.h"
 #include "mongo/db/encryption/secret_string.h"
 #include "mongo/util/invariant.h"
 

--- a/src/mongo/db/encryption/master_key_provider.h
+++ b/src/mongo/db/encryption/master_key_provider.h
@@ -70,10 +70,10 @@ public:
     /// Intended to be called for retrieving the master key for an _existing_
     /// encyption key database.
     ///
-    /// Initiates a graceful exit from the program if can't unambiguously read
-    /// the master encryption key.
+    /// @returns the master encryption key
     ///
-    /// @return the master encryption key
+    /// @throws `encryption::Error` if can't unambiguously read the key from
+    /// the key management facility
     Key readMasterKey() const;
 
     /// @brief Reads an existing master key from a key management factility or
@@ -81,11 +81,6 @@ public:
     ///
     /// Intendend to be called for obtaining the master key for
     /// a _just created_ encryption key database.
-    ///
-    /// If the function can't unambiguously read the key from or save the key
-    /// to the key management facility, it either initiates a graceful exit from
-    /// the program or throws a `KeyError` exception depending on the value
-    /// of the `raiseOnError` argument.
     ///
     /// @param saveKey if true, the generated key is immediately saved
     ///                to the key management facility
@@ -96,15 +91,16 @@ public:
     /// @returns the read or generated encryption key and its identifier;
     ///          the latter is not `nullptr` if `saveKey` is `true`
     ///
-    /// @throw `KeyError` @see above
-    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true,
-                                                           bool raiseOnError = false) const;
+    /// @throws `encryption::Error` if can't unambiguously read the key from or
+    /// save the key to the key management facility
+    std::pair<Key, std::unique_ptr<KeyId>> obtainMasterKey(bool saveKey = true) const;
 
     /// @brief Saves the master key to a key manageent facitlity.
     ///
     /// @param key an encryption key to be saves
     ///
-    /// @throws `KeyError` if can't unambiguously save the master encryption key.
+    /// @throws `encryption::Error` if can't unambiguously save the key to
+    /// the key management facility
     void saveMasterKey(const Key& key) const;
 
 private:

--- a/src/mongo/db/mongod_main.cpp
+++ b/src/mongo/db/mongod_main.cpp
@@ -79,6 +79,7 @@
 #include "mongo/db/dbdirectclient.h"
 #include "mongo/db/dbhelpers.h"
 #include "mongo/db/dbmessage.h"
+#include "mongo/db/encryption/error.h"
 #include "mongo/db/exec/working_set_common.h"
 #include "mongo/db/fcv_op_observer.h"
 #include "mongo/db/free_mon/free_mon_mongod.h"
@@ -163,6 +164,7 @@
 #include "mongo/db/storage/encryption_hooks.h"
 #include "mongo/db/storage/flow_control.h"
 #include "mongo/db/storage/flow_control_parameters_gen.h"
+#include "mongo/db/storage/master_key_rotation_completed.h"
 #include "mongo/db/storage/storage_engine.h"
 #include "mongo/db/storage/storage_engine_init.h"
 #include "mongo/db/storage/storage_engine_lock_file.h"
@@ -406,8 +408,21 @@ ExitCode _initAndListen(ServiceContext* serviceContext, int listenPort) {
     // initialized, a noop recovery unit is used until the initialization is complete.
     auto startupOpCtx = serviceContext->makeOperationContext(&cc());
 
-    auto lastShutdownState =
-        initializeStorageEngine(startupOpCtx.get(), StorageEngineInitFlags::kNone);
+    auto lastShutdownState = [&startupOpCtx]() {
+        try {
+            return initializeStorageEngine(startupOpCtx.get(), StorageEngineInitFlags::kNone);
+        } catch (const MasterKeyRotationCompleted&) {
+            exitCleanly(EXIT_CLEAN);
+        } catch (const encryption::Error& e) {
+            LOGV2_FATAL_OPTIONS(
+                29120,
+                logv2::LogOptions(logv2::LogComponent::kStorage, logv2::FatalMode::kContinue),
+                "Data-at-Rest Encryption Error",
+                "error"_attr = e);
+            exitCleanly(EXIT_PERCONA_DATA_AT_REST_ENCRYPTION_ERROR);
+        }
+        throw;  // suppress the `control reaches end of non-void function` warning
+    }();
     StorageControl::startStorageControls(serviceContext);
 
 #ifdef MONGO_CONFIG_WIREDTIGER_ENABLED

--- a/src/mongo/db/storage/master_key_rotation_completed.h
+++ b/src/mongo/db/storage/master_key_rotation_completed.h
@@ -40,7 +40,8 @@ namespace mongo {
 /// @todo Try to refactor the code so that thre is no need in throwing an exception
 /// in case of successfull execution.
 struct MasterKeyRotationCompleted : std::runtime_error {
-    explicit MasterKeyRotationCompleted(const char* msg) : std::runtime_error(msg) {}
+    explicit MasterKeyRotationCompleted()
+        : std::runtime_error("master key rotation finished successfully") {}
 };
 
 }  // namespace mongo

--- a/src/mongo/db/storage/storage_engine_init.cpp
+++ b/src/mongo/db/storage/storage_engine_init.cpp
@@ -207,19 +207,19 @@ StorageEngine::LastShutdownState initializeStorageEngine(OperationContext* opCtx
             factory->create(opCtx, storageGlobalParams, lockFile ? &*lockFile : nullptr)));
         service->getStorageEngine()->finishInit();
     } catch (const MasterKeyRotationCompleted&) {
+        const encryption::WtKeyIds& keyIds = encryption::WtKeyIds::instance();
+        invariant(keyIds.decryption && keyIds.futureConfigured);
         // Write metadata because KMIP master key ID has been updated.
         writeMetadata(std::move(metadata),
                       factory,
                       storageGlobalParams,
-                      encryption::WtKeyIds::instance().futureConfigured.get(),
+                      keyIds.futureConfigured.get(),
                       initFlags);
-        const encryption::WtKeyIds& keyIds = encryption::WtKeyIds::instance();
-        invariant(keyIds.decryption && keyIds.futureConfigured);
         LOGV2(29111,
               "Rotated master encryption key",
               "oldKeyIdentifier"_attr = *keyIds.decryption,
               "newKeyIdentifier"_attr = *keyIds.futureConfigured);
-        quickExit(EXIT_SUCCESS);
+        throw;
     }
 
     if (lockFile) {

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
@@ -269,7 +269,7 @@ void EncryptionKeyDB::init() {
     LOGV2(29039, "Encryption keys DB is initialized successfully");
 }
 
-void EncryptionKeyDB::import_data_from(EncryptionKeyDB* proto) {
+void EncryptionKeyDB::import_data_from(const EncryptionKeyDB* proto) {
     // not doing any synchronization here because key rotation process is single threaded
     try {
         // copy parameters table
@@ -312,7 +312,7 @@ void EncryptionKeyDB::import_data_from(EncryptionKeyDB* proto) {
 }
 
 std::unique_ptr<EncryptionKeyDB> EncryptionKeyDB::clone(const std::string& path,
-                                                        const encryption::Key& masterKey) {
+                                                        const encryption::Key& masterKey) const {
     std::unique_ptr<EncryptionKeyDB> duplicate(new EncryptionKeyDB(path, masterKey, true));
     duplicate->init();
     duplicate->import_data_from(this);

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -79,7 +79,7 @@ public:
     /// @throws std::runtime_error if can't craete a key database new one at the specified path or
     /// can't copy the data to the just created database.
     std::unique_ptr<EncryptionKeyDB> clone(const std::string& path,
-                                           const encryption::Key& masterKey);
+                                           const encryption::Key& masterKey) const;
 
     // returns encryption key from keys DB
     // create key if it does not exists
@@ -118,6 +118,10 @@ public:
         return _masterkey;
     }
 
+    const std::string& path() const noexcept {
+        return _path;
+    }
+
 private:
     typedef boost::multiprecision::uint128_t _gcm_iv_type;
 
@@ -131,7 +135,7 @@ private:
     int _openWiredTiger(const std::string& path, const std::string& wtOpenConfig);
 
     // during rotation copies data from provided instance
-    void import_data_from(EncryptionKeyDB* proto);
+    void import_data_from(const EncryptionKeyDB* proto);
 
     StatusWith<std::deque<StorageEngine::BackupBlock>> _disableIncrementalBackup();
 

--- a/src/mongo/util/exit_code.h
+++ b/src/mongo/util/exit_code.h
@@ -63,7 +63,7 @@ enum ExitCode : int {
     EXIT_TEST = 101,
 
     // Percona specific exit codes
-    EXIT_PERCONA_MASTER_KEY_ROTATION_ERROR = 1001
+    EXIT_PERCONA_DATA_AT_REST_ENCRYPTION_ERROR = 1001
 };
 
 }  // namespace mongo


### PR DESCRIPTION
Don't prematurely finish the process with the `quickExit` or the `exitCleanly` functions so that each `ScopeGuard` object can do a clean-up job assigned to its destructor.