### PR TITLE
PSMDB-1620: avoid creating empty audit log file (v6.0)

### DIFF
--- a/jstests/audit/audit_config.js
+++ b/jstests/audit/audit_config.js
@@ -92,9 +92,20 @@ removeFile(defaultNameJson)
 auditTest(
     'relativeAuditPathWhenForking',
     function(m, restartServer) {
-        assert.eq(fileExists(defaultNameJson), true);        
+        assert.eq(fileExists(defaultNameJson), true);
     },
     { config: configFileFork, logpath: logPath}
 )
 
 removeFile(defaultNameJson)
+
+// Destination: console
+// Expect no file created
+removeFile(defaultNameJson)
+auditTest(
+    'destinationConsoleNoAuditFileCreated',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultNameJson), false);
+    },
+    { config: configFileBasic, auditDestination: 'console' }
+)

--- a/src/mongo/db/audit/audit_options.cpp
+++ b/src/mongo/db/audit/audit_options.cpp
@@ -112,6 +112,11 @@ namespace mongo {
     }
 
     Status validateAuditOptions() {
+        if (!auditOptions.destination.empty() && auditOptions.destination != "file") {
+            // no validation needed if destination is not to a file
+            return Status::OK();
+        }
+
         auto getAbsolutePath = [](auto const& p) {
             return boost::filesystem::absolute(p, serverGlobalParams.cwd).native();
         };

--- a/src/mongo/db/audit/audit_options_test.cpp
+++ b/src/mongo/db/audit/audit_options_test.cpp
@@ -218,5 +218,59 @@ TEST_F(ValidateAuditOptionsTestFixture, DestinationFile_CustomPath_Fork) {
     ASSERT_TRUE(fs::exists(cwd / path));
 }
 
+// Test file is not created if destination is console
+TEST_F(ValidateAuditOptionsTestFixture, DestinationConsole_FileNotCreated) {
+
+    moe::Environment env;
+    set(env, "auditLog.destination", "console");
+
+    ASSERT_OK(storeAuditOptions(env));
+    ASSERT_OK(validateAuditOptions());
+    ASSERT_FALSE(fs::exists(kDefaultPathBson));
+    ASSERT_FALSE(fs::exists(kDefaultPathJson));
+}
+
+// Test file is not created if destination is console and path is provided
+TEST_F(ValidateAuditOptionsTestFixture, DestinationConsole_PathProvided_FileNotCreated) {
+    const auto path = "auditFileName.json";
+
+    moe::Environment env;
+    set(env, "auditLog.destination", "console");
+    set(env, "auditLog.path", path);
+
+    ASSERT_OK(storeAuditOptions(env));
+    ASSERT_OK(validateAuditOptions());
+    ASSERT_FALSE(fs::exists(path));
+    ASSERT_FALSE(fs::exists(kDefaultPathBson));
+    ASSERT_FALSE(fs::exists(kDefaultPathJson));
+}
+
+// Test file is not created if destination is syslog
+TEST_F(ValidateAuditOptionsTestFixture, DestinationSyslog_FileNotCreated) {
+
+    moe::Environment env;
+    set(env, "auditLog.destination", "syslog");
+
+    ASSERT_OK(storeAuditOptions(env));
+    ASSERT_OK(validateAuditOptions());
+    ASSERT_FALSE(fs::exists(kDefaultPathBson));
+    ASSERT_FALSE(fs::exists(kDefaultPathJson));
+}
+
+// Test file is not created if destination is syslog and path is provided
+TEST_F(ValidateAuditOptionsTestFixture, DestinationSyslog_PathProvided_FileNotCreated) {
+    const auto path = "auditFileName.json";
+
+    moe::Environment env;
+    set(env, "auditLog.destination", "syslog");
+    set(env, "auditLog.path", path);
+
+    ASSERT_OK(storeAuditOptions(env));
+    ASSERT_OK(validateAuditOptions());
+    ASSERT_FALSE(fs::exists(path));
+    ASSERT_FALSE(fs::exists(kDefaultPathBson));
+    ASSERT_FALSE(fs::exists(kDefaultPathJson));
+}
+
 }  // namespace
 }  // namespace mongo


### PR DESCRIPTION
Do not create an audit log file during audit options validations in if the destination is not to a file. This avoids creating an empty file.