### PR TITLE
PSMDB-1992 Skip BSON content check for encrypted rollback oplog files in TDE suites

### DIFF
--- a/jstests/replsets/rollback_writes_oplogs_to_file.js
+++ b/jstests/replsets/rollback_writes_oplogs_to_file.js
@@ -51,12 +51,26 @@ function runRollbackOplogsTest(shouldCreateRollbackFiles) {
     assert.eq(pathExists(oplogRollbackDir), shouldCreateRollbackFiles, oplogRollbackDir);
     if (shouldCreateRollbackFiles) {
         const listRollbackFiles = listFiles(oplogRollbackDir);
+        assert.gt(listRollbackFiles.length, 0, "Expected rollback files in " + oplogRollbackDir);
         let oplogsRolledBack = [];
+        let filesAreEncrypted = false;
         for (let i = 0; i < listRollbackFiles.length; i++) {
-            oplogsRolledBack = oplogsRolledBack.concat(_readDumpFile(listRollbackFiles[i].name));
+            const rollbackFile = listRollbackFiles[i].name;
+            if (
+                rollbackFile.endsWith(".enc") ||
+                rollbackFile.endsWith(".aes256-cbc") ||
+                rollbackFile.endsWith(".aes256-gcm")
+            ) {
+                print("Bypassing check of rollback file data since it is encrypted: " + rollbackFile);
+                filesAreEncrypted = true;
+                break;
+            }
+            oplogsRolledBack = oplogsRolledBack.concat(_readDumpFile(rollbackFile));
         }
-        assert.contains(oplogsToRollback[0], oplogsRolledBack);
-        assert.contains(oplogsToRollback[1], oplogsRolledBack);
+        if (!filesAreEncrypted) {
+            assert.contains(oplogsToRollback[0], oplogsRolledBack);
+            assert.contains(oplogsToRollback[1], oplogsRolledBack);
+        }
     }
     rst.stopSet();
 }


### PR DESCRIPTION
When TDE is enabled, RemoveSaver encrypts rollback files and appends .aes256-cbc/.aes256-gcm to the filename. Calling _readDumpFile() on ciphertext produces an invalid BSON size error. Skip content verification for encrypted files, mirroring the existing guard in rollback_files.js.