### PR TITLE
PSMDB-1621: fix creating audit file if disabled (release-6.0.21-18)

### DIFF
--- a/jstests/audit/audit_config.js
+++ b/jstests/audit/audit_config.js
@@ -12,6 +12,8 @@ var configFile = basePath + '/libs/config_files/audit_config.yaml';
 var configFileDeprecated = basePath + '/libs/config_files/audit_config_deprecated.yaml';
 var configFileBasic = basePath + '/libs/config_files/audit_config_basic.yaml';
 var configFileFork = basePath + '/libs/config_files/audit_config_fork.yaml';
+var configFileEmpty = basePath + '/libs/config_files/audit_config_empty.yaml';
+var configFileDestinationEmpty = basePath + '/libs/config_files/audit_config_destination_empty.yaml';
 
 var defaultNameJson = 'auditLog.json'
 var defaultNameBson = 'auditLog.bson'
@@ -108,4 +110,30 @@ auditTest(
         assert.eq(fileExists(defaultNameJson), false);
     },
     { config: configFileBasic, auditDestination: 'console' }
+)
+
+// Destination: not defined
+// Expect no file created
+removeFile(defaultNameJson)
+removeFile(defaultNameBson)
+auditTest(
+    'destinationNotDefinedNoAuditFileCreated',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultNameJson), false);
+        assert.eq(fileExists(defaultNameBson), false);
+    },
+    { config: configFileEmpty }
+)
+
+// Destination: ''
+// Expect no file created
+removeFile(defaultNameJson)
+removeFile(defaultNameBson)
+auditTest(
+    'destinationEmptyNoAuditFileCreated',
+    function(m, restartServer) {
+        assert.eq(fileExists(defaultNameJson), false);
+        assert.eq(fileExists(defaultNameBson), false);
+    },
+    { config: configFileDestinationEmpty }
 )

--- a/jstests/libs/config_files/audit_config_destination_empty.yaml
+++ b/jstests/libs/config_files/audit_config_destination_empty.yaml
@@ -1,0 +1,2 @@
+auditLog:
+  destination: ''

--- a/jstests/libs/config_files/audit_config_empty.yaml
+++ b/jstests/libs/config_files/audit_config_empty.yaml
@@ -1,0 +1,1 @@
+# empty on purpose

--- a/src/mongo/db/audit/audit_options.cpp
+++ b/src/mongo/db/audit/audit_options.cpp
@@ -112,8 +112,8 @@ namespace mongo {
     }
 
     Status validateAuditOptions() {
-        if (!auditOptions.destination.empty() && auditOptions.destination != "file") {
-            // no validation needed if destination is not to a file
+        if (auditOptions.destination != "file") {
+            // no validation needed if audit is disabled or destination is not to a file
             return Status::OK();
         }
 

--- a/src/mongo/db/audit/audit_options_test.cpp
+++ b/src/mongo/db/audit/audit_options_test.cpp
@@ -109,8 +109,21 @@ TEST_F(ValidateAuditOptionsTestFixture, Default) {
 
     ASSERT_OK(storeAuditOptions(env));
     ASSERT_OK(validateAuditOptions());
-    ASSERT_EQ(auditOptions.path, getCwd() / kDefaultPathJson);
-    ASSERT_TRUE(fs::exists(kDefaultPathJson));
+    // expect no file created if 'destination' is not set
+    ASSERT_FALSE(fs::exists(kDefaultPathJson));
+    ASSERT_FALSE(fs::exists(kDefaultPathBson));
+}
+
+// Test destination is set to empty string
+TEST_F(ValidateAuditOptionsTestFixture, DestinationEmptyString) {
+    moe::Environment env;
+    set(env, "auditLog.destination", "");
+
+    ASSERT_OK(storeAuditOptions(env));
+    ASSERT_OK(validateAuditOptions());
+    // expect no file created if 'destination' is empty string
+    ASSERT_FALSE(fs::exists(kDefaultPathJson));
+    ASSERT_FALSE(fs::exists(kDefaultPathBson));
 }
 
 // Test BSON format with default path


### PR DESCRIPTION
Fix creating audit log file if destination is not set. In such case audit is disabled and thus the default file path shall not be validated for permissions.