### PR TITLE
PSMDB-1781: include OpenAPI spec from vault client in telemetry

### DIFF
--- a/src/mongo/db/encryption/vault_client.cpp
+++ b/src/mongo/db/encryption/vault_client.cpp
@@ -39,6 +39,7 @@ Copyright (C) 2024-present Percona and/or its affiliates. All rights reserved.
 #include <string_view>
 #include <type_traits>
 #include <vector>
+#include <regex>
 
 #include <boost/tokenizer.hpp>
 
@@ -187,6 +188,14 @@ std::string genPutKeyReqBody(const std::string& key,
     data << R"json("data": {"value": ")json" << key << R"json("}})json";
     return data;
 }
+
+// Replaces '$ref' with '_ref'
+// The OpenAPI references can cause a parsing failure because they
+// will be treated as DBRefs.
+std::string removeRef(StringData json) {
+    return std::regex_replace(json.toString(), std::regex{"\"\\$ref\""}, "\"_ref\"");
+}
+
 }  // namespace
 
 class VaultClient::Impl {
@@ -210,6 +219,8 @@ public:
                                                  std::uint64_t secretVersion = 0) const;
     std::uint64_t putKey(const std::string& secretPath, const std::string& key) const;
 
+    StatusWith<BSONObj> getOpenAPISpec() const;
+
 private:
     std::uint64_t requestEngineMaxVersions(const StringData& url) const;
     std::optional<SecretMetadata> requestSecretMetadata(const StringData& url) const;
@@ -220,6 +231,8 @@ private:
     static constexpr std::uint16_t kHttpStatusCodeNotFound = 404;
 
     static constexpr std::uint64_t kDefaultMaxVersions = 10;
+
+    static constexpr auto kOpenAPISpecEndpoint = "sys/internal/specs/openapi"_sd;
 
     std::unique_ptr<HttpClient> _httpClient;
     // concatenation of the URL's scheme, authority and the constant part of the path;
@@ -249,11 +262,13 @@ VaultClient::Impl::Impl(const std::string& host,
     _httpClient->allowInsecureHTTP(disableTls);
 
 
-    std::vector<std::string> headers(1, "X-Vault-Token: ");
-    headers.at(0).append(!token.empty() ? token
-                                        : std::string_view(*detail::readFileToSecureString(
-                                              tokenFile, "Vault token")));
-    _httpClient->setHeaders(headers);
+    if (!token.empty() || !tokenFile.empty()) {
+        std::vector<std::string> headers(1, "X-Vault-Token: ");
+        headers.at(0).append(!token.empty() ? token
+                                            : std::string_view(*detail::readFileToSecureString(
+                                                tokenFile, "Vault token")));
+        _httpClient->setHeaders(headers);
+    }
 }
 
 
@@ -415,6 +430,30 @@ std::uint64_t VaultClient::Impl::putKey(const std::string& secretPath,
     MONGO_UNREACHABLE;
 }
 
+StatusWith<BSONObj> VaultClient::Impl::getOpenAPISpec() const try {
+    str::stream url;
+    url << _urlHead << kOpenAPISpecEndpoint;
+
+    HttpClient::HttpReply reply = _httpClient->request(HttpClient::HttpMethod::kGET, url);
+    ConstDataRangeCursor cur = reply.body.getCursor();
+    StringData replyBody(cur.data(), cur.length());
+
+    LOGV2_DEBUG(29143,
+                1,
+                "Vault: get OpenAPI spec",
+                "request.method"_attr = "GET",
+                "request.url"_attr = url,
+                "response.code"_attr = reply.code,
+                "response.body"_attr = replyBody,
+                "response.size"_attr = replyBody.size());
+
+    return fromjson(removeRef(replyBody));
+} catch (const std::exception& e) {
+    std::ostringstream msg;
+    msg << "Reading the OpenAPI spec failed: " << e.what();
+    return Status(ErrorCodes::OperationFailed, msg.str());
+}
+
 VaultClient::~VaultClient() = default;
 
 VaultClient::VaultClient(VaultClient&&) = default;
@@ -438,5 +477,9 @@ std::pair<std::string, std::uint64_t> VaultClient::getKey(const std::string& sec
 
 std::uint64_t VaultClient::putKey(const std::string& secretPath, const std::string& key) const {
     return _impl->putKey(secretPath, key);
+}
+
+StatusWith<BSONObj> VaultClient::getOpenAPISpec() const {
+    return _impl->getOpenAPISpec();
 }
 }  // namespace mongo::encryption

--- a/src/mongo/db/encryption/vault_client.h
+++ b/src/mongo/db/encryption/vault_client.h
@@ -36,6 +36,8 @@ Copyright (C) 2024-present Percona and/or its affiliates. All rights reserved.
 #include <string>
 #include <utility>
 
