### PR TITLE
PSMDB-2045 Fix aggregation_tde_cbc and aggregation_tde_gcm suites failure

### DIFF
--- a/buildscripts/resmokeconfig/suites/aggregation_tde_cbc.yml
+++ b/buildscripts/resmokeconfig/suites/aggregation_tde_cbc.yml
@@ -11,8 +11,6 @@ selector:
   exclude_files:
   - jstests/aggregation/extras/*.js
   - jstests/aggregation/data/*.js
-  # Skip any tests that run with auth explicitly.
-  - jstests/aggregation/*[aA]uth*.js
   exclude_with_any_tags:
   - does_not_support_encrypted_storage_engine
 executor:

--- a/buildscripts/resmokeconfig/suites/aggregation_tde_gcm.yml
+++ b/buildscripts/resmokeconfig/suites/aggregation_tde_gcm.yml
@@ -11,8 +11,6 @@ selector:
   exclude_files:
   - jstests/aggregation/extras/*.js
   - jstests/aggregation/data/*.js
-  # Skip any tests that run with auth explicitly.
-  - jstests/aggregation/*[aA]uth*.js
   exclude_with_any_tags:
   - does_not_support_encrypted_storage_engine
 executor:


### PR DESCRIPTION
Remove exclude files selector which produces empty result. Empty result could cause "Pattern(s) and/or filename(s) in `exclude_files` do not match any existing test files" failure after commit c0192285898
