### PR TITLE
PSMDB-1745: fix audit log rotation in reopen mode

### DIFF
--- a/src/mongo/db/audit/audit.cpp
+++ b/src/mongo/db/audit/audit.cpp
@@ -164,7 +164,7 @@ class FileAuditLog : public WritableAuditLog {
 public:
     FileAuditLog(const std::string& file, const BSONObj& filter)
         : WritableAuditLog(filter), _file(new Sink), _fileName(file) {
-        _file->open(file.c_str(), std::ios_base::out | std::ios_base::app | std::ios_base::binary);
+        _file->open(file.c_str(), kFileOpenMode);
     }
 
     virtual ~FileAuditLog() {
@@ -175,6 +175,9 @@ public:
     }
 
 protected:
+    static constexpr auto kFileOpenMode =
+        std::ios_base::out | std::ios_base::app | std::ios_base::binary;
+
     // Creates specific Adapter instance for FileAuditLog::append()
     // and passess ownership to caller
     virtual AuditLogFormatAdapter* createAdapter(const BSONObj& obj) const = 0;
@@ -234,7 +237,7 @@ protected:
 
         // Open a new file, with the same name as the original.
         _file.reset(new Sink);
-        _file->open(_fileName.c_str());
+        _file->open(_fileName.c_str(), kFileOpenMode);
 
         return Status::OK();
     }
@@ -498,8 +501,8 @@ Status initialize() {
             _setGlobalAuditLog(new JSONAuditLog(auditOptions.path, filter));
 
         // Rotate the audit log if it already exists.
-        if (needRotate){
-            return logv2::rotateLogs(true, logv2::kAuditLogTag, {});
+        if (needRotate) {
+            return logv2::rotateLogs(serverGlobalParams.logRenameOnRotate, logv2::kAuditLogTag, {});
         }
     }
     return Status::OK();


### PR DESCRIPTION
Respect the logRotation=reopen mode when rotating audit log on startup. Reopen audit log files in append mode when rotating.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
