### PR TITLE
PSMDB-1997: Fix TDE race condition when dropping and recreating database

### DIFF
--- a/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
+++ b/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
@@ -49,6 +49,7 @@
 #include "mongo/db/storage/recovery_unit_noop.h"
 #include "mongo/db/views/view.h"
 #include "mongo/util/assert_util.h"
+#include "mongo/util/database_name_util.h"
 #include "mongo/util/fail_point.h"
 #include "mongo/util/str.h"
 
@@ -275,6 +276,28 @@ void removeIndex(OperationContext* opCtx,
 
     const bool isTwoPhaseDrop = dataRemoval == DataRemoval::kTwoPhase;
 
+    // PSMDB-1997: For TDE deferred key deletion, we need to track pending ident drops.
+    // Get the versioned keyid from the ident's metadata and increment the pending drop count.
+    std::string keyid;
+    if (isTwoPhaseDrop) {
+        // Get the actual keyid from the ident's WiredTiger metadata.
+        // This is the versioned keyid (e.g., "test" or "test.v1") that the ident was created with.
+        keyid = storageEngine->getIdentEncryptionKeyId(*shard_role_details::getRecoveryUnit(opCtx),
+                                                       ident->getIdent());
+        if (keyid.empty()) {
+            // Fallback to database name if encryption is not enabled or keyid not found
+            keyid = DatabaseNameUtil::serialize(collection->ns().dbName(),
+                                                SerializationContext::stateDefault());
+        }
+        storageEngine->keydbIncrementPendingDropCount(keyid);
+
+        // Register rollback handler to decrement if transaction fails
+        shard_role_details::getRecoveryUnit(opCtx)->onRollback(
+            [storageEngine, keyid](OperationContext*) {
+                storageEngine->keydbDecrementPendingDropCount(keyid);
+            });
+    }
+
     // Schedule the second phase of drop to delete the data when it is no longer in use, if the
     // first phase is successfully committed.
     shard_role_details::getRecoveryUnit(opCtx)->onCommitForTwoPhaseDrop(
@@ -285,7 +308,8 @@ void removeIndex(OperationContext* opCtx,
          nss = collection->ns(),
          indexNameStr = std::string{indexName},
          ident,
-         isTwoPhaseDrop](OperationContext*, boost::optional<Timestamp> commitTimestamp) {
+         isTwoPhaseDrop,
+         keyid](OperationContext*, boost::optional<Timestamp> commitTimestamp) {
             if (isTwoPhaseDrop) {
                 StorageEngine::DropTime dropTime;
                 if (!commitTimestamp) {
@@ -302,7 +326,13 @@ void removeIndex(OperationContext* opCtx,
                                 "uuid"_attr = uuid,
                                 "ident"_attr = ident->getIdent(),
                                 "dropTime"_attr = dropTime);
-                storageEngine->addDropPendingIdent(dropTime, ident);
+
+                // PSMDB-1997: Create callback to decrement pending drop count when ident is dropped
+                auto onDrop = [storageEngine, keyid]() {
+                    storageEngine->keydbDecrementPendingDropCount(keyid);
+                };
+
+                storageEngine->addDropPendingIdent(dropTime, ident, std::move(onDrop));
             } else {
                 LOGV2(6361201,
                       "Completing drop for index table immediately",
@@ -342,11 +372,26 @@ Status dropCollection(OperationContext* opCtx,
     auto recoveryUnit = shard_role_details::getRecoveryUnit(opCtx);
     auto storageEngine = opCtx->getServiceContext()->getStorageEngine();
 
+    // PSMDB-1997: For TDE deferred key deletion, track pending ident drops.
+    // Get the actual keyid from the ident's WiredTiger metadata.
+    std::string keyid = storageEngine->getIdentEncryptionKeyId(
+        *shard_role_details::getRecoveryUnit(opCtx), ident->getIdent());
+    if (keyid.empty()) {
+        // Fallback to database name if encryption is not enabled or keyid not found
+        keyid = DatabaseNameUtil::serialize(nss.dbName(), SerializationContext::stateDefault());
+    }
+    storageEngine->keydbIncrementPendingDropCount(keyid);
+
+    // Register rollback handler to decrement if transaction fails
+    shard_role_details::getRecoveryUnit(opCtx)->onRollback(
+        [storageEngine, keyid](OperationContext*) {
+            storageEngine->keydbDecrementPendingDropCount(keyid);
+        });
 
     // Schedule the second phase of drop to delete the data when it is no longer in use, if the
     // first phase is successfully committed.
     shard_role_details::getRecoveryUnit(opCtx)->onCommitForTwoPhaseDrop(
-        [svcCtx = opCtx->getServiceContext(), recoveryUnit, storageEngine, nss, ident](
+        [svcCtx = opCtx->getServiceContext(), recoveryUnit, storageEngine, nss, ident, keyid](
             OperationContext*, boost::optional<Timestamp> commitTimestamp) {
             StorageEngine::DropTime dropTime;
             if (!commitTimestamp) {
@@ -361,7 +406,13 @@ Status dropCollection(OperationContext* opCtx,
                             logAttrs(nss),
                             "ident"_attr = ident->getIdent(),
                             "dropTime"_attr = dropTime);
-            storageEngine->addDropPendingIdent(dropTime, ident);
+
+            // PSMDB-1997: Create callback to decrement pending drop count when ident is dropped
+            auto onDrop = [storageEngine, keyid]() {
+                storageEngine->keydbDecrementPendingDropCount(keyid);
+            };
+
+            storageEngine->addDropPendingIdent(dropTime, ident, std::move(onDrop));
         });
 
     return Status::OK();
@@ -386,10 +437,13 @@ Status dropCollectionsWithPrefix(OperationContext* opCtx,
 
     const auto status = dropCollections(opCtx, toDrop, collectionNamePrefix);
 
-    // If all collections were dropped successfully then drop database's encryption key
+    // PSMDB-1997: If all collections were dropped successfully, mark the database as dropped.
+    // This increments the generation counter. The encryption key will be deleted when
+    // all pending ident drops complete AND the generation still matches (i.e., the database
+    // wasn't recreated in the meantime).
     if (status.isOK()) {
         auto storageEngine = opCtx->getServiceContext()->getStorageEngine();
-        storageEngine->keydbDropDatabase(dbName);
+        storageEngine->keydbMarkDatabaseDropped(dbName);
     }
 
     return status;

--- a/src/mongo/db/storage/keydb_api.h
+++ b/src/mongo/db/storage/keydb_api.h
@@ -31,6 +31,8 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include <string>
+
 namespace mongo {
 class DatabaseName;
 }
@@ -45,10 +47,40 @@ struct KeyDBAPI {
     virtual ~KeyDBAPI() {}
 
     /**
-     * Returns whether the engine supports feature compatibility version 3.6
+     * Mark a database as dropped and pending key deletion.
+     * The encryption key will be deleted when all pending ident drops complete,
+     * unless the database is recreated (which cancels the pending deletion).
      */
-    virtual void keydbDropDatabase(const mongo::DatabaseName& dbName) {
+    virtual void keydbMarkDatabaseDropped(const mongo::DatabaseName& dbName) {
         // do nothing for engines which do not support KeyDB
+    }
+
+    /**
+     * Increment pending drop count for a database.
+     * Called when an ident is scheduled for deferred drop.
+     */
+    virtual void keydbIncrementPendingDropCount(const std::string& keyid) {
+        // do nothing for engines which do not support KeyDB
+    }
+
+    /**
+     * Decrement pending drop count for a database.
+     * When count reaches zero AND the database is still marked for deletion
+     * (wasn't recreated), delete the encryption key.
+     */
+    virtual void keydbDecrementPendingDropCount(const std::string& keyid) {
+        // do nothing for engines which do not support KeyDB
+    }
+
+    /**
+     * Get the current keyid for a database (with generation suffix if applicable).
+     * For a database "test" that was dropped and recreated, this returns "test.v1", etc.
+     * For a database that was never dropped, returns the plain database name.
+     * This is used when creating new tables to get the correct encryption keyid.
+     */
+    virtual std::string keydbGetCurrentKeyId(const std::string& dbName) {
+        // Default: return dbName unchanged (for non-TDE engines)
+        return dbName;
     }
 };
 

--- a/src/mongo/db/storage/kv/kv_engine.h
+++ b/src/mongo/db/storage/kv/kv_engine.h
@@ -634,6 +634,17 @@ public:
     }
 
     /**
+     * Gets the encryption keyid for an ident.
+     *
+     * Returns the keyid string if the ident is encrypted.
+     * Returns an empty string if the ident is not encrypted or keyid is not available.
+     * This is used for TDE deferred key deletion to track which keyid an ident belongs to.
+     */
+    virtual std::string getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) {
+        return std::string();
+    }
+
+    /**
      * The destructor will never be called from mongod, but may be called from tests.
      * Engines may assume that this will only be called in the case of clean shutdown, even if
      * cleanShutdown() hasn't been called.

--- a/src/mongo/db/storage/storage_engine.h
+++ b/src/mongo/db/storage/storage_engine.h
@@ -348,7 +348,7 @@ public:
     class StreamingCursor {
     public:
         StreamingCursor() = delete;
-        explicit StreamingCursor(BackupOptions options) : options(options) {};
+        explicit StreamingCursor(BackupOptions options) : options(options){};
 
         virtual ~StreamingCursor() = default;
 
@@ -1076,6 +1076,15 @@ public:
      * the files available and runs compaction if they are eligible.
      */
     virtual Status autoCompact(RecoveryUnit&, const AutoCompactOptions& options) = 0;
+
+    /**
+     * Gets the encryption keyid for an ident.
+     *
+     * Returns the keyid string if the ident is encrypted.
+     * Returns an empty string if the ident is not encrypted or keyid is not available.
+     * This is used for TDE deferred key deletion to track which keyid an ident belongs to.
+     */
+    virtual std::string getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) = 0;
 
     /**
      * Return true if the storage engine indicates that it is under cache pressure.

--- a/src/mongo/db/storage/storage_engine_impl.cpp
+++ b/src/mongo/db/storage/storage_engine_impl.cpp
@@ -124,8 +124,25 @@ Status StorageEngineImpl::hotBackup(OperationContext* opCtx,
     return _engine->hotBackup(opCtx, s3params);
 }
 
-void StorageEngineImpl::keydbDropDatabase(const DatabaseName& dbName) {
-    _engine->keydbDropDatabase(dbName);
+// PSMDB-1997: Deferred key deletion
+void StorageEngineImpl::keydbMarkDatabaseDropped(const DatabaseName& dbName) {
+    _engine->keydbMarkDatabaseDropped(dbName);
+}
+
+void StorageEngineImpl::keydbIncrementPendingDropCount(const std::string& keyid) {
+    _engine->keydbIncrementPendingDropCount(keyid);
+}
+
+void StorageEngineImpl::keydbDecrementPendingDropCount(const std::string& keyid) {
+    _engine->keydbDecrementPendingDropCount(keyid);
+}
+
+std::string StorageEngineImpl::keydbGetCurrentKeyId(const std::string& dbName) {
+    return _engine->keydbGetCurrentKeyId(dbName);
+}
+
+std::string StorageEngineImpl::getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) {
+    return _engine->getIdentEncryptionKeyId(ru, ident);
 }
 
 StorageEngineImpl::StorageEngineImpl(OperationContext* opCtx,

--- a/src/mongo/db/storage/storage_engine_impl.h
+++ b/src/mongo/db/storage/storage_engine_impl.h
@@ -86,7 +86,12 @@ class StorageEngineImpl final : public StorageEngine {
     Status hotBackup(OperationContext* opCtx, const std::string& path) override;
     Status hotBackupTar(OperationContext* opCtx, const std::string& path) override;
     Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
-    void keydbDropDatabase(const DatabaseName& dbName) override;
+    // PSMDB-1997: Deferred key deletion
+    void keydbMarkDatabaseDropped(const DatabaseName& dbName) override;
+    void keydbIncrementPendingDropCount(const std::string& keyid) override;
+    void keydbDecrementPendingDropCount(const std::string& keyid) override;
+    std::string keydbGetCurrentKeyId(const std::string& dbName) override;
+    std::string getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) override;
 
 public:
     StorageEngineImpl(OperationContext* opCtx,

--- a/src/mongo/db/storage/storage_engine_mock.h
+++ b/src/mongo/db/storage/storage_engine_mock.h
@@ -301,6 +301,10 @@ public:
         return Status::OK();
     }
 
+    std::string getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) final {
+        return std::string();
+    }
+
     bool hasOngoingLiveRestore() final {
         return false;
     }

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
@@ -298,17 +298,55 @@ void EncryptionKeyDB::init() {
 void EncryptionKeyDB::import_data_from(const EncryptionKeyDB* proto) {
     // not doing any synchronization here because key rotation process is single threaded
     try {
-        // copy parameters table
+        // copy parameters table (including generation data for PSMDB-1997)
         // clone is called right after init(). at this point _gcm_iv_reserved is equal to _gcm_iv
         _gcm_iv_reserved = proto->_gcm_iv_reserved;
         if (store_gcm_iv_reserved()) {
             throw std::runtime_error("failed to copy key db data during rotation");
         }
-        // copy key table
+
         int res;
         auto cursor_close = [](WT_CURSOR* c) {
             c->close(c);
         };
+
+        // Copy all parameters (including "dbgen:*" entries for generation tracking)
+        {
+            WT_CURSOR* srcc;
+            res = proto->_sess->open_cursor(
+                proto->_sess, "table:parameters", nullptr, nullptr, &srcc);
+            if (res)
+                throw std::runtime_error(std::string("clone: error opening parameters cursor: ") +
+                                         wiredtiger_strerror(res));
+            std::unique_ptr<WT_CURSOR, std::function<void(WT_CURSOR*)>> srcc_guard(srcc,
+                                                                                   cursor_close);
+            WT_CURSOR* dstc;
+            res = _sess->open_cursor(_sess, "table:parameters", nullptr, nullptr, &dstc);
+            if (res)
+                throw std::runtime_error(std::string("clone: error opening parameters cursor: ") +
+                                         wiredtiger_strerror(res));
+            std::unique_ptr<WT_CURSOR, std::function<void(WT_CURSOR*)>> dstc_guard(dstc,
+                                                                                   cursor_close);
+            while ((res = srcc->next(srcc)) == 0) {
+                char* k;
+                WT_ITEM v;
+                if ((res = srcc->get_key(srcc, &k)) || (res = srcc->get_value(srcc, &v)))
+                    throw std::runtime_error(
+                        std::string("clone: error getting key/value from parameters table: ") +
+                        wiredtiger_strerror(res));
+                dstc->set_key(dstc, k);
+                dstc->set_value(dstc, &v);
+                if ((res = dstc->insert(dstc)) != 0)
+                    throw std::runtime_error(
+                        std::string("clone: error writing parameters table: ") +
+                        wiredtiger_strerror(res));
+            }
+            if (res != WT_NOTFOUND)
+                throw std::runtime_error(std::string("clone: error reading parameters table: ") +
+                                         wiredtiger_strerror(res));
+        }
+
+        // copy key table
         WT_CURSOR* srcc;
         res = proto->_sess->open_cursor(proto->_sess, "table:key", nullptr, nullptr, &srcc);
         if (res)
@@ -464,6 +502,207 @@ int EncryptionKeyDB::delete_key_by_id(const std::string& keyid) {
     }
 
     return res;
+}
+
+// PSMDB-1997: Deferred key deletion implementation
+//
+// The approach: track pending drops by versioned keyid (e.g., "test" or "test.v1").
+// The keyid is obtained from the ident's WiredTiger metadata at increment time.
+// When markDatabaseDropped is called, we mark the current keyid for deletion.
+// When all pending drops for a keyid complete AND it's marked for deletion, we delete the key.
+
+void EncryptionKeyDB::incrementPendingDropCount(const std::string& keyid) {
+    stdx::lock_guard<stdx::mutex> lk(_pendingDropMutex);
+    _pendingDropCounts[keyid]++;
+    LOGV2_DEBUG(29060,
+                4,
+                "incrementPendingDropCount",
+                "keyid"_attr = keyid,
+                "count"_attr = _pendingDropCounts[keyid]);
+}
+
+void EncryptionKeyDB::decrementPendingDropCount(const std::string& keyid) {
+    std::string keyidToDelete;
+
+    {
+        stdx::lock_guard<stdx::mutex> lk(_pendingDropMutex);
+        auto countIt = _pendingDropCounts.find(keyid);
+        if (countIt == _pendingDropCounts.end()) {
+            LOGV2_WARNING(
+                29061, "decrementPendingDropCount called for unknown keyid", "keyid"_attr = keyid);
+            return;
+        }
+
+        countIt->second--;
+        LOGV2_DEBUG(29062,
+                    4,
+                    "decrementPendingDropCount",
+                    "keyid"_attr = keyid,
+                    "count"_attr = countIt->second);
+
+        if (countIt->second <= 0) {
+            _pendingDropCounts.erase(countIt);
+
+            // Check if this keyid is marked for deletion (database was dropped).
+            // If so, delete the key now that all idents using it are dropped.
+            auto pendingIt = _keysPendingDeletion.find(keyid);
+            if (pendingIt != _keysPendingDeletion.end()) {
+                _keysPendingDeletion.erase(pendingIt);
+                keyidToDelete = keyid;
+                LOGV2_DEBUG(29063,
+                            4,
+                            "All pending drops completed, will delete encryption key",
+                            "keyid"_attr = keyid);
+            }
+        }
+    }
+
+    // Delete key outside the lock to avoid potential deadlock
+    if (!keyidToDelete.empty()) {
+        delete_key_by_id(keyidToDelete);
+    }
+}
+
+void EncryptionKeyDB::markDatabaseDropped(const std::string& dbName) {
+    stdx::lock_guard<stdx::mutex> lk(_pendingDropMutex);
+
+    // Get the current keyid for this database (before incrementing generation)
+    std::string currentKeyId = getCurrentKeyId(dbName);
+
+    // Mark this keyid for deletion when all pending drops complete.
+    // The keyid will only be deleted when decrementPendingDropCount brings its count to 0.
+    _keysPendingDeletion.insert(currentKeyId);
+
+    // Increment generation so new database gets a new keyid
+    // If _nextGeneration[dbName] doesn't exist, it defaults to 0
+    // After increment, generation 1 means new collections use "dbName.v1"
+    _nextGeneration[dbName]++;
+
+    // Persist the new generation to table:parameters so it survives restart
+    persistGeneration(dbName, _nextGeneration[dbName]);
+
+    // Re-enable sessioncreate for the old encryptor so checkpoint-cleanup works
+    auto it = _encryptors.find(currentKeyId);
+    if (it != _encryptors.end()) {
+        percona_encryption_extension_drop_keyid(it->second);
+    }
+
+    LOGV2_DEBUG(29065,
+                4,
+                "markDatabaseDropped",
+                "dbName"_attr = dbName,
+                "droppedKeyId"_attr = currentKeyId,
+                "nextGeneration"_attr = _nextGeneration[dbName]);
+}
+
+std::string EncryptionKeyDB::getCurrentKeyId(const std::string& dbName) {
+    // Note: caller must hold _pendingDropMutex if thread safety is needed,
+    // but for table creation this is called from a single-threaded context.
+
+    // Check if we have a next generation cached in memory
+    auto it = _nextGeneration.find(dbName);
+    if (it != _nextGeneration.end()) {
+        if (it->second > 0) {
+            // Database was dropped, use versioned keyid
+            return to_keyid(dbName, it->second);
+        }
+        // Generation is 0 - use plain dbName
+        return dbName;
+    }
+
+    // First access after restart - load generation from table:parameters (O(1) lookup)
+    uint64_t generation = loadGeneration(dbName);
+    _nextGeneration[dbName] = generation;
+
+    if (generation > 0) {
+        // Database was dropped before restart, use versioned keyid
+        return to_keyid(dbName, generation);
+    }
+
+    // Generation is 0 - database was never dropped, use plain dbName
+    return dbName;
+}
+
+int EncryptionKeyDB::persistGeneration(const std::string& dbName, uint64_t generation) {
+    // Store generation in table:parameters with key "dbgen:<dbName>"
+    std::string paramKey = "dbgen:" + dbName;
+
+    int res;
+    WT_CURSOR* cursor;
+    stdx::lock_guard<stdx::mutex> lk(_lock_sess);
+    res = _sess->open_cursor(_sess, "table:parameters", nullptr, nullptr, &cursor);
+    if (res) {
+        LOGV2_ERROR(29066,
+                    "persistGeneration: error opening cursor: {err}",
+                    "err"_attr = wiredtiger_strerror(res));
+        return res;
+    }
+
+    std::unique_ptr<WT_CURSOR, std::function<void(WT_CURSOR*)>> cursor_guard(
+        cursor, [](WT_CURSOR* c) { c->close(c); });
+
+    // Store generation as 8-byte value
+    uint8_t buf[sizeof(uint64_t)];
+    memcpy(buf, &generation, sizeof(uint64_t));
+
+    WT_ITEM v;
+    v.size = sizeof(uint64_t);
+    v.data = buf;
+    cursor->set_key(cursor, paramKey.c_str());
+    cursor->set_value(cursor, &v);
+    res = cursor->insert(cursor);
+    if (res) {
+        LOGV2_ERROR(29067,
+                    "persistGeneration: cursor->insert error {code}: {desc}",
+                    "code"_attr = res,
+                    "desc"_attr = wiredtiger_strerror(res));
+        return res;
+    }
+
+    LOGV2_DEBUG(
+        29068, 4, "persistGeneration", "dbName"_attr = dbName, "generation"_attr = generation);
+    return 0;
+}
+
+uint64_t EncryptionKeyDB::loadGeneration(const std::string& dbName) {
+    // Load generation from table:parameters with key "dbgen:<dbName>"
+    std::string paramKey = "dbgen:" + dbName;
+
+    int res;
+    WT_CURSOR* cursor;
+    stdx::lock_guard<stdx::mutex> lk(_lock_sess);
+    res = _sess->open_cursor(_sess, "table:parameters", nullptr, nullptr, &cursor);
+    if (res) {
+        LOGV2_ERROR(29069,
+                    "loadGeneration: error opening cursor: {err}",
+                    "err"_attr = wiredtiger_strerror(res));
+        return 0;
+    }
+
+    std::unique_ptr<WT_CURSOR, std::function<void(WT_CURSOR*)>> cursor_guard(
+        cursor, [](WT_CURSOR* c) { c->close(c); });
+
+    cursor->set_key(cursor, paramKey.c_str());
+    res = cursor->search(cursor);
+    if (res == 0) {
+        WT_ITEM v;
+        cursor->get_value(cursor, &v);
+        if (v.size == sizeof(uint64_t)) {
+            uint64_t generation;
+            memcpy(&generation, v.data, sizeof(uint64_t));
+            LOGV2_DEBUG(
+                29070, 4, "loadGeneration", "dbName"_attr = dbName, "generation"_attr = generation);
+            return generation;
+        }
+    } else if (res != WT_NOTFOUND) {
+        LOGV2_ERROR(29071,
+                    "loadGeneration: cursor->search error {code}: {desc}",
+                    "code"_attr = res,
+                    "desc"_attr = wiredtiger_strerror(res));
+    }
+
+    // Not found or error - return 0 (database was never dropped)
+    return 0;
 }
 
 int EncryptionKeyDB::store_gcm_iv_reserved() {

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -38,6 +38,7 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/stdx/mutex.h"
 
 #include <map>
+#include <set>
 #include <string>
 
 #include <wiredtiger.h>
@@ -88,6 +89,30 @@ public:
 
     // drop key for specific keyid (used in dropDatabase)
     int delete_key_by_id(const std::string& keyid);
+
+    // PSMDB-1997: Deferred key deletion to handle database drop/recreate race conditions.
+    // When a database is dropped, we defer key deletion until all pending ident drops complete.
+    // If the database is recreated before all drops complete, we do NOT delete the key.
+
+    // Increment pending drop count for a database.
+    // Called when an ident is scheduled for deferred drop.
+    void incrementPendingDropCount(const std::string& keyid);
+
+    // Decrement pending drop count and potentially delete the key.
+    // When count reaches zero AND the database is marked for deletion (wasn't recreated),
+    // delete the key.
+    void decrementPendingDropCount(const std::string& keyid);
+
+    // Mark database as dropped and pending key deletion.
+    // The key will be deleted when all pending ident drops complete,
+    // unless the database is recreated (which clears the pending deletion flag).
+    // This also increments the generation so new database gets a new keyid.
+    void markDatabaseDropped(const std::string& dbName);
+
+    // Get the current keyid for a database (with generation suffix if applicable).
+    // For a database "test" that was dropped and recreated, this returns "test.v1", etc.
+    // For a database that was never dropped, returns the plain database name.
+    std::string getCurrentKeyId(const std::string& dbName);
 
     // get new counter value for IV in GCM mode
     int get_iv_gcm(uint8_t* buf, int len);
@@ -148,6 +173,21 @@ private:
     int reserve_gcm_iv_range();
     void generate_secure_key_inlock(char key[]);  // uses _srng without locks
 
+    // Persist generation number to table:parameters for a database.
+    // Key format: "dbgen:<dbName>" → uint64_t generation
+    int persistGeneration(const std::string& dbName, uint64_t generation);
+
+    // Load generation number from table:parameters for a database.
+    // Returns 0 if not found (database was never dropped).
+    uint64_t loadGeneration(const std::string& dbName);
+
+    static constexpr StringData kKeyIdGenerationSeparator = "."_sd;
+
+    static std::string to_keyid(const std::string& dbName, uint64_t generation) {
+        return generation > 0 ? dbName + kKeyIdGenerationSeparator + std::to_string(generation)
+                              : dbName;
+    }
+
     const bool _rotation;
     const std::string _path;
     std::string _wtOpenConfig;
@@ -167,6 +207,20 @@ private:
     // get_key_by_id creates entry
     // delete_key_by_it lets encryptor know that DB was deleted and deletes entry
     std::map<std::string, void*> _encryptors;
+
+    // PSMDB-1997: Track pending ident drops for deferred key deletion.
+    // _pendingDropMutex protects _pendingDropCounts, _keysPendingDeletion, and _nextGeneration.
+    stdx::mutex _pendingDropMutex;
+    // Counts of pending ident drops per versioned keyid (e.g., "test" or "test.v1").
+    // Now keyed by the actual versioned keyid from the ident's WiredTiger metadata.
+    std::map<std::string, int> _pendingDropCounts;
+    // Set of versioned keyids that are marked for deletion when all pending drops complete.
+    // A keyid is added here when markDatabaseDropped() is called.
+    std::set<std::string> _keysPendingDeletion;
+    // Maps database name to the next generation number to use.
+    // When a database is dropped, we increment this so new collections get a new keyid.
+    // Generation 0 means use plain dbName, generation 1 means use "dbName.v1", etc.
+    std::map<std::string, uint64_t> _nextGeneration;
 
     std::unique_ptr<WiredTigerSession> _backupSession;
     WT_CURSOR* _backupCursor;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp
@@ -33,6 +33,7 @@
 #include "mongo/base/string_data.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/service_context.h"
+#include "mongo/db/storage/storage_engine.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/database_name_util.h"
 #include "mongo/util/decorable.h"
@@ -65,6 +66,13 @@ public:
             boost::none, tableName, SerializationContext::stateDefault());
         std::string keyIdStr =
             DatabaseNameUtil::serialize(ns.dbName(), SerializationContext::stateDefault());
+
+        // Get the versioned keyid from the storage engine.
+        // This handles generation-based keyids for dropped and recreated databases.
+        auto* storageEngine = getGlobalServiceContext()->getStorageEngine();
+        if (storageEngine) {
+            keyIdStr = storageEngine->keydbGetCurrentKeyId(keyIdStr);
+        }
         StringData keyid(keyIdStr);
         // Keep compatibility with v3.6 after SERVER-34617
         const size_t minsize = 6;  // Minimum size which allows following condition to be true

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -1728,7 +1728,7 @@ public:
         : StorageEngine::StreamingCursor(options),
           _session(session),
           _path(path),
-          _wtBackup(wtBackup) {};
+          _wtBackup(wtBackup){};
 
     ~StreamingCursorImpl() override = default;
 
@@ -1957,9 +1957,7 @@ WiredTigerKVEngine::beginNonBlockingBackup(const StorageEngine::BackupOptions& o
 
     // Create ongoingBackup.lock file to signal recovery that it should delete WiredTiger.backup
     // if we have an unclean shutdown with the cursor still open.
-    {
-        boost::filesystem::ofstream ongoingBackup(getOngoingBackupPath());
-    }
+    { boost::filesystem::ofstream ongoingBackup(getOngoingBackupPath()); }
 
     // Oplog truncation thread won't remove oplog since the checkpoint pinned by the backup
     // cursor.
@@ -2492,8 +2490,8 @@ Status WiredTigerKVEngine::hotBackup(OperationContext* opCtx,
         auto outcome = s3_client->ListBuckets();
         if (!outcome.IsSuccess()) {
             return Status(ErrorCodes::InternalError,
-                          str::stream() << "Cannot list buckets on storage server"
-                                        << " : " << outcome.GetError().GetExceptionName() << " : "
+                          str::stream() << "Cannot list buckets on storage server" << " : "
+                                        << outcome.GetError().GetExceptionName() << " : "
                                         << outcome.GetError().GetMessage());
         }
         for (auto&& bucket : outcome.GetResult().GetBuckets()) {
@@ -2531,8 +2529,8 @@ Status WiredTigerKVEngine::hotBackup(OperationContext* opCtx,
         auto outcome = s3_client->ListObjects(request);
         if (!outcome.IsSuccess()) {
             return Status(ErrorCodes::InvalidPath,
-                          str::stream() << "Cannot list objects in the target location"
-                                        << " : " << outcome.GetError().GetExceptionName() << " : "
+                          str::stream() << "Cannot list objects in the target location" << " : "
+                                        << outcome.GetError().GetExceptionName() << " : "
                                         << outcome.GetError().GetMessage());
         }
         const auto root = s3params.path + '/';
@@ -2540,8 +2538,8 @@ Status WiredTigerKVEngine::hotBackup(OperationContext* opCtx,
         for (auto const& s3_object : object_list) {
             if (s3_object.GetKey() != root) {
                 return Status(ErrorCodes::InvalidPath,
-                              str::stream() << "Target location is not empty"
-                                            << " : " << s3params.bucket << '/' << s3params.path);
+                              str::stream() << "Target location is not empty" << " : "
+                                            << s3params.bucket << '/' << s3params.path);
             }
         }
     }
@@ -2582,8 +2580,8 @@ Status WiredTigerKVEngine::hotBackup(OperationContext* opCtx,
                                                     .WithUploadId(upload_id));
             if (!outcome2.IsSuccess()) {
                 return Status(ErrorCodes::InternalError,
-                              str::stream() << "Cannot abort test multipart upload"
-                                            << " : " << upload_id);
+                              str::stream()
+                                  << "Cannot abort test multipart upload" << " : " << upload_id);
             }
         }
     }
@@ -2848,17 +2846,16 @@ Status WiredTigerKVEngine::hotBackup(OperationContext* opCtx,
             "AWS", srcFile.string(), std::ios_base::in | std::ios_base::binary);
         if (!fileToUpload) {
             return Status(ErrorCodes::InvalidPath,
-                          str::stream()
-                              << "Cannot open file '" << srcFile.string() << "' for backup"
-                              << " : " << strerror(errno));
+                          str::stream() << "Cannot open file '" << srcFile.string()
+                                        << "' for backup" << " : " << strerror(errno));
         }
         request.SetBody(fileToUpload);
 
         auto outcome = s3_client->PutObject(request);
         if (!outcome.IsSuccess()) {
             return Status(ErrorCodes::InternalError,
-                          str::stream() << "Cannot backup '" << srcFile.string() << "'"
-                                        << " : " << outcome.GetError().GetExceptionName() << " : "
+                          str::stream() << "Cannot backup '" << srcFile.string() << "'" << " : "
+                                        << outcome.GetError().GetExceptionName() << " : "
                                         << outcome.GetError().GetMessage());
         }
         {
@@ -3591,16 +3588,51 @@ void WiredTigerKVEngine::dropIdentForImport(Interruptible& interruptible,
     invariant(dropStatus);
 }
 
-void WiredTigerKVEngine::keydbDropDatabase(const DatabaseName& dbName) {
+// PSMDB-1997: Deferred key deletion to handle database drop/recreate race conditions.
+// Instead of deleting the key immediately when a database is dropped, we:
+// 1. Mark the database as dropped
+// 2. Track pending ident drops
+// 3. Only delete the key when ALL pending idents are dropped AND the database wasn't recreated
+
+void WiredTigerKVEngine::keydbMarkDatabaseDropped(const DatabaseName& dbName) {
     if (_restEncr) {
-        int res = _restEncr->keyDb()->delete_key_by_id(
+        _restEncr->keyDb()->markDatabaseDropped(
             DatabaseNameUtil::serialize(dbName, SerializationContext::stateDefault()));
-        if (res) {
-            // we cannot throw exceptions here because we are inside WUOW::commit
-            // every other part of DB is already dropped so we just log error message
-            LOGV2_ERROR(29001, "failed to delete encryption key for db", logAttrs(dbName));
-        }
     }
+}
+
+void WiredTigerKVEngine::keydbIncrementPendingDropCount(const std::string& dbName) {
+    if (_restEncr) {
+        _restEncr->keyDb()->incrementPendingDropCount(dbName);
+    }
+}
+
+void WiredTigerKVEngine::keydbDecrementPendingDropCount(const std::string& dbName) {
+    if (_restEncr) {
+        _restEncr->keyDb()->decrementPendingDropCount(dbName);
+    }
+}
+
+std::string WiredTigerKVEngine::keydbGetCurrentKeyId(const std::string& dbName) {
+    if (_restEncr) {
+        return _restEncr->keyDb()->getCurrentKeyId(dbName);
+    }
+    return dbName;
+}
+
+std::string WiredTigerKVEngine::getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) {
+    auto& wtRu = WiredTigerRecoveryUnit::get(ru);
+    auto uri = WiredTigerUtil::buildTableUri(ident);
+    auto result = WiredTigerUtil::getEncryptionKeyId(*wtRu.getSessionNoTxn(), uri);
+    if (!result.isOK()) {
+        LOGV2_DEBUG(29072,
+                    4,
+                    "Failed to get encryption keyid for ident",
+                    "ident"_attr = ident,
+                    "error"_attr = result.getStatus());
+        return std::string();
+    }
+    return result.getValue();
 }
 
 void WiredTigerKVEngine::_checkpoint(WiredTigerSession& session, bool useTimestamp) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -509,7 +509,12 @@ public:
 
     Status alterMetadata(StringData uri, StringData config) override;
 
-    void keydbDropDatabase(const DatabaseName& dbName) override;
+    // PSMDB-1997: Deferred key deletion to handle database drop/recreate race conditions
+    void keydbMarkDatabaseDropped(const DatabaseName& dbName) override;
+    void keydbIncrementPendingDropCount(const std::string& keyid) override;
+    void keydbDecrementPendingDropCount(const std::string& keyid) override;
+    std::string keydbGetCurrentKeyId(const std::string& dbName) override;
+    std::string getIdentEncryptionKeyId(RecoveryUnit& ru, StringData ident) override;
 
     void flushAllFiles(OperationContext* opCtx, bool callerHoldsReadLock) override;
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
@@ -185,6 +185,48 @@ StatusWith<std::string> WiredTigerUtil::getSourceMetadata(WiredTigerSession& ses
     return _getMetadata(cursor, StringData(item.str, item.len));
 }
 
+StatusWith<std::string> WiredTigerUtil::getEncryptionKeyId(WiredTigerSession& session,
+                                                           StringData uri) {
+    // Get the metadata for the table
+    StatusWith<std::string> metadataResult = getMetadataCreate(session, uri);
+    if (!metadataResult.isOK()) {
+        return metadataResult.getStatus();
+    }
+
+    // Parse the metadata to find encryption config
+    WiredTigerConfigParser parser(metadataResult.getValue());
+    WT_CONFIG_ITEM encryptionItem;
+    int ret = parser.get("encryption", &encryptionItem);
+    if (ret == WT_NOTFOUND) {
+        // No encryption configured
+        return std::string();
+    }
+    if (ret != 0) {
+        return Status(ErrorCodes::InternalError,
+                      str::stream() << "Failed to get encryption config: " << ret);
+    }
+
+    // Parse the encryption sub-config to get keyid
+    if (encryptionItem.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRUCT) {
+        return std::string();
+    }
+
+    WiredTigerConfigParser encryptionParser(encryptionItem);
+    WT_CONFIG_ITEM keyidItem;
+    ret = encryptionParser.get("keyid", &keyidItem);
+    if (ret == WT_NOTFOUND || keyidItem.len == 0) {
+        // No keyid configured
+        return std::string();
+    }
+    if (ret != 0) {
+        return Status(ErrorCodes::InternalError,
+                      str::stream() << "Failed to get keyid from encryption config: " << ret);
+    }
+
+    // Return the keyid string
+    return std::string(keyidItem.str, keyidItem.len);
+}
+
 Status WiredTigerUtil::getApplicationMetadata(WiredTigerSession& session,
                                               StringData uri,
                                               BSONObjBuilder* bob) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.h
@@ -222,6 +222,15 @@ public:
     static StatusWith<std::string> getSourceMetadata(WiredTigerSession& session, StringData uri);
 
     /**
+     * Gets the encryption keyid for a table at the given URI.
+     *
+     * Returns the keyid string if encryption is configured for the table.
+     * Returns an empty string if encryption is not configured or keyid is not set.
+     * Returns an error status if the metadata cannot be read.
+     */
+    static StatusWith<std::string> getEncryptionKeyId(WiredTigerSession& session, StringData uri);
+
+    /**
      * Reads app_metadata for collection/index at URI as a BSON document.
      */
     static Status getApplicationMetadata(WiredTigerSession& session,


### PR DESCRIPTION
This commit fixes a race condition in the TDE (Transparent Data Encryption) implementation where dropping a database and immediately recreating it with the same name causes data corruption ('bad decrypt' errors).

Problem:
When a database is dropped, idents are marked for deferred deletion (for checkpoint-cleanup to finish). If the database is recreated before cleanup completes, the old and new databases shared the same encryptor instance because keyid was based solely on database name. When the new key was loaded, it overwrote the old key, causing checkpoint-cleanup to fail when trying to decrypt old data.

Solution:
Implement generation-based keyids to ensure old and new database instances use separate encryptors with separate keys:
- First database 'test' uses keyid='test'
- After drop/recreate: keyid='test.v1', then 'test.v2', etc.
- Generation is persisted in table:parameters (key: 'dbgen:<dbName>')
- O(1) lookup via single cursor search (optimized from O(N) table scan)

Key changes:
- Added getCurrentKeyId() to return versioned keyid for new tables
- Added persistGeneration()/loadGeneration() for O(1) generation lookup
- Modified markDatabaseDropped() to increment generation and persist it
- Updated wiredtiger_customization_hooks.cpp to use versioned keyids
- Updated import_data_from() to copy generation data during key rotation
- Track pending drops by database name with mapping to versioned keyid

The old encryptor (with old key) remains cached for checkpoint-cleanup, while new collections get a new encryptor with a new key.
