### PR TITLE
PSMDB-1297 Add missing header to compile with gcc-13

### DIFF
--- a/src/mongo/db/free_mon/free_mon_options.h
+++ b/src/mongo/db/free_mon/free_mon_options.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
\<cstdint\> is necessary for std::int32_t
The issue appeared while building with gcc-13