### PR TITLE
PSMDB-1291-4.4.22-21: Add STS endpoint override parameter

### DIFF
--- a/src/mongo/shell/encrypted_shell_options.h
+++ b/src/mongo/shell/encrypted_shell_options.h
@@ -39,6 +39,7 @@ struct EncryptedShellGlobalParams {
     std::string awsSessionToken;
     std::string keyVaultNamespace;
     std::string awsKmsURL;
+    std::string awsStsURL;
 };
 
 extern EncryptedShellGlobalParams encryptedShellGlobalParams;

--- a/src/mongo/shell/fle_shell_options.idl
+++ b/src/mongo/shell/fle_shell_options.idl
@@ -35,3 +35,8 @@ configs:
         arg_vartype: String
         cpp_varname: encryptedShellGlobalParams.awsKmsURL
         requires: [ "awsAccessKeyId", "awsSecretAccessKey", "keyVaultNamespace" ]
+    "stsURL":
+        description: "Optional parameter to override the STS endpoint URL"
+        arg_vartype: String
+        cpp_varname: encryptedShellGlobalParams.awsStsURL
+        requires: [ ]


### PR DESCRIPTION
STS endpoint url overrides are needed when Mongo requires VPC endpoints to communicate with STS.

This might be a way to go about it?