### PR TITLE
PSMDB-1434 get rid of excessive events in the audit log

### DIFF
--- a/jstests/audit/audit_authz_delete.js
+++ b/jstests/audit/audit_authz_delete.js
@@ -66,6 +66,16 @@ auditTest(
             'param.command': 'delete',
             result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for remove operation
+        assert.eq(0, auditColl.count({
+            atype: "removeOperation",
+            ts: withinInterval(beforeCmd, beforeLoad),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'param.ns': testDBName + '.' + 'foo',
+            'param.doc._id': 2,
+            result: 0, // <-- We do not expect this remove operation to be logged
+        }), "FAILED, remove operation has been found in the audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }
 );

--- a/jstests/audit/audit_authz_insert.js
+++ b/jstests/audit/audit_authz_insert.js
@@ -63,6 +63,16 @@ auditTest(
             'param.command': 'insert',
             result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for simple insert
+        assert.eq(0, auditColl.count({
+            atype: "insertOperation",
+            ts: withinInterval(beforeCmd, beforeLoad),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'param.ns': testDBName + '.' + 'foo',
+            'param.doc._id': 1,
+            result: 0, // <-- We do not expect this insert operations to be logged
+        }), "FAILED, insert operation has been found in the audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }
 );

--- a/jstests/audit/audit_authz_update.js
+++ b/jstests/audit/audit_authz_update.js
@@ -64,6 +64,16 @@ auditTest(
             'param.command': 'update',
             result: 0, // <-- Authorization successful
         }), "FAILED, audit log: " + tojson(auditColl.find().toArray()));
+
+        // Audit event for update operation
+        assert.eq(0, auditColl.count({
+            atype: "updateOperation",
+            ts: withinInterval(beforeCmd, beforeLoad),
+            users: { $elemMatch: { user:'admin', db:'admin'} },
+            'param.ns': testDBName + '.' + 'foo',
+            'param.doc.bar': 3,
+            result: 0, // <-- We do not expect this update operations to be logged
+        }), "FAILED, update operation has been found in the audit log: " + tojson(auditColl.find().toArray()));
     },
     { auth:"" }
 );

--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -1237,27 +1237,39 @@ namespace audit {
         if (!_auditLog) {
             return;
         }
+        if (!nss.isPrivilegeCollection()) {
+            return;
+        }
 
-        const BSONObj params = BSON("ns" << nssToString(nss) << "doc" << doc);
-        _auditEvent(client, "insertOperation", params);
+        const BSONObj params =
+            BSON("ns" << nssToString(nss) << "document" << doc << "operation" << "insert");
+        _auditEvent(client, "directAuthMutation", params);
     }
 
     void logUpdateOperation(Client* client, const NamespaceString& nss, const BSONObj& doc) {
         if (!_auditLog) {
             return;
         }
+        if (!nss.isPrivilegeCollection()) {
+            return;
+        }
 
-        const BSONObj params = BSON("ns" << nssToString(nss) << "doc" << doc);
-        _auditEvent(client, "updateOperation", params);
+        const BSONObj params =
+            BSON("ns" << nssToString(nss) << "document" << doc << "operation" << "update");
+        _auditEvent(client, "directAuthMutation", params);
     }
 
     void logRemoveOperation(Client* client, const NamespaceString& nss, const BSONObj& doc) {
         if (!_auditLog) {
             return;
         }
+        if (!nss.isPrivilegeCollection()) {
+            return;
+        }
 
-        const BSONObj params = BSON("ns" << nssToString(nss) << "doc" << doc);
-        _auditEvent(client, "removeOperation", params);
+        const BSONObj params =
+            BSON("ns" << nssToString(nss) << "document" << doc << "operation" << "remove");
+        _auditEvent(client, "directAuthMutation", params);
     }
 
     void logGetClusterParameter(


### PR DESCRIPTION
insertOperation/updateOperation/removeOperation events were logged by mistake
The `directAuthMutation` event will be logged only for system.users and system.roles collections