### PR TITLE
PSMDB-1738: fix reacquiring invalidated OIDC user

### DIFF
--- a/src/mongo/db/auth/authorization_manager_impl.cpp
+++ b/src/mongo/db/auth/authorization_manager_impl.cpp
@@ -540,8 +540,7 @@ StatusWith<UserHandle> AuthorizationManagerImpl::reacquireUser(OperationContext*
     // necessary now to preserve the mechanismData from the original UserRequest while eliminating
     // the roles. If the roles aren't reset to none, it will cause LDAP acquisition to be bypassed
     // in favor of reusing the ones from before.
-    UserRequest requestWithoutRoles(user->getUserRequest());
-    requestWithoutRoles.roles = boost::none;
+    UserRequest requestWithoutRoles = user->getUserRequest().cloneForReacquire();
     auto swUserHandle = acquireUser(opCtx, requestWithoutRoles);
     if (!swUserHandle.isOK()) {
         return swUserHandle.getStatus();
@@ -614,7 +613,7 @@ Status AuthorizationManagerImpl::refreshExternalUsers(OperationContext* opCtx) {
     // insertOrAssign if they differ.
     bool isRefreshed{false};
     for (const auto& cachedUser : cachedUsers) {
-        UserRequest request(cachedUser->getName(), boost::none);
+        UserRequest request = cachedUser->getUserRequest().cloneForReacquire();
         auto storedUserStatus = _externalState->getUserObject(
             opCtx, request, CurOp::get(opCtx)->getUserAcquisitionStats());
         if (!storedUserStatus.isOK()) {

--- a/src/mongo/db/auth/authorization_manager_test.cpp
+++ b/src/mongo/db/auth/authorization_manager_test.cpp
@@ -673,5 +673,75 @@ TEST_F(AuthorizationManagerTest, testLogTenantInvalidateInWuowAbandon) {
     assertInvalidateCounts(0, 0, 0);
 }
 
+TEST_F(AuthorizationManagerTest, testReacquireUserOIDC) {
+    std::set<RoleName> roles({{"group1", "admin"}, {"group2", "admin"}});
+    UserName userName("prefix/user", "$external");
+    UserRequest userRequest(userName, roles);
+    userRequest.mechanismData = "OIDC";
+    userRequest.reacquireRoles = roles;
+
+    // Simulate acquiring the user for the first time.
+    auto swUser = authzManager->acquireUser(opCtx.get(), userRequest);
+    ASSERT_OK(swUser.getStatus());
+    auto user = std::move(swUser.getValue());
+    ASSERT(user.isValid());
+    ASSERT_EQUALS(user->getName(), userName);
+    for (auto& r : roles) {
+        ASSERT_TRUE(user->hasRole(r));
+    }
+
+    {
+        auto cacheInfo = authzManager->getUserCacheInfo();
+        ASSERT_EQ(cacheInfo.size(), 1U);
+        ASSERT_EQ(cacheInfo[0].userName, userName);
+        ASSERT_TRUE(cacheInfo[0].active);
+    }
+
+    authzManager->invalidateUserCache();
+
+    {
+        auto cacheInfo = authzManager->getUserCacheInfo();
+        ASSERT_EQ(cacheInfo.size(), 0U);
+    }
+
+    auto reacquiredUser = authzManager->reacquireUser(opCtx.get(), user);
+    ASSERT_OK(reacquiredUser.getStatus());
+    auto reacquiredUserHandle = std::move(reacquiredUser.getValue());
+    ASSERT(reacquiredUserHandle.isValid());
+    ASSERT_EQUALS(reacquiredUserHandle->getName(), userName);
+    for (auto& r : roles) {
+        ASSERT_TRUE(reacquiredUserHandle->hasRole(r));
+    }
+}
+
+TEST_F(AuthorizationManagerTest, testRefreshExternalUsers) {
+    std::set<RoleName> roles({{"group1", "admin"}, {"group2", "admin"}});
+    UserName userName("prefix/user", "$external");
+    UserRequest userRequest(userName, roles);
+    userRequest.mechanismData = "OIDC";
+    userRequest.reacquireRoles = roles;
+
+    // Simulate acquiring the user for the first time.
+    auto swUser = authzManager->acquireUser(opCtx.get(), userRequest);
+    ASSERT_OK(swUser.getStatus());
+    auto user = std::move(swUser.getValue());
+    ASSERT(user.isValid());
+    ASSERT_EQUALS(user->getName(), userName);
+    for (auto& r : roles) {
+        ASSERT_TRUE(user->hasRole(r));
+    }
+
+    {
+        auto cacheInfo = authzManager->getUserCacheInfo();
+        ASSERT_EQ(cacheInfo.size(), 1U);
+        ASSERT_EQ(cacheInfo[0].userName, userName);
+        ASSERT_TRUE(cacheInfo[0].active);
+    }
+
+    auto cacheGeneration = authzManager->getCacheGeneration();
+    ASSERT_OK(authzManager->refreshExternalUsers(opCtx.get()));
+    ASSERT_EQ(authzManager->getCacheGeneration(), cacheGeneration);
+}
+
 }  // namespace
 }  // namespace mongo

--- a/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
+++ b/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
@@ -317,7 +317,10 @@ void SaslOidcServerMechanism::processLogClaims(const OidcIdentityProviderConfig&
 }
 
 UserRequest SaslOidcServerMechanism::getUserRequest() const {
-    return UserRequest{UserName{getPrincipalName(), getAuthenticationDatabase()}, _roles};
+    UserRequest req{UserName{getPrincipalName(), getAuthenticationDatabase()}, _roles};
+    req.mechanismData = std::string(UserRequest::MechanismDataOIDC);
+    req.reacquireRoles = _roles;
+    return req;
 }
 
 boost::optional<Date_t> SaslOidcServerMechanism::getExpirationTime() const {

--- a/src/mongo/db/auth/user.h
+++ b/src/mongo/db/auth/user.h
@@ -67,6 +67,8 @@ namespace mongo {
  * This type is hashable and may be used as a key describing requests
  */
 struct UserRequest {
+    static constexpr auto MechanismDataOIDC = "OIDC"_sd;
+
     UserRequest(UserName name, boost::optional<std::set<RoleName>> roles)
         : name(std::move(name)), roles(std::move(roles)) {}
 
@@ -94,10 +96,24 @@ struct UserRequest {
         return equalityLens() != key.equalityLens();
     }
 
+    UserRequest cloneForReacquire() const {
+        UserRequest clonedRequest{*this};
+        if (clonedRequest.mechanismData == MechanismDataOIDC) {
+            clonedRequest.roles = reacquireRoles;
+        } else {
+            // For all other mechanisms, we do not want to reacquire roles.
+            clonedRequest.roles = boost::none;
+        }
+        return clonedRequest;
+    }
+
     // The name of the requested user
     UserName name;
     // Any authorization grants which should override and be used in favor of roles acquisition.
     boost::optional<std::set<RoleName>> roles;
+
+    // Any authorization grants which shall be used during User reacquisition.
+    boost::optional<std::set<RoleName>> reacquireRoles;
 
     // Mechanism specific metadata which may be used during User acquisition.
     std::string mechanismData;


### PR DESCRIPTION
Make sure the user gets the roles from the authorization claim when user is reacquired after invalidting the user cache.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
