### PR TITLE
Update percona-server-mongodb-enable-auth.sh

### DIFF
--- a/percona-packaging/conf/percona-server-mongodb-enable-auth.sh
+++ b/percona-packaging/conf/percona-server-mongodb-enable-auth.sh
@@ -146,7 +146,7 @@ add_user_to_mongo() {
     port="$(get_value_from_yaml net port)"
     user="$USERNAME"
     password="$PASSWORD"
-    echo "db.createUser({user: \"$user\", pwd: \"$password\", roles: [ \"root\" ] });" | ${MONGO_CLIENT_BIN} -p $port localhost/admin
+    echo "db.createUser({user: \"$user\", pwd: \"$password\", roles: [ \"root\" ] });" | ${MONGO_CLIENT_BIN} -p ${port} localhost/admin
     if [ $? -eq 0 ];then
         echo -e "User has been created successfully!\nUser:${user}\nPassword:${password}"
     else


### PR DESCRIPTION
Fix usage of port variable. The current expression was hard-coding the port instead of correctly referencing the variable, so end result was a line like this:
```
    echo "db.createUser({user: \"$user\", pwd: \"$password\", roles: [ \"root\" ] });" | ${MONGO_CLIENT_BIN} admin --port 27017 --eval > /dev/null 2>&1
```