### PR TITLE
PSMDB-1745: fix audit log rotation in reopen mode

### DIFF
--- a/jstests/audit/audit_log_rotate.js
+++ b/jstests/audit/audit_log_rotate.js
@@ -64,3 +64,44 @@ auditTest(
     // Need to enable the logging manager by passing `logpath'
     { logpath: logDir + '/server.log' }
 );
+
+auditTest(
+    'logRotateReopen',
+    function(m) {
+        var auditOptions = m.adminCommand({ auditGetOptions: 1 });
+        var auditPath = auditOptions.path;
+        assert.eq(true, auditPath == logDir + '/auditLog.json',
+                  "test assumption failure: auditPath is not logDir + auditLog.json? " +
+                  auditPath);
+
+        // Remove the audit log that got rotated on startup
+        getRotatedLogFilePaths(auditPath).forEach(function (f) { removeFile(f) });
+
+        const beforeCmd = Date.now();
+        // This should generate a few new audit log entries on ns 'test.foo'
+        testDB = m.getDB(testDBName);
+        assert.commandWorked(testDB.createCollection('foo'));
+        assert(testDB.getCollection('foo').drop());
+
+        const beforeLoad = Date.now();
+        // There should be something in the audit log since we created 'test.foo'
+        assert.neq(0, getAuditEventsCollection(m, testDBName).count({
+            ts: withinInterval(beforeCmd, beforeLoad)}),
+                   "no audit events before rotate.");
+
+        // // Rotate the server log. The audit log rotates with it.
+        // // Once rotated, the audit log should be empty.
+        assert.commandWorked(m.getDB('admin').runCommand({ logRotate: 1 }));
+        // There should be still audit log entries from before the rotate
+        assert.neq(0, getAuditEventsCollection(m, testDBName).count({
+            ts: withinInterval(beforeCmd, beforeLoad)}),
+                   "no audit events before rotate.");
+
+        // Verify that the audit log has not been renamed.
+        var rotatedLogPaths = getRotatedLogFilePaths(auditPath);
+        assert.eq(0, rotatedLogPaths.length,
+                  "expected no rotated log file after reopen: " + rotatedLogPaths);
+    },
+    // Need to enable the logging manager by passing `logpath'
+    { logpath: logDir + '/server.log', logappend: "", logRotate: "reopen" }
+);

--- a/jstests/audit/audit_log_rotate_on_start.js
+++ b/jstests/audit/audit_log_rotate_on_start.js
@@ -58,8 +58,8 @@ function initAuditLogDir() {
     mkdir(auditLogDir);
 }
 
-// Runs the test for given audit log file name and format.
-function runTest(fileName, format) {
+// Runs the test for a given audit log file name and format with logRotate=rename option (default).
+function runTestRename(fileName, format) {
     const auditPath = auditLogDir + '/' + fileName;
     const config = {
         auditDestination: 'file',
@@ -101,5 +101,41 @@ function runTest(fileName, format) {
     }
 }
 
-runTest('auditFileName.json', 'JSON');
-runTest('auditFileName.bson', 'BSON');
+// Runs the test for a given audit log file name and format with logRotate=reopen option.
+function runTestReopen(fileName, format) {
+    const auditPath = auditLogDir + '/' + fileName;
+    const config = {
+        auditDestination: 'file',
+        auditPath: auditPath,
+        auditFormat: format,
+        logRotate: 'reopen',
+        logappend: "",
+    };
+
+    // Ensure the audit log directory is clean before starting the test
+    initAuditLogDir();
+    assert.eq(getFiles(fileName).length, 0, "Expected no audit log files initially");
+
+    // 1st run: expect 1 file to be created.
+    runAndStopMongod(config);
+    assert.eq(countFiles(fileName), 1, "Expected 1 audit log file after starting 1st mongod");
+    const firstFileContent = cat(getFiles(fileName)[0]);
+
+    // 2nd run: expect 1 file to be reopened, not rotated.
+    runAndStopMongod(config);
+    assert.eq(countFiles(fileName), 1, "Expected 1 audit log files after starting 2nd mongod");
+    const rotatedFiles = getRotatedFiles(fileName);
+    assert.eq(rotatedFiles.length, 0, "Expected no rotated audit log file after");
+
+    // expect the file to be reopened in append mode
+    const secondFileContent = cat(getCurrentFile(fileName));
+    assert(
+        secondFileContent.startsWith(firstFileContent),
+        "Expected second file content to start with first file content (file reopened in append mode)");
+}
+
+runTestRename('auditFileName.json', 'JSON');
+runTestRename('auditFileName.bson', 'BSON');
+
+runTestReopen('auditFileName.json', 'JSON');
+runTestReopen('auditFileName.bson', 'BSON');

--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -170,7 +170,7 @@ namespace audit {
             : WritableAuditLog(filter),
               _file(new Sink),
               _fileName(file) {
-            _file->open(file.c_str(), std::ios_base::out | std::ios_base::app | std::ios_base::binary);
+            _file->open(file.c_str(), kFileOpenMode);
         }
 
         virtual ~FileAuditLog() {
@@ -181,6 +181,8 @@ namespace audit {
         }
 
     protected:
+        static constexpr auto kFileOpenMode =
+            std::ios_base::out | std::ios_base::app | std::ios_base::binary;
         // Creates specific Adapter instance for FileAuditLog::append()
         // and passess ownership to caller
         virtual AuditLogFormatAdapter *createAdapter(const BSONObj &obj) const = 0;
@@ -240,7 +242,7 @@ namespace audit {
 
             // Open a new file, with the same name as the original.
             _file.reset(new Sink);
-            _file->open(_fileName.c_str());
+            _file->open(_fileName.c_str(), kFileOpenMode);
 
             return Status::OK();
         }
@@ -517,7 +519,7 @@ namespace audit {
 
             // Rotate the audit log if it already exists.
             if (needRotate) {
-                return logv2::rotateLogs(true, logv2::kAuditLogTag, {});
+                return logv2::rotateLogs(serverGlobalParams.logRenameOnRotate, logv2::kAuditLogTag, {});
             }
         }
         return Status::OK();


### PR DESCRIPTION
Respect the logRotation=reopen mode when rotating audit log on startup. Reopen audit log files in append mode when rotating.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
