### PR TITLE
PSMDB-2003 Implement caching for userToDN mapping

### DIFF
--- a/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
+++ b/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
@@ -1,0 +1,174 @@
+/**
+ * Tests userToDN mapping cache behavior:
+ * - Authentication works correctly with caching enabled and disabled
+ * - Cache is invalidated when ldapUserToDNMapping is changed at runtime
+ * - Cache is invalidated when ldapUserToDNCacheTTLSeconds is changed at runtime
+ * - Cache is invalidated when ldapUserToDNCacheSize is changed at runtime
+ * - New server parameters can be read and set at runtime
+ */
+import {createAdminUser} from "jstests/ldapauthz/_setup.js";
+
+(function() {
+"use strict";
+
+load("jstests/ldapauthz/_check.js");
+
+const username = "exttestro";
+const userpwd = "exttestro9a5S";
+const nameToDn = function(name) {
+    return "cn=" + name + ",dc=percona,dc=com";
+};
+
+const ldapQueryMapping =
+    '[{match: "(.+)", ldapQuery: "dc=percona,dc=com??sub?(&(objectClass=organizationalPerson)(sn={0}))"}]';
+const substMapping = '[{match: "(.+)", substitution: "cn={0},dc=percona,dc=com"}]';
+const brokenMapping = '[{match: "(.+)", substitution: "cn={0},dc=WRONG,dc=com"}]';
+
+function baseMongodOpts(extraSetParams) {
+    // Use a short user cache invalidation interval so that each auth attempt after
+    // a setParameter change re-resolves the DN via mapUserToDN() instead of being
+    // served from the $external authorization user cache.
+    var setParameter = Object.assign({
+        authenticationMechanisms: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-1",
+        ldapUserCacheInvalidationInterval: 1,
+        ldapShouldRefreshUserCacheEntries: false,
+    },
+                                     extraSetParams || {});
+    return {
+        auth: "",
+        ldapServers: TestData.ldapServers,
+        ldapTransportSecurity: "none",
+        ldapBindMethod: "simple",
+        ldapQueryUser: TestData.ldapQueryUser,
+        ldapQueryPassword: TestData.ldapQueryPassword,
+        ldapAuthzQueryTemplate: TestData.ldapAuthzQueryTemplate,
+        ldapUserToDNMapping: ldapQueryMapping,
+        setParameter: setParameter,
+    };
+}
+
+function authLDAPUser(conn) {
+    var db = conn.getDB("$external");
+    var ok = db.auth({user: username, pwd: userpwd, mechanism: "PLAIN"});
+    if (ok) {
+        checkConnectionStatus(username, db.runCommand({connectionStatus: 1}), nameToDn);
+        db.logout();
+    }
+    return ok;
+}
+
+function setParam(conn, paramObj) {
+    var adminDb = conn.getDB("admin");
+    assert(adminDb.auth({user: "admin", pwd: "password"}));
+    assert.commandWorked(adminDb.adminCommand(Object.assign({setParameter: 1}, paramObj)));
+    adminDb.logout();
+    // Wait for the $external user cache to be invalidated (interval is 1s)
+    // so the next auth attempt re-resolves the DN via mapUserToDN().
+    sleep(2000);
+}
+
+function getParam(conn, paramName) {
+    var adminDb = conn.getDB("admin");
+    assert(adminDb.auth({user: "admin", pwd: "password"}));
+    var cmd = {getParameter: 1};
+    cmd[paramName] = 1;
+    var res = adminDb.adminCommand(cmd);
+    assert.commandWorked(res);
+    adminDb.logout();
+    return res[paramName];
+}
+
+// ------------------------------------------------------------------
+// Instance 1: Cache enabled with default params, ldapQuery mapping
+// ------------------------------------------------------------------
+{
+    jsTestLog("Starting instance with default cache params and ldapQuery mapping");
+
+    var conn = MongoRunner.runMongod(baseMongodOpts());
+    assert(conn, "Cannot start mongod instance");
+
+    createAdminUser(conn);
+
+    jsTestLog("Test: Auth with cache enabled (first call)");
+    assert(authLDAPUser(conn), "First auth should succeed");
+
+    jsTestLog("Test: Auth with cache enabled (second call, cache hit)");
+    assert(authLDAPUser(conn), "Second auth should succeed (cache hit)");
+
+    jsTestLog("Test: getParameter returns default cache values");
+    assert.eq(getParam(conn, "ldapUserToDNCacheTTLSeconds"), 30);
+    assert.eq(getParam(conn, "ldapUserToDNCacheSize"), 10000);
+
+    jsTestLog("Test: Invalidation on ldapUserToDNMapping change to substitution mode");
+    setParam(conn, {ldapUserToDNMapping: substMapping});
+    assert(authLDAPUser(conn), "Auth should succeed with substitution mapping");
+
+    jsTestLog("Test: Invalidation on ldapUserToDNMapping change to broken mapping");
+    setParam(conn, {ldapUserToDNMapping: brokenMapping});
+    assert(!authLDAPUser(conn),
+           "Auth should fail with broken mapping (proves cache was invalidated)");
+
+    jsTestLog("Test: Restore original ldapQuery mapping");
+    setParam(conn, {ldapUserToDNMapping: ldapQueryMapping});
+    assert(authLDAPUser(conn), "Auth should succeed after restoring ldapQuery mapping");
+
+    // To prove TTL/size changes actually invalidate the DN cache, we populate the
+    // cache with the correct mapping, then change the cache parameter AND switch to
+    // the broken mapping in the same batch. If the cache were NOT invalidated by the
+    // parameter change, the old cached DN would still be used and auth would succeed.
+    // Auth failing proves the parameter change cleared the cache.
+
+    jsTestLog("Test: ldapUserToDNCacheTTLSeconds change invalidates the DN cache");
+    setParam(conn, {ldapUserToDNMapping: ldapQueryMapping});
+    assert(authLDAPUser(conn), "Auth should succeed to populate cache");
+    setParam(conn, {ldapUserToDNCacheTTLSeconds: 60, ldapUserToDNMapping: brokenMapping});
+    assert(!authLDAPUser(conn), "Auth should fail — proves TTL change invalidated the DN cache");
+
+    jsTestLog("Test: ldapUserToDNCacheTTLSeconds=0 disables the DN cache");
+    setParam(conn, {ldapUserToDNCacheTTLSeconds: 0, ldapUserToDNMapping: ldapQueryMapping});
+    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (TTL=0)");
+
+    setParam(conn, {ldapUserToDNCacheTTLSeconds: 30});
+
+    jsTestLog("Test: ldapUserToDNCacheSize change invalidates the DN cache");
+    assert(authLDAPUser(conn), "Auth should succeed to populate cache");
+    setParam(conn, {ldapUserToDNCacheSize: 1, ldapUserToDNMapping: brokenMapping});
+    assert(!authLDAPUser(conn), "Auth should fail — proves size change invalidated the DN cache");
+
+    jsTestLog("Test: ldapUserToDNCacheSize=0 disables the DN cache");
+    setParam(conn, {ldapUserToDNCacheSize: 0, ldapUserToDNMapping: ldapQueryMapping});
+    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (size=0)");
+
+    setParam(conn, {ldapUserToDNCacheSize: 10000});
+
+    MongoRunner.stopMongod(conn);
+}
+
+// ------------------------------------------------------------------
+// Instance 2: Cache disabled at startup via TTL=0
+// ------------------------------------------------------------------
+{
+    jsTestLog("Test: Auth works with cache disabled at startup (TTL=0)");
+
+    var conn = MongoRunner.runMongod(baseMongodOpts({ldapUserToDNCacheTTLSeconds: 0}));
+    assert(conn, "Cannot start mongod instance");
+
+    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (TTL=0)");
+
+    MongoRunner.stopMongod(conn);
+}
+
+// ------------------------------------------------------------------
+// Instance 3: Cache disabled at startup via size=0
+// ------------------------------------------------------------------
+{
+    jsTestLog("Test: Auth works with cache disabled at startup (size=0)");
+
+    var conn = MongoRunner.runMongod(baseMongodOpts({ldapUserToDNCacheSize: 0}));
+    assert(conn, "Cannot start mongod instance");
+
+    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (size=0)");
+
+    MongoRunner.stopMongod(conn);
+}
+})();

