### PR TITLE
PSMDB-118: fix default audit file extension

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -49,13 +49,14 @@ mongod --auditDestination=file --auditFormat=BSON
 ### --auditPath
 
 This is the fully qualified path to the file you want the server to create.
-If this parameter is not specified then `auditLog.json` file will be created in server's configured log path.
+If this parameter is not specified then:
+ - The default file name will be `auditLog.json` or `auditLog.bson`, depending on whether the audit log format is `JSON` or `BSON`.
+ - If `--logpath` is provided, the file will be created in the parent directory of the log path.
+ - Otherwise, the file will be created in the current working directory.
 
 ```
 mongod --auditDestination=file --auditPath /var/log/tokumx/audit.json
 ```
-
-If log path is not configured then `auditLog.json` will be created in the current directory.
 
 **Note:** This file will rotate in the same manner as the system logpath, either on server reboot or 
 using the logRotate command. The time of the rotation will be added to old file’s name.

--- a/jstests/audit/audit_add_shard.js
+++ b/jstests/audit/audit_add_shard.js
@@ -11,7 +11,7 @@ auditTestShard(
     function(st) {
         let rsname = "testreplset";
         var port = allocatePorts(10)[9];
-        var conn1 = MongoRunner.runMongod({dbpath: '/data/db/' + jsTestName() + '-extraShard-' + port, port: port,  shardsvr: "", replSet: rsname});
+        var conn1 = MongoRunner.runMongod({dbpath: getDBPath() + '/' + jsTestName() + '-extraShard-' + port, port: port,  shardsvr: "", replSet: rsname});
         var hostandport = conn1.host;
         assert.commandWorked(conn1.adminCommand({
             replSetInitiate: {

--- a/jstests/audit/audit_config.js
+++ b/jstests/audit/audit_config.js
@@ -10,6 +10,13 @@ load(basePath + '/audit/_audit_helpers.js');
 
 var configFile = basePath + '/libs/config_files/audit_config.yaml';
 var configFileDeprecated = basePath + '/libs/config_files/audit_config_deprecated.yaml';
+var configFileBasic = basePath + '/libs/config_files/audit_config_basic.yaml';
+
+var defaultNameJson = 'auditLog.json'
+var defaultNameBson = 'auditLog.bson'
+var logPath = getDBPath() + '/server.log'
+var defaultPathJson = getDBPath() + '/' + defaultNameJson;
+var defaultPathBson = getDBPath() + '/' + defaultNameBson;
 
 auditTest(
     'auditConfig',
@@ -26,3 +33,55 @@ auditTest(
     },
     { config: configFileDeprecated }
 );
+
+// Default path for audit log:
+// format: JSON
+// no logpath provided
+removeFile(defaultNameJson)
+auditTest(
+    'defaultAuditPathJSONCwd',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultNameJson), true);
+    },
+    { config: configFileBasic, auditFormat: 'JSON' }
+)
+removeFile(defaultNameJson)
+
+// Default path for audit log:
+// format: BSON
+// no logpath provided
+removeFile(defaultNameBson)
+auditTest(
+    'defaultAuditPathBSONCwd',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultNameBson), true);
+    },
+    { config: configFileBasic, auditFormat: 'BSON' }
+)
+removeFile(defaultNameBson)
+
+// Default path for audit log:
+// format: JSON
+// logpath provided
+removeFile(defaultPathJson)
+auditTest(
+    'defaultAuditPathJSONLogpath',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultPathJson), true);
+    },
+    { config: configFileBasic, auditFormat: 'JSON', logpath: logPath }
+)
+removeFile(defaultPathJson)
+
+// Default path for audit log:
+// format: BSON
+// logpath provided
+removeFile(defaultPathBson)
+auditTest(
+    'defaultAuditPathBSONLogpath',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultPathBson), true);
+    },
+    { config: configFileBasic, auditFormat: 'BSON', logpath: logPath }
+)
+removeFile(defaultPathBson)

--- a/jstests/audit/audit_remove_shard.js
+++ b/jstests/audit/audit_remove_shard.js
@@ -11,7 +11,7 @@ auditTestShard(
     function(st) {
         let rsname = "testreplset";
         var port = allocatePorts(10)[9];
-        var conn1 = MongoRunner.runMongod({dbpath: '/data/db/' + jsTestName() + '-extraShard-' + port, port: port,  shardsvr: "", replSet: rsname});
+        var conn1 = MongoRunner.runMongod({dbpath: getDBPath() + '/' + jsTestName() + '-extraShard-' + port, port: port,  shardsvr: "", replSet: rsname});
 
         var hostandport = conn1.host;
         assert.commandWorked(conn1.adminCommand({

--- a/jstests/libs/config_files/audit_config_basic.yaml
+++ b/jstests/libs/config_files/audit_config_basic.yaml
@@ -1,0 +1,2 @@
+auditLog:
+  destination: file

--- a/src/mongo/db/audit/audit_options.cpp
+++ b/src/mongo/db/audit/audit_options.cpp
@@ -130,13 +130,18 @@ namespace mongo {
                            "Could not open a file for writing at the given auditPath: " +
                                auditOptions.path));
             }
-        } else if (!serverGlobalParams.logWithSyslog && !serverGlobalParams.logpath.empty()) {
-            auditOptions.path = (boost::filesystem::path(serverGlobalParams.logpath).parent_path() /
-                                 "auditLog.json")
-                                    .native();
         } else {
-            auditOptions.path =
-                (boost::filesystem::path(serverGlobalParams.cwd) / "auditLog.json").native();
+            const std::string defaultFilePath =
+                (auditOptions.format == "BSON") ? "auditLog.bson" : "auditLog.json";
+    
+            const bool useLogPathBase =
+                !serverGlobalParams.logWithSyslog && !serverGlobalParams.logpath.empty();
+    
+            const auto base = useLogPathBase
+                ? boost::filesystem::path(serverGlobalParams.logpath).parent_path()
+                : boost::filesystem::path(serverGlobalParams.cwd);
+    
+            auditOptions.path = (base / defaultFilePath).native();
         }
     }
 } // namespace mongo


### PR DESCRIPTION
If no auditPath option is provided, the default file extension should match the audit log format.
Add jstests for default audit log path.
Minor fix in audit tests.
Run clang-format on audit_option.cpp.
