### PR TITLE
PSMDB-1991 Harden $_backupFile errors, privileges, and lite parsing

### DIFF
--- a/jstests/auth/lib/commands_lib.js
+++ b/jstests/auth/lib/commands_lib.js
@@ -7144,7 +7144,7 @@ export const authCommandsLib = {
           // Only enterprise knows of this aggregation stage.
           skipTest:
               (conn) =>
-                  !isPSMDBOrEnterprise(conn.getDB("admin").runCommand({buildInfo: 1})),
+                  !isPSMDBOrEnterprise(getBuildInfo()),
           testcases: [{
               runOnDb: adminDbName,
               roles: roles_hostManager,
@@ -7171,7 +7171,7 @@ export const authCommandsLib = {
           // Only enterprise knows of this aggregation stage.
           skipTest:
               (conn) =>
-                  !getBuildInfo().modules.includes("enterprise"),
+                  !isPSMDBOrEnterprise(getBuildInfo()),
           testcases: [{
               runOnDb: adminDbName,
               roles: roles_hostManager,
@@ -7194,7 +7194,7 @@ export const authCommandsLib = {
           // Only enterprise knows of this aggregation stage.
           skipTest:
               (conn) =>
-                  !getBuildInfo().modules.includes("enterprise"),
+                  !isPSMDBOrEnterprise(getBuildInfo()),
           testcases: [{
               runOnDb: adminDbName,
               roles: {backup: 1, root: 1, __system: 1},

--- a/src/mongo/db/pipeline/document_source_backup_file.cpp
+++ b/src/mongo/db/pipeline/document_source_backup_file.cpp
@@ -60,11 +60,16 @@ constexpr StringData kFile = "file"_sd;
 constexpr StringData kByteOffset = "byteOffset"_sd;
 
 // We only link this file into mongod so this stage doesn't exist in mongos
-REGISTER_INTERNAL_DOCUMENT_SOURCE(_backupFile,
-                                  LiteParsedDocumentSourceInternal::parse,
-                                  DocumentSourceBackupFile::createFromBson,
-                                  true);
+REGISTER_DOCUMENT_SOURCE(_backupFile,
+                         DocumentSourceBackupFile::LiteParsed::parse,
+                         DocumentSourceBackupFile::createFromBson,
+                         AllowedWithApiStrict::kAlways);
 }  // namespace
+
+std::unique_ptr<DocumentSourceBackupFile::LiteParsed> DocumentSourceBackupFile::LiteParsed::parse(
+    const NamespaceString& nss, const BSONElement& spec, const LiteParserOptions& options) {
+    return std::make_unique<DocumentSourceBackupFile::LiteParsed>(spec.fieldName());
+}
 
 using boost::intrusive_ptr;
 

--- a/src/mongo/db/pipeline/document_source_backup_file.h
+++ b/src/mongo/db/pipeline/document_source_backup_file.h
@@ -36,10 +36,12 @@ Copyright (C) 2024-present Percona and/or its affiliates. All rights reserved.
 #include <set>
 #include <string>
 
+#include <boost/none.hpp>
 #include <boost/optional.hpp>
 
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonelement.h"
+#include "mongo/db/auth/resource_pattern.h"
 #include "mongo/db/pipeline/document_source.h"
 #include "mongo/util/uuid.h"
 
@@ -48,6 +50,33 @@ namespace mongo {
 class DocumentSourceBackupFile final : public DocumentSource {
 public:
     static constexpr StringData kStageName = "$_backupFile"_sd;
+
+    class LiteParsed final : public LiteParsedDocumentSource {
+    public:
+        using LiteParsedDocumentSource::LiteParsedDocumentSource;
+
+        static std::unique_ptr<LiteParsed> parse(const NamespaceString& nss,
+                                                 const BSONElement& spec,
+                                                 const LiteParserOptions& options);
+
+        stdx::unordered_set<NamespaceString> getInvolvedNamespaces() const final {
+            return {};
+        }
+
+        PrivilegeVector requiredPrivileges(bool isMongos,
+                                           bool bypassDocumentValidation) const final {
+            return {Privilege(ResourcePattern::forClusterResource(boost::none),
+                              ActionType::readBackupFile)};
+        }
+
+        bool isInitialSource() const final {
+            return true;
+        }
+
+        void assertSupportsMultiDocumentTransaction() const final {
+            transactionNotSupported(kStageName);
+        }
+    };
 
     /**
      * Parses a $_backupFile stage from 'spec'.


### PR DESCRIPTION
SERVER-110899 introduced new "readBackupFile" auth privilege for $_backupFile. Following changes were implemented to match the behavior expected by jstests/auth/lib/commands_lib.js and thus fix failing tests like commands_builtin_roles_standalone.js

Replace REGISTER_INTERNAL_DOCUMENT_SOURCE with REGISTER_DOCUMENT_SOURCE
    and add a custom LiteParsed class that requires the readBackupFile
    privilege instead of the internal privilege.
    
    Previously, the stage was registered as internal-only
    (AllowedWithClientType::kInternal), which caused two problems:
    - clusterAdmin/hostManager got error 5491300 ("not allowed in user
      requests") from LiteParsedPipeline::validate() instead of the
      expected code 13 Unauthorized, because the kInternal check runs
      after the auth check
    - the backup role got code 13 Unauthorized because
      LiteParsedDocumentSourceInternal::requiredPrivileges() returns
      the internal privilege, which backup role does not have
    
    The fix follows the same pattern used by $backupCursorExtend:
    register as a normal document source with a nested LiteParsed class
    that returns readBackupFile on the cluster resource, matching the
    privilege already assigned to the backup role in builtin_roles.yml.