### PR TITLE
PSMDB-1573 Escape special characters when building LDAP queries

### DIFF
--- a/jstests/ldapauthz/_check.js
+++ b/jstests/ldapauthz/_check.js
@@ -9,6 +9,8 @@ const shortusernames = [
     "extbothrw",
     "exttestrwotherro",
     "exttestrootherrw",
+    "Surname\\, Name",
+    "Question? Mark! *{[(\\<\\>)]} #\\\"\\+\\\\",
 ];
 
 const rolesmap = {
@@ -51,6 +53,12 @@ const rolesmap = {
         "cn=otherwriters,dc=percona,dc=com",
         "cn=testusers,dc=percona,dc=com",
         "cn=otherusers,dc=percona,dc=com",
+    ],
+    "cn=Surname\\, Name,dc=percona,dc=com": [
+        "cn=specchar\\2C\\2B\\3D\\5C,dc=percona,dc=com",
+    ],
+    "cn=Question? Mark! *{[(\\<\\>)]} #\\\"\\+\\\\,dc=percona,dc=com": [
+        "cn=specchar\\2C\\2B\\3D\\5C,dc=percona,dc=com",
     ],
 };
 

--- a/jstests/ldapauthz/ldapauthz_memberof.js
+++ b/jstests/ldapauthz/ldapauthz_memberof.js
@@ -1,0 +1,50 @@
+(function() {
+    'use strict';
+
+    // prepare for the auth mode
+    load('jstests/ldapauthz/_setup.js');
+
+    // test command line parameters related to LDAP authorization
+    var conn = MongoRunner.runMongod({
+        auth: '',
+        ldapServers: TestData.ldapServers,
+        ldapTransportSecurity: 'none',
+        ldapBindMethod: 'simple',
+        ldapQueryUser: TestData.ldapQueryUser,
+        ldapQueryPassword: TestData.ldapQueryPassword,
+        ldapAuthzQueryTemplate: '{USER}?memberOf?base',
+        ldapUserToDNMapping: '[{match: "(.+)", ldapQuery: "dc=percona,dc=com??sub?(&(objectClass=organizationalPerson)(sn={0}))"}]',
+        setParameter: {authenticationMechanisms: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-1'}
+    });
+
+    assert(conn, "Cannot start mongod instance");
+
+    // load check roles routine
+    load('jstests/ldapauthz/_check.js');
+
+    var db = conn.getDB('$external');
+
+    shortusernames.forEach(function(entry){
+        const username = entry;
+        const userpwd = entry + '9a5S';
+
+        print('authenticating ' + username);
+        assert(db.auth({
+            user: username,
+            pwd: userpwd,
+            mechanism: 'PLAIN'
+        }));
+
+        // ensure user have got correct set of privileges
+        checkConnectionStatus(username, db.runCommand({connectionStatus: 1}),
+            function(name) {
+                return 'cn=' + name + ',dc=percona,dc=com';
+            }
+        );
+        
+        db.logout();
+    });
+
+    MongoRunner.stopMongod(conn);
+})();
+

--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -677,50 +677,139 @@ Status LDAPManagerImpl::execQuery(const std::string& ldapurl,
     return Status::OK();
 }
 
+namespace {
+
+std::string escapeForLDAPFilter(const std::string& str) {
+    std::string result;
+    result.reserve(str.size() * 2);
+    for (auto c : str) {
+        if (c == '\\') {
+            result += "\\5c";
+        } else if (c == '*') {
+            result += "\\2a";
+        } else if (c == '(') {
+            result += "\\28";
+        } else if (c == ')') {
+            result += "\\29";
+        } else if (c == '\0') {
+            result += "\\00";
+        } else {
+            result += c;
+        }
+    }
+    return result;
+};
+
+std::string escapeForLDAPURL(const std::string& str) {
+    std::string result;
+    result.reserve(str.size() * 2);
+    for (auto c : str) {
+        if (c == ' ') {
+            result += "%20";
+        } else if (c == '#') {
+            result += "%23";
+        } else if (c == '%') {
+            result += "%25";
+        } else if (c == '+') {
+            result += "%2b";
+        } else if (c == ',') {
+            result += "%2c";
+        } else if (c == ';') {
+            result += "%3b";
+        } else if (c == '<') {
+            result += "%3c";
+        } else if (c == '>') {
+            result += "%3e";
+        } else if (c == '?') {
+            result += "%3f";
+        } else if (c == '@') {
+            result += "%40";
+        } else if (c == '\\') {
+            result += "%5c";
+        } else if (c == '=') {
+            result += "%3d";
+        } else if (c == '/') {
+            result += "%2f";
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}
+
+std::string escapeNoop(const std::string& str) {
+    return str;
+}
+
+std::string escapeCombined(const std::string& str) {
+    return escapeForLDAPURL(escapeForLDAPFilter(str));
+}
+
+// substitute {0}, {1}, ... in stempl with corresponding values from sm
+std::string substituteFromMatch(const std::string& stempl,
+                                const std::smatch& sm,
+                                std::string (*escFn)(const std::string&) = escapeNoop) {
+    static const std::regex rex{R"(\{(\d+)\})"};
+    std::string ss;
+    ss.reserve(stempl.length() * 2);
+    std::sregex_iterator it{stempl.begin(), stempl.end(), rex};
+    std::sregex_iterator end;
+    auto suffix_len = stempl.length();
+    for (; it != end; ++it) {
+        ss += it->prefix();
+        ss += escFn(sm[std::stol((*it)[1].str()) + 1].str());
+        suffix_len = it->suffix().length();
+    }
+    ss += stempl.substr(stempl.length() - suffix_len);
+    return ss;
+}
+
+}  // namespace
+
 Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
-    //TODO: keep BSONArray somewhere is ldapGlobalParams (but consider multithreaded access)
+    // TODO: keep BSONArray somewhere in ldapGlobalParams (but consider multithreaded access)
     std::string mapping = ldapGlobalParams.ldapUserToDNMapping.get();
 
-    //Parameter validator checks that mapping is valid array of objects
-    //see validateLDAPUserToDNMapping function
+    // Parameter validator checks that mapping is valid array of objects
+    // see validateLDAPUserToDNMapping function
     BSONArray bsonmapping{fromjson(mapping)};
-    for (const auto& elt: bsonmapping) {
+    for (const auto& elt : bsonmapping) {
         auto step = elt.Obj();
         std::smatch sm;
         std::regex rex{step["match"].str()};
         if (std::regex_match(user, sm, rex)) {
             // user matched current regex
             BSONElement eltempl = step["substitution"];
-            bool substitution = true;
-            if (!eltempl) {
-                // ldapQuery mode
-                eltempl = step["ldapQuery"];
-                substitution = false;
-            }
-            // format template
-            {
-                std::regex rex{R"(\{(\d+)\})"};
-                std::string ss;
-                const std::string stempl = eltempl.str();
-                ss.reserve(stempl.length() * 2);
-                std::sregex_iterator it{stempl.begin(), stempl.end(), rex};
-                std::sregex_iterator end;
-                auto suffix_len = stempl.length();
-                for (; it != end; ++it) {
-                    ss += it->prefix();
-                    ss += sm[std::stol((*it)[1].str()) + 1].str();
-                    suffix_len = it->suffix().length();
-                }
-                ss += stempl.substr(stempl.length() - suffix_len);
-                out = std::move(ss);
-            }
-            // in substitution mode we are done - just return 'out'
-            if (substitution)
+            if (eltempl) {
+                // substitution mode
+                // we do not escape substituted values here because result value will be used as
+                // {USER} and will be escaped there
+                out = substituteFromMatch(eltempl.str(), sm);
                 return Status::OK();
+            }
+            // ldapQuery mode
+            std::string escapedQuery;
+            eltempl = step["ldapQuery"];
+            std::istringstream iss{eltempl.str()};
+            std::string part;
+            int partnum = 0;
+            while (std::getline(iss, part, '?')) {
+                if (partnum > 0) {
+                    escapedQuery += '?';
+                }
+                if (partnum == 3) {
+                    // ldap search filter should be escaped in a special way
+                    escapedQuery += substituteFromMatch(part, sm, escapeCombined);
+                } else {
+                    escapedQuery += substituteFromMatch(part, sm, escapeForLDAPURL);
+                }
+                ++partnum;
+            }
+
             // in ldapQuery mode we need to execute query and make decision based on query result
             auto ldapurl = fmt::format("ldap://{Servers}/{Query}",
-                fmt::arg("Servers", "ldap.server"),
-                fmt::arg("Query", out));
+                                       fmt::arg("Servers", "ldap.server"),
+                                       fmt::arg("Query", escapedQuery));
             std::vector<std::string> qresult;
             auto status = execQuery(ldapurl, true, qresult);
             if (!status.isOK())
@@ -734,8 +823,7 @@ Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
         }
     }
     // we have no successful transformations, return error
-    return Status(ErrorCodes::UserNotFound,
-                  "Failed to map user '{}' to LDAP DN"_format(user));
+    return {ErrorCodes::UserNotFound, "Failed to map user '{}' to LDAP DN"_format(user)};
 }
 
 Status LDAPManagerImpl::queryUserRoles(const UserName& userName, stdx::unordered_set<RoleName>& roles) {
@@ -749,12 +837,39 @@ Status LDAPManagerImpl::queryUserRoles(const UserName& userName, stdx::unordered
             return mapRes;
     }
 
+    // avoid escaping in the loop
+    const std::string mappedUserEscaped = escapeForLDAPURL(mappedUser);
+    const std::string providedUserEscaped = escapeForLDAPURL(providedUser);
+    const std::string mappedUserEscapedForFilter =
+        escapeForLDAPURL(escapeForLDAPFilter(mappedUser));
+    const std::string providedUserEscapedForFilter =
+        escapeForLDAPURL(escapeForLDAPFilter(providedUser));
+
+    // split query template into parts and replace placeholders in each part with escaped values
+    std::string escapedQuery;
+    std::istringstream iss{ldapGlobalParams.ldapQueryTemplate.get()};
+    std::string part;
+    int partnum = 0;
+    while (std::getline(iss, part, '?')) {
+        if (partnum > 0) {
+            escapedQuery += '?';
+        }
+        if (partnum == 3) {
+            // ldap search filter should be escaped in a special way
+            escapedQuery += fmt::format(part,
+                                        fmt::arg("USER", mappedUserEscapedForFilter),
+                                        fmt::arg("PROVIDED_USER", providedUserEscapedForFilter));
+        } else {
+            escapedQuery += fmt::format(part,
+                                        fmt::arg("USER", mappedUserEscaped),
+                                        fmt::arg("PROVIDED_USER", providedUserEscaped));
+        }
+        ++partnum;
+    }
+
     auto ldapurl = fmt::format("ldap://{Servers}/{Query}",
-            fmt::arg("Servers", "ldap.server"),
-            fmt::arg("Query", ldapGlobalParams.ldapQueryTemplate.get()));
-    ldapurl = fmt::format(ldapurl,
-            fmt::arg("USER", mappedUser),
-            fmt::arg("PROVIDED_USER", providedUser));
+                               fmt::arg("Servers", "ldap.server"),
+                               fmt::arg("Query", escapedQuery));
 
     std::vector<std::string> qresult;
     auto status = execQuery(ldapurl, false, qresult);

--- a/support-files/ldap-sasl/ldap/deploy_openldap.sh
+++ b/support-files/ldap-sasl/ldap/deploy_openldap.sh
@@ -35,6 +35,26 @@ apt-get install -y slapd  || {
 
 service slapd start
 
+# configure memberof overlay
+ldapmodify -Q -Y EXTERNAL -H ldapi:/// <<EOF
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: memberof.la
+EOF
+
+ldapadd -Y EXTERNAL -H ldapi:/// <<EOF
+dn: olcOverlay=memberof,olcDatabase={1}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcMemberOf
+olcOverlay: memberof
+olcMemberOfRefint: TRUE
+olcMemberOfDangling: ignore
+olcMemberOfGroupOC: groupOfNames
+olcMemberOfMemberAD: member
+olcMemberOfMemberOfAD: memberOf
+EOF
+
 # add the test users
 
 ${BASEDIR}/generate_users_ldif.sh > ${BASEDIR}/users.ldif

--- a/support-files/ldap-sasl/ldap/generate_users_ldif.sh
+++ b/support-files/ldap-sasl/ldap/generate_users_ldif.sh
@@ -15,12 +15,14 @@ extbothro
 extbothrw
 exttestrwotherro
 exttestrootherrw
+Surname\\, Name
+Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\
 _EOU_
 
-while read line
+while read -r line
 do
   cat <<_EOLDIF_
-dn: cn=$line,dc=percona,dc=com
+dn: cn=$line,${LDAP_BIND_DN}
 objectclass: organizationalPerson
 cn: $line 
 sn: $line

--- a/support-files/ldap-sasl/ldap/groups.ldif
+++ b/support-files/ldap-sasl/ldap/groups.ldif
@@ -46,3 +46,8 @@ member: cn=exttestrootherrw,dc=percona,dc=com
 member: cn=extbothro,dc=percona,dc=com
 member: cn=extbothrw,dc=percona,dc=com
 
+dn: cn=specchar\,\+\=\\,dc=percona,dc=com
+objectClass: groupOfNames
+cn: specchar\,\+\=\\
+member: cn=Surname\, Name,dc=percona,dc=com
+member: cn=Question? Mark! *{[(\<\>)]} #\"\+\\,dc=percona,dc=com

--- a/support-files/ldap-sasl/ldap/users.ldif
+++ b/support-files/ldap-sasl/ldap/users.ldif
@@ -54,3 +54,17 @@ sn: exttestrootherrw
 userPassword: exttestrootherrw9a5S
 description: exttestrootherrw userPassword
 
+dn: cn=Surname\, Name,dc=percona,dc=com
+objectclass: organizationalPerson
+cn: Surname\, Name 
+sn: Surname\, Name
+userPassword: Surname\, Name9a5S
+description: Surname\, Name userPassword
+
+dn: cn=Question? Mark! *{[(\<\>)]} #\"\+\\,dc=percona,dc=com
+objectclass: organizationalPerson
+cn: Question? Mark! *{[(\<\>)]} #\"\+\\ 
+sn: Question? Mark! *{[(\<\>)]} #\"\+\\
+userPassword: Question? Mark! *{[(\<\>)]} #\"\+\\9a5S
+description: Question? Mark! *{[(\<\>)]} #\"\+\\ userPassword
+


### PR DESCRIPTION
We cannot use the same escaping implementation for each part of LDAP query. This is because LDAP query filters (see RFC 4515) require escaping of some special characters which are used to build filter expressions. Thus substituting placeholders in filter expression differs from substituting in other parts of LDAP query.

It is not documented formally but we can assume more or less that {USER} placeholder will often contain distinguished name string values. For example if we use userToDNMapping mechanism and its ldapQuery to get the {USER} value it will in most cases contain DN value returned by LDAP server. Nevertheless {PROVIDED_USER} can be anything: DN, email, some other user identifier.

When we receive DN value from LDAP server as a result of ldapQuery it is already in escaped form - defined in RFC 4514 - thus in this case we don't need to do DN escaping. But if we don't use userToDNMapping mechanism values in {PROVIDED_USER} and {USER} are provided directly by the client application - that means it is client's responsibility to escape DN according to RFC 4514 if client wants to use DN as a user name.

In substitution no escaping happens during replacing placeholders. Result string becomes value for {USER} placeholder and that value is escaped when that placeholder is substituted in the queryTemplate. But if substitution contains parts of DN those parts should be escaped by config maintainer using DN escaping rules (RFC 4514).
ldapQuery can contain LDAP search filter. That means that if substitution placeholders are found in search filter server will need to do additional escaping on substitution value - as described in RFC 4515. Also URL escaping of substituted values is done before executing the query.

mongoDB server always escapes substitution values using URL escaping rules (RFC 4516). If that substitution occurs inside LDAP search filter then URL escaping is going AFTER search filter escaping.

LDAP queries specified in queryTemplate and ldapQuery configuration parameters must be escaped by config maintainer. All three escaping mechanisms should be used if necessary:

DN escaping - when full or partial DN is hardcoded into query
search filter escaping - when query contains search filter
URL escaping - when query contains some special characters which can alter query interpretation (think about question mark character for example)