### PR TITLE
PSMDB-1300 psmdb-4.4: update go to 1.19.11

### DIFF
--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -238,11 +238,11 @@ switch_to_vault_repo() {
 }
 
 install_golang() {
-    wget https://golang.org/dl/go1.15.7.linux-amd64.tar.gz -O /tmp/golang1.15.tar.gz
-    tar --transform=s,go,go1.15, -zxf /tmp/golang1.15.tar.gz
-    rm -rf /usr/local/go1.15 /usr/local/go1.11  /usr/local/go1.8 /usr/local/go1.9 /usr/local/go1.9.2 /usr/local/go
-    mv go1.15 /usr/local/
-    ln -s /usr/local/go1.15 /usr/local/go
+    wget https://golang.org/dl/go1.19.11.linux-amd64.tar.gz -O /tmp/golang1.19.tar.gz
+    tar --transform=s,go,go1.19, -zxf /tmp/golang1.19.tar.gz
+    rm -rf /usr/local/go1.19 /usr/local/go1.11  /usr/local/go1.8 /usr/local/go1.9 /usr/local/go1.9.2 /usr/local/go
+    mv go1.19 /usr/local/
+    ln -s /usr/local/go1.19 /usr/local/go
 }
 
 install_gcc_8_centos(){


### PR DESCRIPTION
GO should be updated due to 
```shell
19:19:57  cd /mnt/jenkins/workspace/psmdb44-autobuild-RELEASE/test/percona-server-mongodb-4.4.23/../src/github.com/mongodb/mongo-tools; \
19:19:57          sed -i '12d' buildscript/build.go; \
19:19:57          sed -i '168,177d' buildscript/build.go; \
19:19:57          sed -i "s:versionStr,:\"4.4.23-22\",:" buildscript/build.go; \
19:19:57          sed -i "s:gitCommit):\"ad89a1c6dbe283012012cf0e5f4cb7fb1fcdf75d\"):" buildscript/build.go; \
19:19:57          ./make build;
19:19:59  # github.com/mongodb/mongo-tools/common/testtype
19:19:59  common/testtype/types.go:70:6: missing function body
19:19:59  common/testtype/types.go:70:12: syntax error: unexpected [, expecting (
19:19:59  note: module requires Go 1.19

```