### PR TITLE
Revert "SERVER-81878 Allow writes in read-only mode from ident reaper"

### DIFF
--- a/src/mongo/db/repl/replication_recovery_test.cpp
+++ b/src/mongo/db/repl/replication_recovery_test.cpp
@@ -1536,7 +1536,8 @@ TEST_F(ReplicationRecoveryTest, RecoverFromOplogAsStandaloneRecoversOplog) {
     ASSERT_EQ(getConsistencyMarkers()->getAppliedThrough(opCtx), OpTime(Timestamp(5, 5), 1));
 
     // Test the node is readOnly.
-    ASSERT_TRUE(storageGlobalParams.readOnly);
+    ASSERT_THROWS(getStorageInterface()->insertDocument(opCtx, testNs, {_makeInsertDocument(2)}, 1),
+                  AssertionException);
 }
 
 TEST_F(ReplicationRecoveryTest,

--- a/src/mongo/db/storage/write_unit_of_work.cpp
+++ b/src/mongo/db/storage/write_unit_of_work.cpp
@@ -47,7 +47,7 @@ WriteUnitOfWork::WriteUnitOfWork(OperationContext* opCtx)
     : _opCtx(opCtx), _toplevel(opCtx->_ruState == RecoveryUnitState::kNotInUnitOfWork) {
     uassert(ErrorCodes::IllegalOperation,
             "Cannot execute a write operation in read-only mode",
-            !storageGlobalParams.readOnly || opCtx->getClient()->isFromSystemConnection());
+            !storageGlobalParams.readOnly);
     _opCtx->lockState()->beginWriteUnitOfWork();
     if (_toplevel) {
         _opCtx->recoveryUnit()->beginUnitOfWork(_opCtx);
@@ -59,7 +59,7 @@ WriteUnitOfWork::WriteUnitOfWork(OperationContext* opCtx)
 }
 
 WriteUnitOfWork::~WriteUnitOfWork() {
-    dassert(!storageGlobalParams.readOnly || _opCtx->getClient()->isFromSystemConnection());
+    dassert(!storageGlobalParams.readOnly);
     if (!_released && !_committed) {
         invariant(_opCtx->_ruState != RecoveryUnitState::kNotInUnitOfWork);
         if (_toplevel) {


### PR DESCRIPTION
This reverts commit 3187d717c3314f96a0288b4b8ebc99c270ea490a.
This is necessary because of SERVER-84432