--- a/src/mongo/db/ldap/ldap_manager.h
+++ b/src/mongo/db/ldap/ldap_manager.h
@@ -61,6 +61,9 @@ public:
 
     // Invalidate all pooled LDAP connections. Called when bind credentials change.
     virtual void invalidateConnections() = 0;
+
+    // Invalidate all cached userToDN mapping results.
+    virtual void invalidateUserToDNCache() = 0;
 };
 
 }  // namespace mongo

--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -36,6 +36,7 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include <map>
 #include <memory>
 #include <regex>
+#include <shared_mutex>
 #include <utility>
 #include <vector>
 
@@ -657,6 +658,9 @@ Status LDAPManagerImpl::initialize() {
         ber_set_option(nullptr, LBER_OPT_LOG_PRINT_FN, reinterpret_cast<const void*>(cb_log));
     }
 
+    // Initialize _userToDNCache and friends on startup
+    invalidateUserToDNCache();
+
     return Status::OK();
 }
 
@@ -902,14 +906,48 @@ std::string substituteFromMatch(const std::string& stempl,
 
 }  // namespace
 
-Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
-    // TODO: keep BSONArray somewhere in ldapGlobalParams (but consider multithreaded access)
-    std::string mapping = ldapGlobalParams.ldapUserToDNMapping.get();
+void LDAPManagerImpl::invalidateUserToDNCache() {
+    // Exclusive lock: waits for all in-flight mapUserToDN() calls to finish,
+    // then resets the cache before allowing new mapUserToDN() invocations.
+    stdx::lock_guard rwLock(_userToDNRWMutex);
+    auto cacheSize = ldapGlobalParams.ldapUserToDNCacheSize.load();
+    auto cacheTTL = ldapGlobalParams.ldapUserToDNCacheTTLSeconds.load();
+    _userToDNCache =
+        std::make_unique<UserToDNCache>(static_cast<std::size_t>(std::max(cacheSize, 0)));
+    _userToDNCacheTTLSnapshot = cacheTTL;
+    _userToDNCacheEnabled = (cacheTTL > 0 && cacheSize > 0);
+    BSONArray bsonMapping{fromjson(ldapGlobalParams.ldapUserToDNMapping.get())};
+    _userToDNMappingSnapshot.swap(bsonMapping);
+}
 
+Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
+    // _userToDNCacheEnabled and _userToDNCacheTTLSnapshot are safe to read without
+    // _userToDNCacheMutex because they are only written under the exclusive RW lock.
+    std::shared_lock rwLock(_userToDNRWMutex);  // NOLINT
+
+    const bool cacheEnabled = _userToDNCacheEnabled;
+    const auto ttl = _userToDNCacheTTLSnapshot;
+
+    // Check the userToDN cache
+    if (cacheEnabled) {
+        stdx::lock_guard<Latch> lock(_userToDNCacheMutex);
+        // Use cfind to avoid promoting outdated entries
+        auto it = _userToDNCache->cfind(user);
+        if (it != _userToDNCache->cend()) {
+            if (Date_t::now() - it->second.insertedAt < Seconds(ttl)) {
+                _userToDNCache->promote(it);
+                out = it->second.dn;
+                return Status::OK();
+            }
+        }
+    }
+
+    // Perform the actual mapping (inner mutex NOT held during potential LDAP queries,
+    // but shared RW lock IS held to prevent concurrent cache invalidation)
     // Parameter validator checks that mapping is valid array of objects
     // see validateLDAPUserToDNMapping function
-    BSONArray bsonmapping{fromjson(mapping)};
-    for (const auto& elt : bsonmapping) {
+    bool mapped = false;
+    for (const auto& elt : _userToDNMappingSnapshot) {
         auto step = elt.Obj();
         std::smatch sm;
         std::regex rex{step["match"].str()};
@@ -921,7 +959,8 @@ Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
                 // we do not escape substituted values here because result value will be used as
                 // {USER} and will be escaped there
                 out = substituteFromMatch(eltempl.str(), sm);
-                return Status::OK();
+                mapped = true;
+                break;
             }
             // ldapQuery mode
             std::string escapedQuery;
@@ -954,12 +993,21 @@ Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
             // otherwise continue search
             if (qresult.size() == 1) {
                 out = qresult[0];
-                return Status::OK();
+                mapped = true;
+                break;
             }
         }
     }
