### PR TITLE
PSMDB-1282: support 'security.kmip.useLegacyProtocol' 

### DIFF
--- a/src/mongo/db/mongod_options.cpp
+++ b/src/mongo/db/mongod_options.cpp
@@ -571,6 +571,14 @@ Status storeMongodOptions(const moe::Environment& params) {
             params["security.kmip.keyStatePollingSeconds"].as<int>();
     }
 
+    if (params.count("security.kmip.useLegacyProtocol")) {
+        LOGV2_WARNING_OPTIONS(
+            29119,
+            {logv2::LogTag::kStartupWarnings},
+            "The security.kmip.useLegacyProtocol option was specified, but it has no effect. "
+            "KMIP protocol version 1.0 is always used.");
+    }
+
     if (params.count("security.ldap.authz.queryTemplate")) {
         ldapGlobalParams.ldapQueryTemplate = params["security.ldap.authz.queryTemplate"].as<std::string>();
     }

--- a/src/mongo/db/mongod_options_encryption.idl
+++ b/src/mongo/db/mongod_options_encryption.idl
@@ -239,3 +239,10 @@ configs:
         short_name: kmipKeyStatePollingSeconds
         arg_vartype: Int
         requires: 'security.kmip.serverName'
+
+    'security.kmip.useLegacyProtocol':
+        description: >-
+            This option is supported for compatibility but has no effect.
+            KMIP protocol version 1.0 is always used.
+        short_name: kmipUseLegacyProtocol
+        arg_vartype: Bool


### PR DESCRIPTION
Accept the 'security.kmip.useLegacyProtocol' option and print warning message is used, because the KMIP protocol version 1.0 is always used.