### PR TITLE
PSMDB-1155 Report error on attempt to extend backup cursor on standalone node

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.cpp
@@ -257,6 +257,9 @@ BackupCursorExtendState WiredTigerBackupCursorHooks::extendBackupCursor(Operatio
             _openCursor == backupId);
     // wait for extendTo
     auto* replCoord = repl::ReplicationCoordinator::get(opCtx->getServiceContext());
+    uassert(29144,
+            "Cannot extend backup cursor when replication is not enabled",
+            replCoord->getSettings().isReplSet());
     if (auto status = replCoord->awaitTimestampCommitted(opCtx, extendTo); !status.isOK()) {
         LOGV2_ERROR_OPTIONS(29096,
                             {logv2::UserAssertAfterLog(status.code())},


### PR DESCRIPTION
Before this fix attempt to extend backup cursor on standalone node resulted in stuck command.
With this fix such attempt returns dedicated error immediately:

```
admin> db.aggregate([{$backupCursorExtend: {backupId: UUID('669ac32e-8cbb-47ea-9215-2d8985406f65'), timestamp: new Timestamp(1665416158, 1)}}])
MongoServerError[Location29144]: Cannot extend backup cursor when replication is not enabled.
```