### PR TITLE
PSMDB-1820 exclude query_shape_hash_in_current_op.js from sharded_collections_jscore_passthrough_with_replica_set_endpoint

### DIFF
--- a/buildscripts/resmokeconfig/suites/sharded_collections_jscore_passthrough_with_replica_set_endpoint.yml
+++ b/buildscripts/resmokeconfig/suites/sharded_collections_jscore_passthrough_with_replica_set_endpoint.yml
@@ -73,6 +73,9 @@ selector:
   - jstests/core/query/query_settings/query_settings_reject_application.js
   # This test expects to see an unsharded collection as untracked
   - jstests/core/catalog/agg_list_cluster_catalog_sharding_fields.js
+  # The 'queryShapeHash' is only computed on mongos in sharded clusters, therefore the test will fail
+  # as hash won't be present when running via replica set endpoint.
+  - jstests/core/query/query_settings/query_shape_hash_in_current_op.js
 
   exclude_with_any_tags:
   - assumes_standalone_mongod


### PR DESCRIPTION
Backports SERVER-95050 to v8.0 
