### PR TITLE
PSMDB-1728 Improve logging and testing

### DIFF
--- a/jstests/oidc/auth_issuers_no_human_flows.js
+++ b/jstests/oidc/auth_issuers_no_human_flows.js
@@ -56,6 +56,7 @@ const expectedLog = {
     id: 5286307,
     msg: "Failed to authenticate",
     attr: {
+        mechanism: "MONGODB-OIDC",
         error: "BadValue: None of configured identity providers support human flows"
     }
 };

--- a/jstests/oidc/lib/oidc_fixture.js
+++ b/jstests/oidc/lib/oidc_fixture.js
@@ -373,9 +373,14 @@ export class OIDCFixture {
      * Check if the expected log exists in the global log.
      *
      * @param {object} expectedLog - The expected log object to check for.
+     * @param {boolean} advanceLogCutOffTimePoint - whether the function should also advance the log
+     *     cut-off time point to the time point of the expected log entry if the latter is found.
+     *     Default is `true`. Note: log entries older than the cut-off time point are not considered
+     *     at the subsequent calls of the function.
+     *
      * @returns True if the expected log exists, false otherwise.
      */
-    checkLogExists(expectedLog) {
+    checkLogExists(expectedLog, advanceLogCutOffTimePoint = true) {
         const logs =
             assert.commandWorked(this.admin.runCommand({ getLog: "global" })).log.map(element => JSON.parse(element));
 
@@ -383,7 +388,7 @@ export class OIDCFixture {
             new Date(element["t"]["$date"]);
         });
 
-        if (result.res) {
+        if (result.res && advanceLogCutOffTimePoint) {
             this.last_log_date = result.lastDate;
         }
 

--- a/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
+++ b/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
@@ -41,13 +41,9 @@ Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/auth/oidc_protocol_gen.h"
 #include "mongo/db/auth/sasl_mechanism_registry.h"
 #include "mongo/db/server_parameter.h"
-#include "mongo/logv2/log.h"
-#include "mongo/logv2/log_attr.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/duration.h"
 #include "mongo/util/time_support.h"
-
-#define MONGO_LOGV2_DEFAULT_COMPONENT ::mongo::logv2::LogComponent::kAccessControl
 
 namespace mongo {
 namespace {
@@ -122,8 +118,6 @@ StatusWith<std::tuple<bool, std::string>> SaslOidcServerMechanism::step1(
 
     auto principalName = request.getPrincipalName().map(
         [](const auto& str) -> std::string_view { return std::string_view{str}; });
-
-    LOGV2(77012, "OIDC step 1", "principalName"_attr = principalName.value_or("none"));
 
     // If there are more than one IdP with human flows support, the client must provide a principal
     // name to choose a specific IdP. If there is only one IdP with human flows support, the client
@@ -209,8 +203,6 @@ StatusWith<std::tuple<bool, std::string>> SaslOidcServerMechanism::step2(
 
     processAuthorizationClaim(*idp, token);
     processLogClaims(*idp, token);
-
-    LOGV2(77012, "OIDC step 2", "principalName"_attr = _principalName, "roles"_attr = _roles);
 
     // authentication succeeded
     return std::tuple{true, std::string{}};

--- a/src/mongo/db/auth/oidc/oidc_commands_test.cpp
+++ b/src/mongo/db/auth/oidc/oidc_commands_test.cpp
@@ -29,6 +29,7 @@ Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
     it in the license file.
 ======= */
 
+#include "mongo/bson/bsonmisc.h"
 #include "mongo/db/audit_interface.h"
 #include "mongo/db/auth/authorization_session_for_test.h"
 #include "mongo/db/auth/authz_manager_external_state_mock.h"
@@ -74,12 +75,9 @@ protected:
     }
 
     // wrapepr for running the command, returns the status with optional BSON result
-    StatusWith<boost::optional<BSONObj>> runCmd() try {
+    StatusWith<BSONObj> runCmd() try {
         BSONObjBuilder result;
-        if (!cmd().run(operationContext(), _dbName, createCmdObj(), result)) {
-            return boost::none;
-        }
-
+        cmd().run(operationContext(), _dbName, createCmdObj(), result);
         return result.obj();
     } catch (const DBException& e) {
         return e.toStatus();
@@ -167,14 +165,9 @@ TEST_F(OidcRefreshKeysTest, AuthorizationPositive) {
 
 // Test for the oidcListKeys command with no JWK managers.
 TEST_F(OidcListKeysTest, Run_NoJWKManagers) {
-    const auto status = runCmd();
-    ASSERT_OK(status);
-
-    const auto result = status.getValue();
-    ASSERT_TRUE(result.has_value());
-
-    const auto& keySets = result->getField("keySets");
-    ASSERT_TRUE(keySets.ok());
+    const auto result = runCmd();
+    ASSERT_OK(result);
+    const auto& keySets = result.getValue().getField("keySets");
     ASSERT_EQ(keySets.type(), BSONType::Object);
     ASSERT_TRUE(keySets.Obj().isEmpty());
 }
@@ -208,15 +201,13 @@ TEST_F(OidcListKeysTest, Run) {
     registryMock().setJWKManager(issuer2, jwkManager2);
 
     // Run the oidcListKeys command
-    const auto status = runCmd();
-    ASSERT_OK(status);
-
-    const auto result = status.getValue();
+    const auto result = runCmd();
+    ASSERT_OK(result);
 
     // Check the format of the result
 
     // Check if the keySets field exists.
-    const auto& keySets = result->getField("keySets");
+    const auto& keySets = result.getValue().getField("keySets");
     ASSERT_TRUE(keySets.ok());
     ASSERT_EQ(keySets.type(), BSONType::Object);
 
@@ -282,7 +273,31 @@ TEST_F(OidcRefreshKeysTest, Run_OneJwkManager_Failed) {
         issuer,
         std::make_shared<crypto::JWKManager>(jwksFetcherFactoryMock.makeJWKSFetcher(issuer)));
 
-    ASSERT_NOT_OK(runCmd());
+    const StatusWith<BSONObj> result{runCmd()};
+    // the command finishes successfully but returns an error
+    ASSERT_OK(result);
+
+    const BSONElement okField{result.getValue().getField("ok")};
+    ASSERT_EQ(okField.type(), BSONType::NumberInt);
+    ASSERT_EQ(okField.numberInt(), 0);
+
+    const BSONElement errmsgField{result.getValue().getField("errmsg")};
+    ASSERT_EQ(errmsgField.type(), BSONType::String);
+    ASSERT_EQ(errmsgField.str(), "Failed to load a JWKS from one or more IdPs");
+
+    const BSONElement failuresField{result.getValue().getField("failures")};
+    ASSERT_EQ(failuresField.type(), BSONType::Array);
+    std::vector<BSONElement> failures{failuresField.Array()};
+    ASSERT_EQ(failures.size(), 1);
+    ASSERT_EQ(failures[0].type(), BSONType::Object);
+
+    const BSONObj expectedFailure{
+        BSON("issuer" << issuer << "error"
+                      << BSON("code" << 211 << "codeName" << "KeyNotFound" << "errmsg"
+                                     << std::string("No JWK for issuer ") + issuer))};
+    const BSONObj::ComparisonRulesSet rules{BSONObj::ComparatorInterface::kConsiderFieldName |
+                                            BSONObj::ComparatorInterface::kIgnoreFieldOrder};
+    ASSERT_EQ(failures[0].Obj().woCompare(expectedFailure, {}, rules), 0);
 }
 
 // Test for oidcRefreshKeys command with multiple JWK managers:
@@ -311,9 +326,42 @@ TEST_F(OidcRefreshKeysTest, Run_MultipleJwkManagers_Failed) {
     // set the JWKSet for the last issuer
     jwksFetcherFactoryMock.setJWKSet(issuer3, crypto::JWKSet{{create_sample_jwk("kid")}});
 
-    ASSERT_NOT_OK(runCmd());
+    const StatusWith<BSONObj> result{runCmd()};
+    // the command finishes successfully but returns an error
+    ASSERT_OK(result);
 
-    // first two JWK fetchers failed, the last one should succed once
+    const BSONElement okField{result.getValue().getField("ok")};
+    ASSERT_EQ(okField.type(), BSONType::NumberInt);
+    ASSERT_EQ(okField.numberInt(), 0);
+
+    const BSONElement errmsgField{result.getValue().getField("errmsg")};
+    ASSERT_EQ(errmsgField.type(), BSONType::String);
+    ASSERT_EQ(errmsgField.str(), "Failed to load a JWKS from one or more IdPs");
+
+    // the first two JWK fetchers failed
+    const BSONElement failuresField{result.getValue().getField("failures")};
+    ASSERT_EQ(failuresField.type(), BSONType::Array);
+    std::vector<BSONElement> failures{failuresField.Array()};
+    ASSERT_EQ(failures.size(), 2);
+    ASSERT_EQ(failures[0].type(), BSONType::Object);
+    ASSERT_EQ(failures[1].type(), BSONType::Object);
+
+    auto expectedFailure = [](const std::string issuer) {
+        return BSON("issuer" << issuer << "error"
+                             << BSON("code" << 211 << "codeName" << "KeyNotFound" << "errmsg"
+                                            << std::string("No JWK for issuer ") + issuer));
+    };
+    auto failureEq = [](const BSONObj& lhs, const BSONObj& rhs) {
+        const BSONObj::ComparisonRulesSet rules{BSONObj::ComparatorInterface::kConsiderFieldName |
+                                                BSONObj::ComparatorInterface::kIgnoreFieldOrder};
+        return lhs.woCompare(rhs, {}, rules) == 0;
+    };
+    ASSERT_TRUE(failureEq(failures[0].Obj(), expectedFailure(issuer1)) &&
+                    failureEq(failures[1].Obj(), expectedFailure(issuer2)) ||
+                failureEq(failures[0].Obj(), expectedFailure(issuer2)) &&
+                    failureEq(failures[1].Obj(), expectedFailure(issuer1)));
+
+    // the third JWK fetcher succeded once
     ASSERT_EQ(jwksFetcherFactoryMock.getFetchCount(issuer3), 1);
 }
 

--- a/src/mongo/db/auth/oidc/oidc_identity_providers_registry.cpp
+++ b/src/mongo/db/auth/oidc/oidc_identity_providers_registry.cpp
@@ -38,8 +38,6 @@ Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/service_context.h"
 #include "mongo/util/assert_util_core.h"
 
-#define MONGO_LOGV2_DEFAULT_COMPONENT ::mongo::logv2::LogComponent::kDefault
-
 namespace mongo {
 
 namespace {

--- a/src/mongo/db/auth/oidc/oidc_identity_providers_registry_impl.cpp
+++ b/src/mongo/db/auth/oidc/oidc_identity_providers_registry_impl.cpp
@@ -39,7 +39,7 @@ Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/util/assert_util_core.h"
 #include "mongo/util/periodic_runner.h"
 
-#define MONGO_LOGV2_DEFAULT_COMPONENT ::mongo::logv2::LogComponent::kDefault
+#define MONGO_LOGV2_DEFAULT_COMPONENT ::mongo::logv2::LogComponent::kControl
 
 namespace mongo {
 

--- a/src/mongo/db/auth/oidc/oidc_server_parameters.cpp
+++ b/src/mongo/db/auth/oidc/oidc_server_parameters.cpp
@@ -109,7 +109,7 @@ public:
     ///     a particular issuer
     void verifyAllIssuerOccurrencesShareCommonValue() const {
         for (const auto& [issuer, info] : _infos) {
-            uassert(77708,
+            uassert(ErrorCodes::BadValue,
                     errorMsgHeader(info.indexes)
                         << "`" << _fiedlName << "` values are different for the same `issuer` (`"
                         << issuer << "`). `" << _fiedlName << "` should be the same for each "
@@ -134,20 +134,20 @@ void validate(const OidcIdentityProviderConfig& conf, std::size_t index) {
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"};
     auto authNamePrefix{static_cast<std::string_view>(conf.getAuthNamePrefix())};
     if (auto pos{authNamePrefix.find_first_not_of(kLegalChars)}; pos != std::string_view::npos) {
-        uasserted(77702,
+        uasserted(ErrorCodes::BadValue,
                   errorMsgHeader(std::views::single(index))
                       << "`" << OidcIdentityProviderConfig::kAuthNamePrefixFieldName
                       << "` contains illegal char `" << authNamePrefix[pos]
                       << "`. Only [a-zA-Z0-9_-] are allowed.");
     }
-    uassert(77703,
+    uassert(ErrorCodes::BadValue,
             errorMsgHeader(std::views::single(index))
                 << "`" << OidcIdentityProviderConfig::kClientIdFieldName << "` must present if `"
                 << OidcIdentityProviderConfig::kSupportsHumanFlowsFieldName
                 << "` is `true`, which is the default.",
             conf.getSupportsHumanFlows() ? static_cast<bool>(conf.getClientId()) : true);
     uassert(
-        77704,
+        ErrorCodes::BadValue,
         errorMsgHeader(std::views::single(index))
             << "`" << OidcIdentityProviderConfig::kAuthorizationClaimFieldName
             << "` must present if `" << OidcIdentityProviderConfig::kUseAuthorizationClaimFieldName
@@ -186,7 +186,7 @@ void validate(const OidcIdentityProvidersServerParameter& param) {
     }
 
     for (std::size_t i{0u}; i < matchPatternIndexes.size(); ++i) {
-        uassert(77705,
+        uassert(ErrorCodes::BadValue,
                 errorMsgHeader(std::views::iota(i, matchPatternIndexes[i]))
                     << "configurations without the `matchPattern` field "
                     << "must be listed after those with the `matchPattern` field",
@@ -197,7 +197,7 @@ void validate(const OidcIdentityProvidersServerParameter& param) {
         std::ranges::set_difference(humanFlowsIndexes,
                                     matchPatternIndexes,
                                     std::back_inserter(humanFlowsNoMatchPatternIndexes));
-        uassert(77706,
+        uassert(ErrorCodes::BadValue,
                 errorMsgHeader(humanFlowsNoMatchPatternIndexes)
                     << "`supportsHumanFlows` enabled but there is no `matchPattern`. "
                     << "If more that one configuration has `supportsHumanFlow` enabled, "
@@ -205,7 +205,7 @@ void validate(const OidcIdentityProvidersServerParameter& param) {
                 humanFlowsNoMatchPatternIndexes.empty());
     }
     for (const auto& [issAud, indexes] : equalAudienceIndexes) {
-        uassert(77707,
+        uassert(ErrorCodes::BadValue,
                 errorMsgHeader(indexes)
                     << "`issuer` values are equal (`" << issAud.issuer
                     << "`) and `audience` values are also eqaul (`" << issAud.audience


### PR DESCRIPTION
- `src/mongo/db/auth/oidc/oidc_server_parameters.cpp`:
  - remove custom uassert IDs; they are ignored anyway while constructing an error message about the `oidcIdentityProviders` server parameter
- `src/mongo/db/auth/oidc/oidc_identity_providers_registry.cpp`:
  - remove the unused log component definition
- `src/mongo/db/auth/oidc/oidc_identity_providers_registry_impl.cpp`:
  - use more specific log component
- `src/mongo/db/auth/oidc/oidc_commands.cpp`:
  - use more specific log component
  - provide detailed error description in the command's response
- `src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp`:
  - remove unnecessary logging that can potentially compromise security
- test the command response and log messages on failure