### PR TITLE
PSMDB-1265 Fix the WiredTiger unit test

### DIFF
--- a/src/mongo/db/storage/wiredtiger/SConscript
+++ b/src/mongo/db/storage/wiredtiger/SConscript
@@ -169,7 +169,7 @@ wtEnv.CppUnitTest(
         '$BUILD_DIR/mongo/db/encryption/key',
         '$BUILD_DIR/mongo/db/service_context_test_fixture',
         '$BUILD_DIR/mongo/util/clock_source_mock',
-        'storage_wiredtiger_core',
+        'storage_wiredtiger',
     ],
 )
 


### PR DESCRIPTION
Fix the `storage_wiredtiger_kv_engine_encryption_key_test` unit test by linking all the necessary code. In particular, the method `StorageClientObserver::onCreateOperationContext` is now linked via the `storage_wiredtiger` -> `storage_engine_common` dependency chain.