### PR TITLE
PSMDB-1991 Harden $_backupFile errors, privileges, and lite parsing

### DIFF
--- a/src/mongo/db/exec/agg/backup_file_stage.cpp
+++ b/src/mongo/db/exec/agg/backup_file_stage.cpp
@@ -66,11 +66,11 @@ BackupFileStage::BackupFileStage(StringData stageName,
       _filePath(std::move(filePath)),
       _byteOffset(byteOffset),
       _file(_filePath, std::ios_base::in | std::ios_base::binary) {
-    tassert(ErrorCodes::FileOpenFailed,
+    uassert(ErrorCodes::FileOpenFailed,
             str::stream() << "Failed to open file " << _filePath,
             _file.is_open());
     _file.seekg(_byteOffset);
-    tassert(ErrorCodes::FileOpenFailed,
+    uassert(ErrorCodes::FileOpenFailed,
             str::stream() << "Failed to set read position " << _byteOffset << " in file "
                           << _filePath,
             !_file.fail());

--- a/src/mongo/db/pipeline/document_source_backup_file.cpp
+++ b/src/mongo/db/pipeline/document_source_backup_file.cpp
@@ -60,8 +60,9 @@ constexpr StringData kFile = "file"_sd;
 constexpr StringData kByteOffset = "byteOffset"_sd;
 }  // namespace
 
-REGISTER_INTERNAL_LITE_PARSED_DOCUMENT_SOURCE(_backupFile,
-                                              DocumentSourceBackupFile::LiteParsed::parse);
+REGISTER_LITE_PARSED_DOCUMENT_SOURCE(_backupFile,
+                                     DocumentSourceBackupFile::LiteParsed::parse,
+                                     AllowedWithApiStrict::kAlways);
 
 REGISTER_DOCUMENT_SOURCE_WITH_STAGE_PARAMS_DEFAULT(_backupFile,
                                                    DocumentSourceBackupFile,

--- a/src/mongo/db/pipeline/document_source_backup_file.h
+++ b/src/mongo/db/pipeline/document_source_backup_file.h
@@ -68,7 +68,8 @@ public:
         PrivilegeVector requiredPrivileges(
             [[maybe_unused]] bool isMongos,
             [[maybe_unused]] bool bypassDocumentValidation) const final {
-            return {Privilege(ResourcePattern::forClusterResource(boost::none), ActionType::fsync)};
+            return {Privilege(ResourcePattern::forClusterResource(boost::none),
+                              ActionType::readBackupFile)};
         }
 
         bool isInitialSource() const final {


### PR DESCRIPTION
SERVER-110899 introduced new "readBackupFile" auth privilege for $_backupFile. Following changes were implemented to match the behavior expected by jstests/auth/lib/commands_lib.js and thus fix failing tests like commands_builtin_roles_standalone.js

- In BackupFileStage, use uassert instead of tassert when opening the backup file or seeking to the byte offset so failures return as command errors instead of fatally asserting the server.
- For LiteParsed privilege checks, require ActionType::readBackupFile on the cluster resource instead of fsync so authorization matches the intended backup-file capability during command coverage.
- Register $_backupFile with REGISTER_LITE_PARSED_DOCUMENT_SOURCE and AllowedWithApiStrict::kAlways rather than the internal-only macro so parsing and API-strict behavior are explicit for this stage.