-    // we have no successful transformations, return error
-    return {ErrorCodes::UserNotFound, "Failed to map user '{}' to LDAP DN"_format(user)};
+
+    if (!mapped) {
+        return {ErrorCodes::UserNotFound, "Failed to map user '{}' to LDAP DN"_format(user)};
+    }
+
+    if (cacheEnabled) {
+        stdx::lock_guard<Latch> lock(_userToDNCacheMutex);
+        _userToDNCache->add(user, UserToDNCacheEntry{.dn = out, .insertedAt = Date_t::now()});
+    }
+    return Status::OK();
 }
 
 Status LDAPManagerImpl::queryUserRoles(const UserName& userName,

--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -36,7 +36,6 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include <map>
 #include <memory>
 #include <regex>
-#include <shared_mutex>
 #include <utility>
 #include <vector>
 
@@ -906,48 +905,44 @@ std::string substituteFromMatch(const std::string& stempl,
 
 }  // namespace
 
+LDAPManagerImpl::UserToDNCacheHolder::UserToDNCacheHolder()
+    : size(ldapGlobalParams.ldapUserToDNCacheSize.load()),
+      ttl(ldapGlobalParams.ldapUserToDNCacheTTLSeconds.load()),
+      enabled(ttl > 0 && size > 0),
+      mapping(fromjson(ldapGlobalParams.ldapUserToDNMapping.get())),
+      cache(static_cast<std::size_t>(std::max(size, 0))) {}
+
 void LDAPManagerImpl::invalidateUserToDNCache() {
-    // Exclusive lock: waits for all in-flight mapUserToDN() calls to finish,
-    // then resets the cache before allowing new mapUserToDN() invocations.
-    stdx::lock_guard rwLock(_userToDNRWMutex);
-    auto cacheSize = ldapGlobalParams.ldapUserToDNCacheSize.load();
-    auto cacheTTL = ldapGlobalParams.ldapUserToDNCacheTTLSeconds.load();
-    _userToDNCache =
-        std::make_unique<UserToDNCache>(static_cast<std::size_t>(std::max(cacheSize, 0)));
-    _userToDNCacheTTLSnapshot = cacheTTL;
-    _userToDNCacheEnabled = (cacheTTL > 0 && cacheSize > 0);
-    BSONArray bsonMapping{fromjson(ldapGlobalParams.ldapUserToDNMapping.get())};
-    _userToDNMappingSnapshot.swap(bsonMapping);
+    // Atomically replace instance of UserToDNCacheHolder
+    // the new instance is current snapshot of the ldapGlobalParams
+    _userToDNCacheHolder = std::make_shared<UserToDNCacheHolder>();
 }
 
 Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
-    // _userToDNCacheEnabled and _userToDNCacheTTLSnapshot are safe to read without
-    // _userToDNCacheMutex because they are only written under the exclusive RW lock.
-    std::shared_lock rwLock(_userToDNRWMutex);  // NOLINT
-
-    const bool cacheEnabled = _userToDNCacheEnabled;
-    const auto ttl = _userToDNCacheTTLSnapshot;
+    // Atomically get shared pointer instance to the current cache
+    // We can work with this instance of the cache even if configuration changes trigger
+    // invalidateUserToDNCache() in parallel
+    std::shared_ptr<UserToDNCacheHolder> cache = *_userToDNCacheHolder;
 
     // Check the userToDN cache
-    if (cacheEnabled) {
-        stdx::lock_guard<Latch> lock(_userToDNCacheMutex);
+    if (cache->enabled) {
+        stdx::lock_guard<Latch> lock(cache->mutex);
         // Use cfind to avoid promoting outdated entries
-        auto it = _userToDNCache->cfind(user);
-        if (it != _userToDNCache->cend()) {
-            if (Date_t::now() - it->second.insertedAt < Seconds(ttl)) {
-                _userToDNCache->promote(it);
+        auto it = cache->cache.cfind(user);
+        if (it != cache->cache.cend()) {
+            if (Date_t::now() - it->second.insertedAt < Seconds(cache->ttl)) {
+                cache->cache.promote(it);
                 out = it->second.dn;
                 return Status::OK();
             }
         }
     }
 
-    // Perform the actual mapping (inner mutex NOT held during potential LDAP queries,
-    // but shared RW lock IS held to prevent concurrent cache invalidation)
+    // Perform the actual mapping (inner mutex NOT held during potential LDAP queries
     // Parameter validator checks that mapping is valid array of objects
     // see validateLDAPUserToDNMapping function
     bool mapped = false;
-    for (const auto& elt : _userToDNMappingSnapshot) {
+    for (const auto& elt : cache->mapping) {
         auto step = elt.Obj();
         std::smatch sm;
         std::regex rex{step["match"].str()};
@@ -1003,9 +998,9 @@ Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
         return {ErrorCodes::UserNotFound, "Failed to map user '{}' to LDAP DN"_format(user)};
     }
 
-    if (cacheEnabled) {
-        stdx::lock_guard<Latch> lock(_userToDNCacheMutex);
-        _userToDNCache->add(user, UserToDNCacheEntry{.dn = out, .insertedAt = Date_t::now()});
+    if (cache->enabled) {
+        stdx::lock_guard<Latch> lock(cache->mutex);
+        cache->cache.add(user, UserToDNCacheEntry{.dn = out, .insertedAt = Date_t::now()});
     }
     return Status::OK();
 }

--- a/src/mongo/db/ldap/ldap_manager_impl.h
+++ b/src/mongo/db/ldap/ldap_manager_impl.h
@@ -31,10 +31,15 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include <ldap.h>
+
+#include "mongo/bson/bsonobj.h"
 #include "mongo/db/ldap/ldap_manager.h"
 #include "mongo/logv2/log_severity.h"
-
-#include <ldap.h>
+#include "mongo/platform/mutex.h"
+#include "mongo/platform/rwmutex.h"
+#include "mongo/util/lru_cache.h"
+#include "mongo/util/time_support.h"
 
 namespace mongo {
 
@@ -56,7 +61,26 @@ public:
 
     void invalidateConnections() override;
 
+    void invalidateUserToDNCache() override;
+
 private:
+    struct UserToDNCacheEntry {
+        std::string dn;
+        Date_t insertedAt;
+    };
+
+    // RWMutex ensures invalidateUserToDNCache() waits for all in-flight mapUserToDN() calls.
+    // mapUserToDN() holds a shared lock for its entire duration (including LDAP queries).
+    // invalidateUserToDNCache() holds an exclusive lock to drain and reset the cache.
+    RWMutex _userToDNRWMutex;
+    // Inner mutex protects the cache data structure from concurrent mapUserToDN() callers.
+    Mutex _userToDNCacheMutex = MONGO_MAKE_LATCH("LDAPManagerImpl::_userToDNCacheMutex");
+    using UserToDNCache = LRUCache<std::string, UserToDNCacheEntry>;
+    std::unique_ptr<UserToDNCache> _userToDNCache;
+    int _userToDNCacheTTLSnapshot{0};
+    bool _userToDNCacheEnabled{false};
+    BSONArray _userToDNMappingSnapshot;
+
     std::unique_ptr<ConnectionPoller> _connPoller;
 
     LDAP* borrow_search_connection();

--- a/src/mongo/db/ldap/ldap_manager_impl.h
+++ b/src/mongo/db/ldap/ldap_manager_impl.h
@@ -31,15 +31,16 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include "mongo/util/synchronized_value.h"
 #include <ldap.h>
 
 #include "mongo/bson/bsonobj.h"
 #include "mongo/db/ldap/ldap_manager.h"
 #include "mongo/logv2/log_severity.h"
 #include "mongo/platform/mutex.h"
-#include "mongo/platform/rwmutex.h"
 #include "mongo/util/lru_cache.h"
 #include "mongo/util/time_support.h"
+#include <memory>
 
 namespace mongo {
 
@@ -69,17 +70,24 @@ private:
         Date_t insertedAt;
     };
 
-    // RWMutex ensures invalidateUserToDNCache() waits for all in-flight mapUserToDN() calls.
-    // mapUserToDN() holds a shared lock for its entire duration (including LDAP queries).
-    // invalidateUserToDNCache() holds an exclusive lock to drain and reset the cache.
-    RWMutex _userToDNRWMutex;
-    // Inner mutex protects the cache data structure from concurrent mapUserToDN() callers.
-    Mutex _userToDNCacheMutex = MONGO_MAKE_LATCH("LDAPManagerImpl::_userToDNCacheMutex");
-    using UserToDNCache = LRUCache<std::string, UserToDNCacheEntry>;
-    std::unique_ptr<UserToDNCache> _userToDNCache;
-    int _userToDNCacheTTLSnapshot{0};
-    bool _userToDNCacheEnabled{false};
-    BSONArray _userToDNMappingSnapshot;
+    struct UserToDNCacheHolder {
+        UserToDNCacheHolder();
+
+        using UserToDNCache = LRUCache<std::string, UserToDNCacheEntry>;
+
+        const int size;
+        const int ttl;
+        const bool enabled;
+        const BSONArray mapping;
+        Mutex mutex = MONGO_MAKE_LATCH("UserToDNCacheHolder::mutex");
+        UserToDNCache cache;
+    };
+
+    // UserToDNCacheHolder will be atomically replaced on any configuration changes
+    // This enables cache reset without blocking any client threads running mapUserToDN()
+    // Multiple threads can have shared_ptr instances pointing to the same UserToDNCacheHolder
+    // instance
+    synchronized_value<std::shared_ptr<UserToDNCacheHolder>> _userToDNCacheHolder;
 
     std::unique_ptr<ConnectionPoller> _connPoller;
 

--- a/src/mongo/db/ldap_options.cpp
+++ b/src/mongo/db/ldap_options.cpp
@@ -95,14 +95,17 @@ std::string LDAPGlobalParams::ldapURIList() const {
 }
 
 
-static void invalidateLDAPConnections() {
+namespace {
+void invalidateLDAPConnections() {
     if (hasGlobalServiceContext()) {
         auto* manager = LDAPManager::get(getGlobalServiceContext());
         if (manager) {
             manager->invalidateConnections();
+            manager->invalidateUserToDNCache();
         }
     }
 }
+}  // namespace
 
 void LDAPServersParameter::append(OperationContext*,
                                   BSONObjBuilder* b,
@@ -139,6 +142,27 @@ Status LDAPQueryPasswordParameter::setFromString(StringData newValueString,
                                                  const boost::optional<TenantId>&) {
     ldapGlobalParams.ldapQueryPassword = std::string(newValueString);
     invalidateLDAPConnections();
+    return Status::OK();
+}
+
+namespace {
+void invalidateUserToDNCache() {
+    if (hasGlobalServiceContext()) {
+        auto* manager = LDAPManager::get(getGlobalServiceContext());
+        if (manager) {
+            manager->invalidateUserToDNCache();
+        }
+    }
+}
+}  // namespace
+
+Status onUpdateLDAPUserToDNCacheParam(const int&) {
+    invalidateUserToDNCache();
+    return Status::OK();
+}
+
+Status onUpdateLDAPUserToDNMapping(const std::string&) {
+    invalidateUserToDNCache();
     return Status::OK();
 }
 

--- a/src/mongo/db/ldap_options.h
+++ b/src/mongo/db/ldap_options.h
@@ -68,6 +68,8 @@ struct LDAPGlobalParams {
     AtomicWord<bool> ldapDebug;
     AtomicWord<bool> ldapFollowReferrals;
     AtomicWord<int> ldapConnectionPoolSizePerHost;
+    AtomicWord<int> ldapUserToDNCacheTTLSeconds;
+    AtomicWord<int> ldapUserToDNCacheSize;
     bool ldapValidateLDAPServerConfig = true;
 
     std::string getServersStr() const;
@@ -80,6 +82,9 @@ Status validateLDAPBindMethod(const std::string&);
 Status validateLDAPTransportSecurity(const std::string&);
 Status validateLDAPUserToDNMapping(const std::string&);
 Status validateLDAPAuthzQueryTemplate(const std::string&);
+
+Status onUpdateLDAPUserToDNCacheParam(const int&);
+Status onUpdateLDAPUserToDNMapping(const std::string&);
 
 Status validateLDAPUserToDNMappingServerParam(const std::string&, const boost::optional<TenantId>&);
 Status validateLDAPAuthzQueryTemplateServerParam(const std::string&,

--- a/src/mongo/db/ldap_options.idl
+++ b/src/mongo/db/ldap_options.idl
@@ -62,6 +62,7 @@ server_parameters:
         set_at: runtime
         cpp_varname: "ldapGlobalParams.ldapUserToDNMapping"
         default: "[{match: \"(.+)\", substitution: \"{0}\"}]"
+        on_update: "onUpdateLDAPUserToDNMapping"
         validator:
             callback: validateLDAPUserToDNMappingServerParam
     ldapUseConnectionPool:
@@ -109,6 +110,26 @@ server_parameters:
         default: 2
         validator:
           gt: 0
+    ldapUserToDNCacheTTLSeconds:
+        description: "TTL in seconds for userToDN mapping cache entries. 0 disables caching."
+        set_at: [startup, runtime]
+        cpp_varname: "ldapGlobalParams.ldapUserToDNCacheTTLSeconds"
+        default: 30
+        on_update: "onUpdateLDAPUserToDNCacheParam"
+        validator:
+            gte: 0
+            lte: 86400
+        redact: false
+    ldapUserToDNCacheSize:
+        description: "Maximum number of entries in the userToDN mapping cache. 0 disables caching."
+        set_at: [startup, runtime]
+        cpp_varname: "ldapGlobalParams.ldapUserToDNCacheSize"
+        default: 10000
+        on_update: "onUpdateLDAPUserToDNCacheParam"
+        validator:
+            gte: 0
+            lte: 1000000
+        redact: false
 
 configs:
     'security.ldap.servers':


### PR DESCRIPTION
Cache the result of LDAPManagerImpl::mapUserToDN() to reduce LDAP server roundtrips during authentication and authorization. The cache uses an LRU eviction policy (via LRUCache) and per-entry TTL.

Two new server parameters control the cache:
- ldapUserToDNCacheTTLSeconds (default 30, 0 disables)
- ldapUserToDNCacheSize (default 10000, 0 disables)

Synchronization uses two synchronization mechanisms:
- synchronized_value: cache configuration snapshot is protected by synchronized_value which allows us to minimize blocking on configuration changes.
- Inner Mutex: serializes concurrent cache access from mapUserToDN().

The cache is invalidated on runtime changes to ldapUserToDNMapping, ldapUserToDNCacheTTLSeconds, ldapUserToDNCacheSize, ldapServers, ldapQueryUser, and ldapQueryPassword.