### PR TITLE
PSMDB-1738: fix reacquiring invalidated OIDC user

### DIFF
--- a/src/mongo/db/auth/authorization_manager_impl.cpp
+++ b/src/mongo/db/auth/authorization_manager_impl.cpp
@@ -517,8 +517,7 @@ StatusWith<UserHandle> AuthorizationManagerImpl::reacquireUser(OperationContext*
     // necessary now to preserve the mechanismData from the original UserRequest while eliminating
     // the roles. If the roles aren't reset to none, it will cause LDAP acquisition to be bypassed
     // in favor of reusing the ones from before.
-    UserRequest requestWithoutRoles(user->getUserRequest());
-    requestWithoutRoles.roles = boost::none;
+    UserRequest requestWithoutRoles = user->getUserRequest().cloneForReacquire();
     auto swUserHandle = acquireUser(opCtx, requestWithoutRoles);
     if (!swUserHandle.isOK()) {
         return swUserHandle.getStatus();
@@ -594,7 +593,7 @@ Status AuthorizationManagerImpl::refreshExternalUsers(OperationContext* opCtx) {
     // insertOrAssign if they differ.
     bool isRefreshed{false};
     for (const auto& cachedUser : cachedUsers) {
-        UserRequest request(cachedUser->getName(), boost::none);
+        UserRequest request = cachedUser->getUserRequest().cloneForReacquire();
         auto storedUserStatus = _externalState->getUserObject(opCtx, request);
         if (!storedUserStatus.isOK()) {
             // If the user simply is not found, then just invalidate the cached user and continue.

--- a/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
+++ b/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
@@ -318,7 +318,10 @@ void SaslOidcServerMechanism::processLogClaims(const OidcIdentityProviderConfig&
 }
 
 UserRequest SaslOidcServerMechanism::getUserRequest() const {
-    return UserRequest{UserName{getPrincipalName(), getAuthenticationDatabase()}, _roles};
+    UserRequest req{UserName{getPrincipalName(), getAuthenticationDatabase()}, _roles};
+    req.mechanismData = std::string(UserRequest::MechanismDataOIDC);
+    req.reacquireRoles = _roles;
+    return req;
 }
 
 boost::optional<Date_t> SaslOidcServerMechanism::getExpirationTime() const {


### PR DESCRIPTION
Make sure the user gets the roles from the authorization claim when user is reacquired after invalidting the user cache.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
