### PR TITLE
PSMDB-1566: avoid copying string from stream in audit

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4033,6 +4033,35 @@ def doConfigure(myenv):
 
     conf.Finish()
 
+    def CheckBasicStringBufStrRvalue(context):
+        test_body = """
+        #include <sstream>
+        #include <string>
+
+        int main() {
+            std::stringstream ss("a very long string that exceeds the small string optimization buffer length");
+            std::string s = std::move(ss).str();
+            return ss.str().empty() ? 0 : -1;
+        }
+        """
+
+        context.Message('Checking if basic_stringbuf::str()&& overload exists...')
+        ret = context.TryRun(textwrap.dedent(test_body), ".cpp")
+        context.Result(ret[0])
+        return ret[0]
+
+    conf = Configure(
+        env,
+        custom_tests={
+            'CheckBasicStringBufStrRvalue': CheckBasicStringBufStrRvalue,
+        },
+    )
+
+    if conf.CheckBasicStringBufStrRvalue():
+        conf.env.SetConfigHeaderDefine("MONGO_CONFIG_HAVE_BASIC_STRINGBUF_STR_RVALUE")
+
+    conf.Finish()
+
     # C11 memset_s - a secure memset
     def CheckMemset_s(context):
         test_body = """

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -79,6 +79,7 @@ config_header_substs = (
     ('@mongo_config_glibc_rseq@', 'MONGO_CONFIG_GLIBC_RSEQ'),
     ('@mongo_config_tcmalloc_google@', 'MONGO_CONFIG_TCMALLOC_GOOGLE'),
     ('@mongo_config_tcmalloc_gperf@', 'MONGO_CONFIG_TCMALLOC_GPERF'),
+    ('@mongo_config_have_basic_stringbuf_str_rvalue@', 'MONGO_CONFIG_HAVE_BASIC_STRINGBUF_STR_RVALUE'),
     ('@percona_fipsmode_enabled@', 'PERCONA_FIPSMODE_ENABLED'),
 )
 

--- a/src/mongo/config.h.in
+++ b/src/mongo/config.h.in
@@ -121,3 +121,6 @@
 
 // FIPSMode enabled
 @percona_fipsmode_enabled@
+
+// Defined if basic_stringbuf::str()&& overload exists
+@mongo_config_have_basic_stringbuf_str_rvalue@

--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -278,7 +278,7 @@ private:
         // first, then repeatedly write to that position if we
         // have to retry.
         auto pos = _file->tellp();
-        auto data = _membuf.str();
+        auto data = std::move(_membuf).str();
         _membuf.str({});
 
         int writeRet;

--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -279,7 +279,13 @@ private:
         // have to retry.
         auto pos = _file->tellp();
         auto data = std::move(_membuf).str();
+#if !defined(MONGO_CONFIG_HAVE_BASIC_STRINGBUF_STR_RVALUE)
+        // Explicitly clear the buffer if the rvalue-qualified overload of str()
+        // (basic_stringbuf::str() &&) is not available.
+        // In that case, std::move(buf).str() calls the const lvalue-qualified overload,
+        // which returns a copy and leaves the buffer unchanged.
         _membuf.str({});
+#endif
 
         int writeRet;
         for (int retries = 10; retries > 0; --retries) {


### PR DESCRIPTION
Eliminate unneccessary copying of the string from the buffer when
flushing the audit log file. This is possible due to std::ostringstream
having a str() overload which is rvalue-ref qualified.
Added in C++20 p0408r7.