+#include "mongo/bson/bsonobj.h"
+
 namespace mongo::encryption {
 class VaultClient {
 public:
@@ -80,6 +82,11 @@ public:
     ///
     /// @throws std::runtime_error in case of issues
     std::uint64_t putKey(const std::string& secretPath, const std::string& key) const;
+
+    /// @brief Retrieves the OpenAPI specification from the Vault server.
+    ///
+    /// @returns Status with the OpenAPI specification as a BSON object in case of success.
+    StatusWith<BSONObj> getOpenAPISpec() const;
 
 private:
     class Impl;

--- a/src/mongo/db/telemetry/SConscript
+++ b/src/mongo/db/telemetry/SConscript
@@ -35,6 +35,7 @@ env.Library(
     ],
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/db/catalog/collection_options',
+        '$BUILD_DIR/mongo/db/encryption/vault_client',
         '$BUILD_DIR/mongo/db/repl/repl_server_parameters',
         '$BUILD_DIR/mongo/db/repl/storage_interface',
         '$BUILD_DIR/mongo/s/grid',

--- a/src/mongo/db/telemetry/telemetry_thread_d.cpp
+++ b/src/mongo/db/telemetry/telemetry_thread_d.cpp
@@ -52,6 +52,7 @@ Copyright (C) 2024-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/db/client.h"
 #include "mongo/db/cluster_role.h"
 #include "mongo/db/encryption/encryption_options.h"
+#include "mongo/db/encryption/vault_client.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/repl/member_state.h"
@@ -84,6 +85,7 @@ constexpr StringData kId = "_id"_sd;
 constexpr StringData kScheduledAt = "scheduledAt"_sd;
 
 constexpr StringData kEncryptionKeyStorage = "tde_key_storage"_sd;
+constexpr StringData kEncryptionVaultSpec = "tde_vault_info"_sd;
 constexpr StringData kVaultKeyFile = "keyfile"_sd;
 constexpr StringData kVaultVault = "vault"_sd;
 constexpr StringData kVaultKmip = "kmip"_sd;
@@ -93,6 +95,45 @@ constexpr StringData kPBMActive = "pbm_active"_sd;
 
 constexpr StringData kInitialSyncMethod = "initial_sync_method"_sd;
 
+constexpr StringData kOpenApiSpecFieldInfo = "info"_sd;
+constexpr StringData kOpenApiSpecInfoFields[] = {
+    "title"_sd,
+    "version"_sd,
+};
+
+namespace {
+encryption::VaultClient createVaultClient() {
+    // Without the token the response will be shorter but the fields we need should be available.
+    return encryption::VaultClient(encryptionGlobalParams.vaultServerName,
+                                   encryptionGlobalParams.vaultPort,
+                                   "", // encryptionGlobalParams.vaultToken,
+                                   "", // encryptionGlobalParams.vaultTokenFile,
+                                   encryptionGlobalParams.vaultServerCAFile,
+                                   encryptionGlobalParams.vaultCheckMaxVersions,
+                                   encryptionGlobalParams.vaultDisableTLS,
+                                   encryptionGlobalParams.vaultTimeout);
+}
+
+bool isKeyStorageVault(StringData keyStorage) {
+    return keyStorage == kVaultVault;
+}
+
+// Return specified fields from the 'info' section from the OpenAPI spec document.
+BSONObj getVaultInfo(const BSONObj& obj) {
+    BSONObjBuilder builder;
+    const auto infoElement = obj.getField(kOpenApiSpecFieldInfo);
+    if (infoElement.ok() && infoElement.isABSONObj()) {
+        const auto infoObj = infoElement.Obj();
+        for (const auto fieldName : kOpenApiSpecInfoFields) {
+            const auto field = infoObj.getField(fieldName);
+            if (field.ok()) {
+                builder.appendAs(field, fieldName);
+            }
+        }
+    }
+    return builder.obj();
+}
+}  // namespace
 
 StringData keyStorageType() {
     if (!encryptionGlobalParams.encryptionKeyFile.empty()) {
@@ -295,7 +336,21 @@ private:
         }
         // data at rest encryption
         if (encryptionGlobalParams.enableEncryption) {
-            builder->append(kEncryptionKeyStorage, keyStorageType());
+            const auto keyStorage = keyStorageType();
+            builder->append(kEncryptionKeyStorage, keyStorage);
+
+            // Add more information if key storage is Vault
+            if (isKeyStorageVault(keyStorage)) {
+                const auto status = createVaultClient().getOpenAPISpec();
+                if (status.isOK()) {
+                    builder->append(kEncryptionVaultSpec, getVaultInfo(status.getValue()));
+                } else {
+                    LOGV2_DEBUG(29142,
+                                1,
+                                "Failed to collect encryption vault spec",
+                                "status"_attr = status.getStatus());
+                }
+            }
         }
 
         // operation context is necessary for following operations


### PR DESCRIPTION
Include 'info.title' and 'info.version' fields from the OpenAPI spec from the vault client in the telemetry data. The new telemetry makes it possible to know which backend is used.