### PR TITLE
PSMDB-1643: update build instructions for AWS SDK (v6.0)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -179,7 +179,13 @@ Debian/Ubuntu
 
       .. code:: sh   
 
-      cd aws-sdk-cpp && git checkout 1.9.379 && git submodule update --init --recursive
+         cd aws-sdk-cpp && git checkout 1.9.379 && git submodule update --init --recursive
+
+   -  Apply a patch to fix build failure with libcurl >= 7.87.0
+
+      .. code:: sh
+
+         curl -L https://github.com/aws/aws-sdk-cpp/commit/0fba9f908d7ddc30aceab69b939f997330a44bb3.patch | git apply
 
    -  It is recommended to keep build files outside the SDK directory.
       Create a build directory and navigate to it


### PR DESCRIPTION
Update the build instructions for the AWS SDK to include an additional step applying a patch that fixes a build failure in `CurlHttpClient.cpp` on systems with libcurl ≥ 7.87.0.

The issue is caused by the use of the deprecated `CURLOPT_PUT` option, which triggers a warning or error with newer libcurl versions. The patch replaces it with `CURLOPT_UPLOAD` where supported.
