### PR TITLE
PSMDB-1567 Avoid server crash when LDAP server is down

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -390,8 +390,13 @@ public:
         auto it = std::find_if(_poll_fds.begin(), _poll_fds.end(), [&](auto const& e) {
             return e.second.conn == ldap;
         });
+        if (it == _poll_fds.end()) {
+            // for this connection there was no cb_add call
+            // unbind it here
+            ldap_unbind_ext(ldap, nullptr, nullptr);
+            return;
+        }
         // returning connection which was not borrowed is an error
-        invariant(it != _poll_fds.end());
         invariant(it->second.borrowed);
         it->second.borrowed = false;
         // poller should be always notified here


### PR DESCRIPTION
Our connection pool has `_poll_fds` collection of open LDAP connections. But it is implemented in a way that we call bind function without adding LDAP handle to the collection. Then, if connection is established, LDAP library reports this event via callback function call. In that callback we add LDAP connection to the `_poll_fds` collection.
Thus if LDAP server is not available it is possible that we create LDAP handle and are trying to execute query on it before connection is established and before LDAP handle is placed into `_poll_fds`.
This fix is a workaround which allows us to correctly free LDAP resources in such case.