### PR TITLE
PSMDB-2033: fix clang-tidy workflow for upstream compiledb changes

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -81,13 +81,12 @@ jobs:
       - name: Fetch tags
         run: |
           git fetch --tags --force origin
+          # Fetch upstream MongoDB tags (r*) needed for version detection via git describe
+          git fetch --tags --force https://github.com/mongodb/mongo.git 'refs/tags/r*:refs/tags/r*'
           git describe --abbrev=0
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
-
-      - name: Setup AWS SDK
-        uses: ./.github/actions/setup-aws-sdk
 
       - name: clang-tidy-sarif cache
         uses: actions/cache@v4
@@ -100,32 +99,56 @@ jobs:
         if: steps.clang_tidy_sarif_cache.outputs.cache-hit != 'true'
         run: cargo install clang-tidy-sarif --version "${CLANG_TIDY_SARIF_VERSION}" --locked
 
-      - name: Generate compile_commands.json and build dependencies
+      - name: Bazel disk cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/bazel-disk-cache
+          key: bazel-disk-cache-clang-tidy-${{ runner.os }}-${{ hashFiles('.github/workflows/clang-tidy.yml', 'MODULE.bazel', 'WORKSPACE', 'WORKSPACE.bazel', '**/*.bzl', '**/BUILD', '**/BUILD.bazel') }}
+          restore-keys: |
+            bazel-disk-cache-clang-tidy-${{ runner.os }}-
+
+      - name: Configure Bazel
         run: |
+          # Set JVM heap in user bazelrc so it applies to ALL bazel invocations
+          # (including the wrapper hook's prereq install which runs before
+          # .bazelrc.compiledb is read)
+          echo 'startup --host_jvm_args=-Xmx8g' >> ~/.bazelrc
           {
             echo 'common --config=local'
+            echo 'common --bes_timeout=0s'
+            echo 'common --bes_upload_mode=nowait_for_upload_complete'
+            echo 'common --disk_cache=/tmp/bazel-disk-cache'
             echo 'common --//bazel/config:build_enterprise=False'
             echo 'common --//bazel/config:compiler_type=clang'
           } > .bazelrc.compiledb
-          # Build compiledb target - this triggers the wrapper hook which:
-          # 1. Generates compile_commands.json via aquery
-          # 2. Builds all gen_source targets (config.h, wiredtiger.h, etc.)
-          # 3. Builds clang_tidy_config and copies .clang-tidy to repo root
-          # Use both .bazelrc and .bazelrc.compiledb to retain baseline repo settings
+
+      - name: Generate compile_commands.json and build dependencies
+        run: |
+          # Compute the narrowest compiledb scope from the changed files.
+          # The new compiledb aspect builds the entire scope (default: //src/...)
+          # which is too heavy for CI without remote execution. Narrow it to only
+          # the packages containing changed files.
+          CHANGED="${{ needs.changed_files.outputs.changed_files }}"
+          SCOPE=$(echo "$CHANGED" | tr ' ' '\n' | python3 - <<'PY'
+          import sys, os
+          files = [l.strip() for l in sys.stdin if l.strip()]
+          dirs = sorted(set(os.path.dirname(f) for f in files))
+          if not dirs:
+              print('//src/...')
+          else:
+              common = os.path.commonpath(dirs)
+              print(f'//{common}/...')
+          PY
+          )
+          export MONGO_COMPILEDB_TARGET_SCOPE="$SCOPE"
+          echo "Compiledb scope: $SCOPE (from $(echo $CHANGED | wc -w) changed files)"
+
           bazel \
             --bazelrc=.bazelrc \
             --bazelrc=.bazelrc.compiledb \
             build \
             //:compiledb \
             //src/mongo/tools/mongo_tidy_checks:mongo_tidy_checks
-          # Build prometheus exporter to fetch external dependencies (prometheus-cpp)
-          # needed for clang-tidy to analyze otel/metrics files.
-          # This is not covered by gen_source tag.
-          bazel \
-            --bazelrc=.bazelrc \
-            --bazelrc=.bazelrc.compiledb \
-            build \
-            //src/third_party/opentelemetry-cpp/exporters/prometheus:prometheus_exporter_utils
 
       - name: Verify clang-tidy config
         run: |
@@ -151,8 +174,18 @@ jobs:
         run: |
           CHANGED="${{ needs.changed_files.outputs.changed_files }}"
           echo "Changed C++ files: '$CHANGED'"
+          TIDY_CHECKS_LIB="bazel-bin/src/mongo/tools/mongo_tidy_checks/libmongo_tidy_checks.so"
+          if [ ! -f "$TIDY_CHECKS_LIB" ]; then
+            TIDY_CHECKS_LIB="$(find bazel-bin/src/mongo/tools/mongo_tidy_checks -maxdepth 1 -type f -name 'libmongo_tidy_checks*.so' | head -n 1)"
+          fi
+          if [ -z "$TIDY_CHECKS_LIB" ] || [ ! -f "$TIDY_CHECKS_LIB" ]; then
+            echo "Error: Could not find a loadable mongo_tidy_checks plugin shared library under bazel-bin/src/mongo/tools/mongo_tidy_checks"
+            ls -la bazel-bin/src/mongo/tools/mongo_tidy_checks || true
+            exit 1
+          fi
+          echo "Using clang-tidy plugin: $TIDY_CHECKS_LIB"
           external/mongo_toolchain_v5/v5/bin/clang-tidy \
-            --load="bazel-bin/src/mongo/tools/mongo_tidy_checks/libmongo_tidy_checks.so" \
+            --load="$TIDY_CHECKS_LIB" \
             $CHANGED \
           | clang-tidy-sarif --output=clang-tidy-results.sarif
 


### PR DESCRIPTION
The upstream compiledb.py was rewritten from a lightweight bazel aquery approach to a full bazel build with aspects.

Changes:
- Scope compiledb build to changed files' packages via MONGO_COMPILEDB_TARGET_SCOPE instead of building all of //src/...
- Fetch upstream MongoDB r* tags for correct git describe version (needed by releases.h TemplateRenderer)
- Remove Setup AWS SDK step
- Fix Bazel BES hang: add --bes_timeout=0s and --bes_upload_mode=nowait_for_upload_complete
- Set JVM heap (-Xmx8g) in ~/.bazelrc for consistent startup options
- Add Bazel disk cache via actions/cache for faster subsequent runs
- Fall back to libmongo_tidy_checks_static.so when shared lib is absent

