### PR TITLE
PSMDB-1525. Update go version to prevent CVE-2024-34156

### DIFF
--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -240,7 +240,7 @@ install_golang() {
     elif [ x"$ARCH" = "xaarch64" ]; then
       GO_ARCH="arm64"
     fi
-    wget https://golang.org/dl/go1.22.4.linux-${GO_ARCH}.tar.gz -O /tmp/golang1.22.tar.gz
+    wget https://golang.org/dl/go1.22.7.linux-${GO_ARCH}.tar.gz -O /tmp/golang1.22.tar.gz
     tar --transform=s,go,go1.22, -zxf /tmp/golang1.22.tar.gz
     rm -rf /usr/local/go1.22 /usr/local/go1.19 /usr/local/go1.11 /usr/local/go1.8 /usr/local/go1.9 /usr/local/go1.9.2 /usr/local/go
     mv go1.22 /usr/local/


### PR DESCRIPTION
```
usr/bin/mongodump (gobinary)
============================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ fixed  │ 1.22.4            │ 1.22.7, 1.23.1 │ encoding/gob: golang: Calling Decoder.Decode on a message │
│         │                │          │        │                   │                │ which contains deeply nested structures...                │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34156                │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘

```