### PR TITLE
PSMDB-1991 Fix $_backupFile aggregate stage auth check for tests

### DIFF
--- a/jstests/auth/lib/commands_lib.js
+++ b/jstests/auth/lib/commands_lib.js
@@ -6798,7 +6798,7 @@ export const authCommandsLib = {
           // Only enterprise knows of this aggregation stage.
           skipTest:
               (conn) =>
-                  !isPSMDBOrEnterprise(conn.getDB("admin").runCommand({buildInfo: 1})),
+                  !isPSMDBOrEnterprise(getBuildInfo()),
           testcases: [{
               runOnDb: adminDbName,
               roles: roles_hostManager,
@@ -6826,7 +6826,7 @@ export const authCommandsLib = {
           // Only enterprise knows of this aggregation stage.
           skipTest:
               (conn) =>
-                  !getBuildInfo().modules.includes("enterprise"),
+                  !isPSMDBOrEnterprise(getBuildInfo()),
           testcases: [{
               runOnDb: adminDbName,
               roles: roles_hostManager,
@@ -6849,7 +6849,7 @@ export const authCommandsLib = {
           // Only enterprise knows of this aggregation stage.
           skipTest:
               (conn) =>
-                  !getBuildInfo().modules.includes("enterprise"),
+                  !isPSMDBOrEnterprise(getBuildInfo()),
           testcases: [{
               runOnDb: adminDbName,
               roles: {__system: 1},

--- a/src/mongo/db/pipeline/document_source_backup_file.cpp
+++ b/src/mongo/db/pipeline/document_source_backup_file.cpp
@@ -69,7 +69,6 @@ using boost::intrusive_ptr;
 
 std::unique_ptr<DocumentSourceBackupFile::LiteParsed> DocumentSourceBackupFile::LiteParsed::parse(
     const NamespaceString& nss, const BSONElement& spec) {
-
     return std::make_unique<DocumentSourceBackupFile::LiteParsed>(spec.fieldName());
 }
 

--- a/src/mongo/db/pipeline/document_source_backup_file.h
+++ b/src/mongo/db/pipeline/document_source_backup_file.h
@@ -41,6 +41,7 @@ Copyright (C) 2024-present Percona and/or its affiliates. All rights reserved.
 
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonelement.h"
+#include "mongo/db/auth/resource_pattern.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/db/pipeline/document_source.h"
 #include "mongo/db/pipeline/lite_parsed_document_source.h"
@@ -67,7 +68,7 @@ public:
         PrivilegeVector requiredPrivileges(
             [[maybe_unused]] bool isMongos,
             [[maybe_unused]] bool bypassDocumentValidation) const final {
-            return {Privilege(ResourcePattern::forClusterResource(), ActionType::fsync)};
+            return {Privilege(ResourcePattern::forClusterResource(), ActionType::internal)};
         }
 
         bool isInitialSource() const final {


### PR DESCRIPTION
Replace `fsync` privilege with `internal` privilege fixes those tests which use `commands_lib.js`