### PR TITLE
PSMDB-121: fix creating audit log when forking (v7.0)

### DIFF
--- a/jstests/audit/audit_config.js
+++ b/jstests/audit/audit_config.js
@@ -11,6 +11,7 @@ load(basePath + '/audit/_audit_helpers.js');
 var configFile = basePath + '/libs/config_files/audit_config.yaml';
 var configFileDeprecated = basePath + '/libs/config_files/audit_config_deprecated.yaml';
 var configFileBasic = basePath + '/libs/config_files/audit_config_basic.yaml';
+var configFileFork = basePath + '/libs/config_files/audit_config_fork.yaml';
 
 var defaultNameJson = 'auditLog.json'
 var defaultNameBson = 'auditLog.bson'
@@ -85,3 +86,15 @@ auditTest(
     { config: configFileBasic, auditFormat: 'BSON', logpath: logPath }
 )
 removeFile(defaultPathBson)
+
+// Test for creating audit log with relative path when forking.
+removeFile(defaultNameJson)
+auditTest(
+    'relativeAuditPathWhenForking',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultNameJson), true);        
+    },
+    { config: configFileFork, logpath: logPath}
+)
+
+removeFile(defaultNameJson)

--- a/jstests/libs/config_files/audit_config_fork.yaml
+++ b/jstests/libs/config_files/audit_config_fork.yaml
@@ -1,0 +1,5 @@
+auditLog:
+  destination: file
+  path: 'auditLog.json'
+processManagement:
+  fork: true


### PR DESCRIPTION
Fix creating audit log file if provided as a relative path when forking.