### PR TITLE
PSMDB-1300 psmdb-4.4: fix build for aarch64

### DIFF
--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -176,6 +176,12 @@ get_sources(){
 	    -replace golang.org/x/text@v0.3.7=golang.org/x/text@v0.3.8
     go mod tidy
     go mod vendor
+
+    # Dirty hack for mongo-tools 100.7.3 and aarch64 builds. Should fail once Mongo fixes OS detection https://jira.mongodb.org/browse/TOOLS-3318
+    if [ x"$ARCH" = "xaarch64" ]; then
+        sed -i '125 {/\(GetByOsAndArch("ubuntu1804", archName)\)/ s/\bubuntu1804\b/rhel82/; t; q1}' release/platform/platform.go || exit 1
+    fi
+
     cd ${WORKDIR}
     source percona-server-mongodb-44.properties
     #

--- a/src/mongo/db/storage/wiredtiger/SConscript
+++ b/src/mongo/db/storage/wiredtiger/SConscript
@@ -120,8 +120,8 @@ if wiredtiger:
             'aws-c-cal',
             'aws-c-sdkutils',
             's2n',
-            'aws-c-common',
             'aws-checksums',
+            'aws-c-common',
             ]
         )
 


### PR DESCRIPTION
1. fix aws-sdk-cpp build for arm64
2. fix mongo-tools aarch64 build for OL8