### PR TITLE
PSMDB-1757 Fail FCBIS attempt if storage engine is not wiredTiger

### DIFF
--- a/src/mongo/db/repl/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_syncer_fcb.cpp
@@ -305,6 +305,19 @@ Status InitialSyncerFCB::startup(OperationContext* opCtx,
 
     _setUp_inlock(opCtx, initialSyncMaxAttempts);
 
+    if (storageGlobalParams.engine != "wiredTiger") {
+        static constexpr char msg[] =
+            "wiredTiger storage engine required on the syncing node for file copy-based initial "
+            "sync";
+        LOGV2_ERROR(128466, msg, "currentEngine"_attr = storageGlobalParams.engine);
+        // Schedule _finishCallback to terminate initial sync with error.
+        auto scheduleResult =
+            _exec->scheduleWork([this](const mongo::executor::TaskExecutor::CallbackArgs&) {
+                _finishCallback(Status(ErrorCodes::InitialSyncFailure, msg));
+            });
+        return scheduleResult.getStatus();
+    }
+
     // Start first initial sync attempt.
     std::uint32_t initialSyncAttempt = 0;
     _attemptExec = std::make_unique<executor::ScopedTaskExecutor>(


### PR DESCRIPTION
FCBIS attempt will fail and server will be shut down if storage engine is not wiredTiger.
Server log will contain record with id = 128466
Example of the server log:

```
[js_test:p1757] d20042| {"t":{"$date":"2025-09-03T15:59:04.640+01:00"},"s":"E",  "c":"INITSYNC", "id":128466,  "ctx":"ReplCoord-0","msg":"wiredTiger storage engine required on the syncing node for file copy-based initial sync","attr":{"currentEngine":"inMemory"}}

...

[js_test:p1757] d20042| {"t":{"$date":"2025-09-03T15:59:04.642+01:00"},"s":"E",  "c":"REPL",     "id":21416,   "ctx":"ReplCoordExtern-0","msg":"Initial sync failed, shutting down now. Restart the server to attempt a new initial sync"}
[js_test:p1757] d20042| {"t":{"$date":"2025-09-03T15:59:04.642+01:00"},"s":"F",  "c":"ASSERT",   "id":23095,   "ctx":"ReplCoordExtern-0","msg":"Fatal assertion","attr":{"msgid":40088,"error":"InitialSyncFailure: wiredTiger storage engine required on the syncing node for file copy-based initial sync","file":"src/mongo/db/repl/replication_coordinator_impl.cpp","line":869}}
[js_test:p1757] d20042| {"t":{"$date":"2025-09-03T15:59:04.642+01:00"},"s":"F",  "c":"ASSERT",   "id":23096,   "ctx":"ReplCoordExtern-0","msg":"\n\n***aborting after fassert() failure\n\n"}
```
