### PR TITLE
PSMDB-2012 Reject FCBIS sync source with newer binary version

### DIFF
--- a/jstests/replsets/fcbis_backup_cursor_extend.js
+++ b/jstests/replsets/fcbis_backup_cursor_extend.js
@@ -14,7 +14,7 @@
  * - Ensure that $backupCursorExtend was called and worked correctly
  * - Check that the new node is in the correct state
  *
- * @tags: [requires_wiredtiger]
+ * @tags: [requires_wiredtiger, multiversion_incompatible]
  */
 import {ReplSetTest} from "jstests/libs/replsettest.js";
 import {reconfig} from "jstests/replsets/rslib.js";

--- a/src/mongo/db/repl/initial_sync/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_sync/initial_syncer_fcb.cpp
@@ -106,6 +106,7 @@ Copyright (C) 2024-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/util/str.h"
 #include "mongo/util/time_support.h"
 #include "mongo/util/timer.h"
+#include "mongo/util/version.h"
 #include "mongo/util/version/releases.h"
 
 #include <algorithm>
@@ -1377,6 +1378,31 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
                             kDenylistPersistent,
                             "sync source does not support file copy-based initial sync");
                         return;
+                    }
+                    // WiredTiger files are not backward-compatible: reject sources whose binary
+                    // is newer than the local binary to prevent a WiredTiger panic on the
+                    // destination.
+                    auto versionArrayElem = args.response.data.getField("versionArray");
+                    if (versionArrayElem.type() == BSONType::array) {
+                        BSONObjIterator it(versionArrayElem.Obj());
+                        int srcMajor = it.more() ? it.next().numberInt() : 0;
+                        int srcMinor = it.more() ? it.next().numberInt() : 0;
+                        const auto& vi = VersionInfoInterface::instance();
+                        if (srcMajor > vi.majorVersion() ||
+                            (srcMajor == vi.majorVersion() && srcMinor > vi.minorVersion())) {
+                            LOGV2_WARNING(128472,
+                                          "Invalid sync source: binary version is newer than local",
+                                          "sourceMajor"_attr = srcMajor,
+                                          "sourceMinor"_attr = srcMinor,
+                                          "localMajor"_attr = vi.majorVersion(),
+                                          "localMinor"_attr = vi.minorVersion());
+                            result = _invalidSyncSource(
+                                lk,
+                                syncSource,
+                                kDenylistPersistent,
+                                "sync source binary version is newer than local binary version");
+                            return;
+                        }
                     }
                 });
     if (!scheduleResult.isOK()) {


### PR DESCRIPTION
WiredTiger data files are not backward-compatible, so copying them from a newer binary (e.g. 8.3) to an older one (e.g. 8.0) causes a WiredTiger panic on the destination. Add a version check in _chooseSyncSource() that rejects any sync source whose major.minor version exceeds the local binary version, preventing the panic.

Also mark fcbis_backup_cursor_extend.js as multiversion_incompatible so the replica_sets_last_lts suite skips it rather than running it in a mixed-version environment where FCBIS is inherently unsupported.
