### PR TITLE
PSMDB-1755 FCBIS: switch to original db path on retry or shutdown

### DIFF
--- a/src/mongo/db/repl/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_syncer_fcb.cpp
@@ -1044,7 +1044,7 @@ void InitialSyncerFCB::_finishInitialSyncAttempt(const StatusWith<OpTimeAndWallT
 
     LOGV2(128440, "Initial sync attempt finishing up");
 
-    stdx::lock_guard<Latch> lock(_mutex);
+    stdx::unique_lock<Latch> lock(_mutex);
 
     auto runTime = _initialSyncState ? _initialSyncState->timer.millis() : 0;
     int rollBackId = -1;
@@ -1056,6 +1056,25 @@ void InitialSyncerFCB::_finishInitialSyncAttempt(const StatusWith<OpTimeAndWallT
         operationsRetried = _sharedData->getTotalRetries(sdLock);
         totalTimeUnreachableMillis =
             durationCount<Milliseconds>(_sharedData->getTotalTimeUnreachable(sdLock));
+    }
+
+    // Before cleaning temporary directories we need to switch back to configured db path if current
+    // storage engine uses temporary location. In case of shutdown we shouldn't try to shutdown
+    // storage engine working in temporary directory because that directory will be deleted. In case
+    // of initial sync attempt retry we also need to switch back.
+    if (_needToSwitchBackToOriginalDBPath) {
+        auto opCtx = makeOpCtx();
+        lock.unlock();
+        Status status = _switchStorageLocation(
+            opCtx.get(), _cfgDBPath, startup_recovery::StartupRecoveryMode::kReplicaSetMember);
+        lock.lock();
+        if (!status.isOK()) {
+            // We failed to switch back to original db path. This is a serious error because we
+            // cannot proceed with retry or shutdown. We should crash to avoid running in a bad
+            // state.
+            LOGV2_FATAL(128467, "Failed to switch back to original db path", "error"_attr = status);
+        }
+        _needToSwitchBackToOriginalDBPath = false;
     }
 
     // Remove temporary directories created by the initial syncer.
@@ -2251,6 +2270,7 @@ void InitialSyncerFCB::_switchToDownloadedCallback(
         onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
         return;
     }
+    _needToSwitchBackToOriginalDBPath = true;
 
     // do some cleanup
     auto* consistencyMarkers = _replicationProcess->getConsistencyMarkers();
@@ -2383,6 +2403,7 @@ void InitialSyncerFCB::_switchToDummyToDBPathCallback(
         onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
         return;
     }
+    _needToSwitchBackToOriginalDBPath = true;
 
     // Delete the list of files obtained from the local backup cursor
     status = _deleteLocalFiles();
@@ -2408,6 +2429,7 @@ void InitialSyncerFCB::_switchToDummyToDBPathCallback(
         onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
         return;
     }
+    _needToSwitchBackToOriginalDBPath = false;
 
     // schedule next task
     status = _scheduleWorkAndSaveHandle_inlock(

--- a/src/mongo/db/repl/initial_syncer_fcb.h
+++ b/src/mongo/db/repl/initial_syncer_fcb.h
@@ -570,6 +570,9 @@ private:
     const std::string _cfgDBPath;                                      // TODO:
     std::unique_ptr<BackupCursorInfo> _backupCursorInfo;               // TODO:
 
+    // Flag that we need to switch back to the original dbpath
+    bool _needToSwitchBackToOriginalDBPath = false;  // (M)
+
     // This is invoked with the final status of the initial sync. If startup() fails, this callback
     // is never invoked. The caller gets the last applied optime when the initial sync completes
     // successfully or an error status.


### PR DESCRIPTION
We need to switch back to original db path to be able to correectly shutdow or to retry initial sync attempt