### PR TITLE
PSMDB-1357 report included features in build info and add --full-featured build switch

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -244,6 +244,11 @@ add_option('enable-fipsmode',
     nargs=0,
 )
 
+add_option('full-featured',
+    help='Enable all optional features',
+    nargs=0,
+)
+
 add_option('ocsp-stapling',
     choices=['on', 'off'],
     default='on',
@@ -2155,11 +2160,14 @@ def link_guard_libdeps_tag_expand(source, target, env, for_signature):
 
 env['LIBDEPS_TAG_EXPANSIONS'].append(link_guard_libdeps_tag_expand)
 
+env['PSMDB_PRO_FEATURES'] = []
+
 if has_option('audit'):
     env.Append( CPPDEFINES=[ 'PERCONA_AUDIT_ENABLED' ] )
 
-if has_option('enable-fipsmode'):
+if has_option('enable-fipsmode') or has_option('full-featured'):
     env.SetConfigHeaderDefine("PERCONA_FIPSMODE_ENABLED")
+    env['PSMDB_PRO_FEATURES'].append('FIPSMode')
 
 env.Tool('forceincludes')
 

--- a/src/mongo/util/SConscript
+++ b/src/mongo/util/SConscript
@@ -20,6 +20,7 @@ env.InjectThirdParty('asio')
 js_engine_ver = get_option("js-engine") if get_option("server-js") == "on" else "none"
 
 module_list = ',\n'.join(['"{0}"_sd'.format(x) for x in env['MONGO_MODULES']])
+psmdb_pro_feature_list = ',\n'.join(['"{0}"_sd'.format(x) for x in env['PSMDB_PRO_FEATURES']])
 
 # Render the MONGO_BUILDINFO_ENVIRONMENT_DATA dict into an initializer for a
 # `std::vector<VersionInfoInterface::BuildInfoField>`.
@@ -50,6 +51,7 @@ generatedVersionFile = env.Substfile(
         ('@buildinfo_js_engine@', js_engine_ver),
         ('@buildinfo_allocator@', env['MONGO_ALLOCATOR']),
         ('@buildinfo_modules@', module_list),
+        ('@buildinfo_psmdb_pro_features@', psmdb_pro_feature_list),
         ('@buildinfo_environment_data@', buildInfoInitializer),
     ])
 env.Alias('generated-sources', generatedVersionFile)

--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -88,6 +88,10 @@ public:
         return {"unknown"};
     }
 
+    std::vector<StringData> psmdbProFeatures() const final {
+        return {"unknown"};
+    }
+
     StringData allocator() const noexcept final {
         return "unknown";
     }
@@ -166,6 +170,7 @@ void VersionInfoInterface::appendBuildInfo(BSONObjBuilder* result) const {
     o.append("targetMinOS", targetMinOS());
 #endif
     o.append("modules", modules());
+    o.append("proFeatures", psmdbProFeatures());
     o.append("allocator", allocator());
     o.append("javascriptEngine", jsEngine());
     o.append("sysInfo", "deprecated");
@@ -229,6 +234,7 @@ void VersionInfoInterface::logBuildInfo(std::ostream* os) const {
     bob.append("openSSLVersion", openSSLVersion());
 #endif
     bob.append("modules", modules());
+    bob.append("proFeatures", psmdbProFeatures());
     bob.append("allocator", allocator());
     {
         auto envObj = BSONObjBuilder(bob.subobjStart("environment"));

--- a/src/mongo/util/version.h
+++ b/src/mongo/util/version.h
@@ -114,6 +114,11 @@ public:
     virtual std::vector<StringData> modules() const = 0;
 
     /**
+     * Returns a list of the enabled features.
+     */
+    virtual std::vector<StringData> psmdbProFeatures() const = 0;
+
+    /**
      * Returns a string describing the configured memory allocator.
      */
     virtual StringData allocator() const noexcept = 0;

--- a/src/mongo/util/version_constants.h.in
+++ b/src/mongo/util/version_constants.h.in
@@ -52,6 +52,12 @@ inline std::vector<StringData> modulesList() {
     };
 }
 
+inline std::vector<StringData> psmdbProFeatureList() {
+    return {
+@buildinfo_psmdb_pro_features@
+    };
+}
+
 inline std::vector<VersionInfoInterface::BuildInfoField> buildEnvironment() {
     return {
 @buildinfo_environment_data@

--- a/src/mongo/util/version_impl.cpp
+++ b/src/mongo/util/version_impl.cpp
@@ -72,6 +72,10 @@ public:
         return version::modulesList();
     }
 
+    std::vector<StringData> psmdbProFeatures() const final {
+        return version::psmdbProFeatureList();
+    }
+
     StringData allocator() const noexcept final {
         return version::kAllocator;
     }


### PR DESCRIPTION
Adding `proFeatures` array to build info:
```
$ ./mongod --version
db version v6.0.11
Build Info: {
    "version": "6.0.11",
    "gitVersion": "nogitversion",
    "openSSLVersion": "OpenSSL 1.1.1f  31 Mar 2020",
    "modules": [],
    "proFeatures": [
        "FIPSMode"
    ],
    "allocator": "tcmalloc",
    "environment": {
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}
```
Shell command:
```
test> db.runCommand({buildInfo:1})
{
  version: '6.0.11',
  psmdbVersion: '6.0.11',
  gitVersion: 'nogitversion',
  modules: [],
  proFeatures: [ 'FIPSMode' ],
  allocator: 'tcmalloc',
  javascriptEngine: 'mozjs',
...
```