### PR TITLE
PSMDB-1738: fix reacquiring invalidated OIDC user

### DIFF
--- a/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
+++ b/src/mongo/db/auth/external/sasl_oidc_server_mechanism.cpp
@@ -38,6 +38,7 @@ Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/crypto/jws_validated_token.h"
 #include "mongo/db/auth/oidc/oidc_identity_providers_registry.h"
 #include "mongo/db/auth/oidc/oidc_server_parameters_gen.h"
+#include "mongo/db/auth/oidc/user_request_oidc.h"
 #include "mongo/db/auth/oidc_protocol_gen.h"
 #include "mongo/db/auth/sasl_mechanism_registry.h"
 #include "mongo/db/server_parameter.h"
@@ -317,8 +318,8 @@ void SaslOidcServerMechanism::processLogClaims(const OidcIdentityProviderConfig&
 }
 
 StatusWith<std::unique_ptr<UserRequest>> SaslOidcServerMechanism::makeUserRequest(OperationContext*) const  {
-    return std::make_unique<UserRequestGeneral>(
-        UserName{getPrincipalName(), getAuthenticationDatabase()}, _roles);
+    return std::make_unique<UserRequestOIDC>(
+        UserName{getPrincipalName(), getAuthenticationDatabase()}, _roles, _roles);
 }
 
 boost::optional<Date_t> SaslOidcServerMechanism::getExpirationTime() const {

--- a/src/mongo/db/auth/oidc/BUILD.bazel
+++ b/src/mongo/db/auth/oidc/BUILD.bazel
@@ -21,6 +21,7 @@ mongo_cc_library(
     hdrs = [
         "oidc_identity_providers_registry.h",
         "oidc_identity_providers_registry_impl.h",
+        "user_request_oidc.h",
         "match_pattern.h",
         "//src/mongo/crypto:jwks_fetcher_factory.h",
     ],
@@ -29,6 +30,7 @@ mongo_cc_library(
         "//src/mongo/crypto:jwt",
         "//src/mongo/crypto:jwt_types",
         "//src/mongo/db:server_base",
+        "//src/mongo/db:service_context",
         "//src/mongo/util/options_parser"
     ],
 )

--- a/src/mongo/db/auth/oidc/SConscript
+++ b/src/mongo/db/auth/oidc/SConscript
@@ -8,6 +8,7 @@ env.CppUnitTest(
     source=[
         "oidc_commands_test.cpp",
         "oidc_identity_providers_registry_test.cpp",
+        "user_request_oidc_test.cpp"
     ],
     LIBDEPS=[
         "$BUILD_DIR/mongo/crypto/jwt",
@@ -15,8 +16,6 @@ env.CppUnitTest(
         "$BUILD_DIR/mongo/db/auth/auth_impl_internal",
         "$BUILD_DIR/mongo/db/auth/authmocks",
         "$BUILD_DIR/mongo/db/auth/authorization_session_test_fixture",
-        "$BUILD_DIR/mongo/db/service_context",
-        "$BUILD_DIR/mongo/util/periodic_runner",
         "oidc",
         "oidc_commands",
     ],

--- a/src/mongo/db/auth/oidc/user_request_oidc.h
+++ b/src/mongo/db/auth/oidc/user_request_oidc.h
@@ -1,0 +1,63 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+#pragma once
+
+#include "mongo/db/auth/user.h"
+
+namespace mongo {
+
+class UserRequestOIDC : public UserRequestGeneral {
+public:
+    UserRequestType getType() const override {
+        return UserRequestType::OIDC;
+    }
+
+    std::unique_ptr<UserRequest> clone() const override {
+        return std::unique_ptr<UserRequest>(
+            std::make_unique<UserRequestOIDC>(getUserName(), getRoles(), _rolesFromToken));
+    }
+
+    StatusWith<std::unique_ptr<UserRequest>> cloneForReacquire() const override {
+        return std::make_unique<UserRequestOIDC>(getUserName(), _rolesFromToken, _rolesFromToken);
+    }
+
+    UserRequestOIDC(UserName name,
+                    boost::optional<std::set<RoleName>> roles,
+                    boost::optional<std::set<RoleName>> rolesFromToken)
+        : UserRequestGeneral(std::move(name), std::move(roles)),
+          _rolesFromToken(std::move(rolesFromToken)) {}
+
+protected:
+    boost::optional<std::set<RoleName>> _rolesFromToken;
+};
+
+}  // namespace mongo

--- a/src/mongo/db/auth/oidc/user_request_oidc_test.cpp
+++ b/src/mongo/db/auth/oidc/user_request_oidc_test.cpp
@@ -1,0 +1,113 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2025-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+#include "mongo/db/auth/oidc/user_request_oidc.h"
+
+#include "mongo/unittest/assert.h"
+#include "mongo/unittest/framework.h"
+
+namespace mongo {
+namespace {
+
+const auto kTestUserName = UserName{"testUser", "testDB"};
+
+const std::set<RoleName> kTestRolesFromToken{
+    RoleName{"testRoleFromToken1", "someDB1"},
+    RoleName{"testRoleFromToken2", "someDB2"},
+};
+
+const std::set<RoleName> kTestRoles = {
+    RoleName{"testRoleFromToken1", "someDB1"},
+    RoleName{"testRoleFromToken2", "someDB2"},
+    RoleName{"testRole1", "testDB1"},
+    RoleName{"testRole2", "testDB2"},
+};
+
+// Test for getType method of UserRequestOIDC class which should return UserRequestType::OIDC.
+TEST(UserRequestOIDCTest, Type) {
+    UserRequestOIDC request(kTestUserName, boost::none, boost::none);
+
+    ASSERT_EQ(request.getType(), UserRequest::UserRequestType::OIDC);
+}
+
+// Test for clone method of UserRequestOIDC class.
+// It should return a new UserRequestOIDC object with the same user name and roles.
+TEST(UserRequestOIDCTest, Clone) {
+    UserRequestOIDC request(kTestUserName, kTestRoles, kTestRolesFromToken);
+
+    auto clonedRequest = request.clone();
+    ASSERT_NE(clonedRequest, nullptr);
+    ASSERT_TRUE(clonedRequest->getUserName() == kTestUserName);
+    ASSERT_TRUE(clonedRequest->getRoles().has_value());
+    ASSERT_EQ(clonedRequest->getRoles(), kTestRoles);
+
+    auto anotherClonedRequest = clonedRequest->clone();
+    ASSERT_NE(anotherClonedRequest, nullptr);
+    ASSERT_TRUE(anotherClonedRequest->getUserName() == kTestUserName);
+    ASSERT_TRUE(anotherClonedRequest->getRoles().has_value());
+    ASSERT_EQ(anotherClonedRequest->getRoles(), kTestRoles);
+}
+
+// Test for cloneForReacquire method of UserRequestOIDC class.
+// It should return a new UserRequestOIDC object with the same user name and roles from token.
+TEST(UserRequestOIDCTest, CloneForReacquire) {
+
+    UserRequestOIDC request(kTestUserName, kTestRoles, kTestRolesFromToken);
+
+    auto clonedRequest = request.cloneForReacquire();
+    ASSERT_OK(clonedRequest.getStatus());
+    ASSERT_TRUE(clonedRequest.getValue()->getUserName() == kTestUserName);
+    ASSERT_TRUE(clonedRequest.getValue()->getRoles().has_value());
+    ASSERT_EQ(clonedRequest.getValue()->getRoles(), kTestRolesFromToken);
+}
+
+// Test for cloneForReacquire method after clone.
+// The request cloned for reacquire after normal clone should have the same user name
+// and roles from token as the original request.
+TEST(UserRequestOIDCTest, CloneForReacquireAfterClone) {
+
+    UserRequestOIDC request(kTestUserName, kTestRoles, kTestRolesFromToken);
+
+    auto clonedRequest = request.clone();
+    ASSERT_NE(clonedRequest, nullptr);
+    ASSERT_TRUE(clonedRequest->getUserName() == kTestUserName);
+    ASSERT_TRUE(clonedRequest->getRoles().has_value());
+    ASSERT_EQ(clonedRequest->getRoles(), kTestRoles);
+
+    auto clonedForReacquire = clonedRequest->cloneForReacquire();
+    ASSERT_OK(clonedForReacquire.getStatus());
+    ASSERT_TRUE(clonedForReacquire.getValue()->getUserName() == kTestUserName);
+    ASSERT_TRUE(clonedForReacquire.getValue()->getRoles().has_value());
+    ASSERT_EQ(clonedForReacquire.getValue()->getRoles(), kTestRolesFromToken);
+}
+
+}  // namespace
+}  // namespace mongo


### PR DESCRIPTION
Make sure the user gets the roles from the authorization claim when user is reacquired after invalidting the user cache.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
