### PR TITLE
PSMDB-1997: Defer encryption key cleanup and use per-database keyId generations

### DIFF
--- a/buildscripts/resmokeconfig/suites/tde_deferred_cleanup_cbc.yml
+++ b/buildscripts/resmokeconfig/suites/tde_deferred_cleanup_cbc.yml
@@ -1,0 +1,26 @@
+# Resmoke suite for testing encryption key cleanup with AES256-CBC cipher mode.
+# These tests stress test periodic encryption key cleanup with aggressive
+# cleanup intervals (1 second) while performing many dropDatabase operations.
+
+config_variables:
+  - &keyFileGood jstests/percona/tde/ekf
+  - &cipherMode AES256-CBC
+
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/percona/tde/deferred_key_cleanup_command.js
+    - jstests/percona/tde/deferred_key_cleanup_drop_database.js
+    - jstests/percona/tde/deferred_key_cleanup_on_startup.js
+    - jstests/percona/tde/deferred_key_cleanup_stress.js
+
+# Tests start their own mongod with encryption and periodic cleanup enabled.
+executor:
+  config:
+    shell_options:
+      global_vars:
+        TestData:
+          keyFileGood: *keyFileGood
+          cipherMode: *cipherMode
+      nodb: ""

--- a/buildscripts/resmokeconfig/suites/tde_deferred_cleanup_gcm.yml
+++ b/buildscripts/resmokeconfig/suites/tde_deferred_cleanup_gcm.yml
@@ -1,0 +1,26 @@
+# Resmoke suite for testing encryption key cleanup with AES256-GCM cipher mode.
+# These tests stress test periodic encryption key cleanup with aggressive
+# cleanup intervals (1 second) while performing many dropDatabase operations.
+
+config_variables:
+  - &keyFileGood jstests/percona/tde/ekf
+  - &cipherMode AES256-GCM
+
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/percona/tde/deferred_key_cleanup_command.js
+    - jstests/percona/tde/deferred_key_cleanup_drop_database.js
+    - jstests/percona/tde/deferred_key_cleanup_on_startup.js
+    - jstests/percona/tde/deferred_key_cleanup_stress.js
+
+# Tests start their own mongod with encryption and periodic cleanup enabled.
+executor:
+  config:
+    shell_options:
+      global_vars:
+        TestData:
+          keyFileGood: *keyFileGood
+          cipherMode: *cipherMode
+      nodb: ""

--- a/jstests/core/catalog/views/views_all_commands.js
+++ b/jstests/core/catalog/views/views_all_commands.js
@@ -298,6 +298,7 @@ let viewsCommandTests = {
     cleanupOrphaned: {
         skip: "Tested in views/views_sharded.js",
     },
+    cleanupOrphanedEncryptionKeys: {skip: isUnrelated},
     cleanupStructuredEncryptionData: {skip: isUnrelated},
     clearJumboFlag: {
         command: {clearJumboFlag: "test.view"},

--- a/jstests/percona/tde/deferred_key_cleanup_command.js
+++ b/jstests/percona/tde/deferred_key_cleanup_command.js
@@ -1,0 +1,184 @@
+/**
+ * Tests the cleanupOrphanedEncryptionKeys admin command.
+ *
+ * This test verifies that:
+ * 1. The command succeeds and cleans up orphaned keys on demand.
+ * 2. The command does not remove keys for databases that still exist.
+ * 3. The command is idempotent (safe to run multiple times).
+ * 4. The command works when periodic cleanup is disabled.
+ * 5. The command cleans up keys for databases dropped between invocations.
+ *
+ * @tags: [
+ *   requires_wiredtiger,
+ * ]
+ */
+import {checkLog} from "src/mongo/shell/check_log.js";
+
+(function () {
+    "use strict";
+
+    const keyFile = TestData.keyFileGood || "jstests/percona/tde/ekf";
+    const cipherMode = TestData.cipherMode || "AES256-GCM";
+    const numDocsPerCollection = 50;
+    const testDbPrefix = "cmd_cleanup_test_";
+
+    jsTestLog("Starting deferred key cleanup command test with cipher mode: " + cipherMode);
+
+    // Start mongod with periodic cleanup disabled to test command-only cleanup.
+    // Use a log file so we can reliably check for cleanup messages (the RAM log
+    // buffer returned by getLog has limited capacity).
+    const dbpath = MongoRunner.dataPath + "deferred_key_cleanup_command";
+    const logpath = dbpath + "/mongod.log";
+    const conn = MongoRunner.runMongod({
+        dbpath: dbpath,
+        enableEncryption: "",
+        encryptionKeyFile: keyFile,
+        encryptionCipherMode: cipherMode,
+        logpath: logpath,
+        setParameter: {
+            encryptionKeyCleanupIntervalSeconds: 0,
+        },
+    });
+    assert.neq(null, conn, "mongod failed to start with encryption enabled");
+
+    const adminDb = conn.getDB("admin");
+
+    // Helper function to create a database with data
+    function createDatabaseWithData(dbName) {
+        const db = conn.getDB(dbName);
+        const coll = db["data"];
+        let docs = [];
+        for (let d = 0; d < numDocsPerCollection; d++) {
+            docs.push({_id: d, data: "test_data_" + d, dbName: dbName});
+        }
+        assert.commandWorked(coll.insertMany(docs));
+        assert.eq(numDocsPerCollection, coll.countDocuments({}), "Document count mismatch in " + dbName);
+    }
+
+    // Helper function to verify database integrity
+    function verifyDatabaseIntegrity(dbName) {
+        const db = conn.getDB(dbName);
+        const coll = db["data"];
+        assert.eq(numDocsPerCollection, coll.countDocuments({}), "Document count mismatch in " + dbName);
+        for (let d = 0; d < Math.min(5, numDocsPerCollection); d++) {
+            const doc = coll.findOne({_id: d});
+            assert.neq(null, doc, "Missing document _id=" + d + " in " + dbName);
+            assert.eq("test_data_" + d, doc.data, "Data mismatch for document _id=" + d);
+        }
+    }
+
+    // After dropDatabase, idents become "drop-pending" and are reaped by the
+    // TimestampMonitor on its periodic tick (~1s). The reaper needs a checkpoint
+    // to have happened, then it drops the idents from WiredTiger on the next tick.
+    // We force a checkpoint (fsync) and then sleep to let the reaper process.
+    function waitForIdentsToBeReaped() {
+        assert.commandWorked(adminDb.runCommand({fsync: 1}));
+        sleep(3000);
+    }
+
+    // Phase 1: Test command with no orphaned keys (no-op)
+    jsTestLog("Phase 1: Run cleanup command with no orphaned keys");
+    assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
+    jsTestLog("Cleanup command succeeded with no orphaned keys");
+
+    // Phase 2: Create databases, drop some, run cleanup command
+    jsTestLog("Phase 2: Create databases and drop some");
+
+    const allDbs = [];
+    const droppedDbs = [];
+    const survivingDbs = [];
+    for (let i = 0; i < 8; i++) {
+        const dbName = testDbPrefix + i;
+        createDatabaseWithData(dbName);
+        allDbs.push(dbName);
+        if (i < 4) {
+            droppedDbs.push(dbName);
+        } else {
+            survivingDbs.push(dbName);
+        }
+    }
+
+    // Verify all databases are intact
+    for (const dbName of allDbs) {
+        verifyDatabaseIntegrity(dbName);
+    }
+
+    // Drop databases 0-3
+    for (const dbName of droppedDbs) {
+        jsTestLog("Dropping database: " + dbName);
+        assert.commandWorked(conn.getDB(dbName).dropDatabase());
+    }
+
+    // Wait for drop-pending idents to be reaped and removed from WT metadata
+    waitForIdentsToBeReaped();
+
+    jsTestLog("Phase 3: Run cleanup command to remove orphaned keys");
+
+    assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
+
+    // Verify the cleanup deleted orphaned keys by checking the log file.
+    // LOGV2 ID 29160 = "Deleting orphaned encryption key for non-existent database"
+    for (const dbName of droppedDbs) {
+        checkLog.containsJson(logpath, 29160, {keyId: dbName});
+    }
+    jsTestLog("Verified cleanup command deleted orphaned keys for dropped databases");
+
+    // Verify surviving databases are still intact
+    for (const dbName of survivingDbs) {
+        verifyDatabaseIntegrity(dbName);
+    }
+    jsTestLog("Verified surviving databases are intact after cleanup");
+
+    // Phase 4: Test idempotency - running cleanup again should be a no-op
+    jsTestLog("Phase 4: Test idempotency - run cleanup again");
+    assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
+
+    // Verify surviving databases are still intact
+    for (const dbName of survivingDbs) {
+        verifyDatabaseIntegrity(dbName);
+    }
+    jsTestLog("Cleanup command is idempotent - surviving databases still intact");
+
+    // Phase 5: Drop more databases, run cleanup again
+    jsTestLog("Phase 5: Drop remaining databases and run cleanup");
+
+    for (const dbName of survivingDbs) {
+        jsTestLog("Dropping database: " + dbName);
+        assert.commandWorked(conn.getDB(dbName).dropDatabase());
+    }
+
+    // Wait for idents to be reaped
+    waitForIdentsToBeReaped();
+
+    assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
+
+    // Verify the cleanup deleted orphaned keys for the remaining databases
+    for (const dbName of survivingDbs) {
+        checkLog.containsJson(logpath, 29160, {keyId: dbName});
+    }
+    jsTestLog("Verified cleanup command deleted orphaned keys for all dropped databases");
+
+    // Phase 6: Verify system is functional after all cleanups
+    jsTestLog("Phase 6: Verify system is functional after cleanup");
+
+    // Verify all test databases are gone
+    const finalDbs = adminDb.adminCommand({listDatabases: 1}).databases;
+    for (const dbInfo of finalDbs) {
+        assert(!dbInfo.name.startsWith(testDbPrefix), "Test database should have been dropped: " + dbInfo.name);
+    }
+
+    // Create new databases to verify system works
+    for (let i = 0; i < 3; i++) {
+        const dbName = testDbPrefix + "final_" + i;
+        createDatabaseWithData(dbName);
+        verifyDatabaseIntegrity(dbName);
+        assert.commandWorked(conn.getDB(dbName).dropDatabase());
+    }
+
+    // One final cleanup
+    assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
+
+    jsTestLog("Deferred key cleanup command test completed successfully");
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/jstests/percona/tde/deferred_key_cleanup_command.js
+++ b/jstests/percona/tde/deferred_key_cleanup_command.js
@@ -117,9 +117,11 @@ import {checkLog} from "src/mongo/shell/check_log.js";
     assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
 
     // Verify the cleanup deleted orphaned keys by checking the log file.
-    // LOGV2 ID 29160 = "Deleting orphaned encryption key for non-existent database"
+    // LOGV2 ID 29160 = "Deleting orphaned encryption key for non-existent database".
+    // The logged keyId is `<dbName>` (legacy bare format) or `<dbName>.<UUID>`
+    // (per-generation format). Match either with a regex anchored on dbName.
     for (const dbName of droppedDbs) {
-        checkLog.containsJson(logpath, 29160, {keyId: dbName});
+        checkLog.containsJson(logpath, 29160, {keyId: new RegExp("^" + dbName + "(\\..+)?$")});
     }
     jsTestLog("Verified cleanup command deleted orphaned keys for dropped databases");
 
@@ -152,9 +154,10 @@ import {checkLog} from "src/mongo/shell/check_log.js";
 
     assert.commandWorked(adminDb.runCommand({cleanupOrphanedEncryptionKeys: 1}));
 
-    // Verify the cleanup deleted orphaned keys for the remaining databases
+    // Verify the cleanup deleted orphaned keys for the remaining databases.
+    // Match `<dbName>` or `<dbName>.<UUID>` (per-generation format).
     for (const dbName of survivingDbs) {
-        checkLog.containsJson(logpath, 29160, {keyId: dbName});
+        checkLog.containsJson(logpath, 29160, {keyId: new RegExp("^" + dbName + "(\\..+)?$")});
     }
     jsTestLog("Verified cleanup command deleted orphaned keys for all dropped databases");
 

--- a/jstests/percona/tde/deferred_key_cleanup_drop_database.js
+++ b/jstests/percona/tde/deferred_key_cleanup_drop_database.js
@@ -1,0 +1,187 @@
+/**
+ * Tests that encryption key cleanup works correctly with dropDatabase.
+ *
+ * This test verifies that:
+ * 1. Databases can be created and dropped without errors
+ * 2. Encryption keys are eventually cleaned up by the periodic background process
+ * 3. No data corruption occurs
+ * 4. The cleanupOrphanedEncryptionKeys admin command works
+ *
+ * @tags: [
+ *   requires_wiredtiger,
+ * ]
+ */
+(function () {
+    "use strict";
+
+    const keyFile = TestData.keyFileGood || "jstests/percona/tde/ekf";
+    const cipherMode = TestData.cipherMode || "AES256-GCM";
+    const cleanupIntervalSecs = 1;
+    const numDatabases = 10;
+    const numCollections = 3;
+    const numDocsPerCollection = 100;
+
+    jsTestLog("Starting deferred key cleanup drop database test with cipher mode: " + cipherMode);
+
+    // Start mongod with encryption and periodic key cleanup enabled
+    const conn = MongoRunner.runMongod({
+        enableEncryption: "",
+        encryptionKeyFile: keyFile,
+        encryptionCipherMode: cipherMode,
+        setParameter: {
+            encryptionKeyCleanupIntervalSeconds: cleanupIntervalSecs,
+        },
+    });
+    assert.neq(null, conn, "mongod failed to start with encryption enabled");
+
+    const testDbPrefix = "deferred_cleanup_test_";
+
+    // Helper function to create a database with collections and data
+    function createDatabaseWithData(dbName) {
+        const db = conn.getDB(dbName);
+        for (let c = 0; c < numCollections; c++) {
+            const collName = "coll_" + c;
+            const coll = db[collName];
+
+            // Insert documents
+            let docs = [];
+            for (let d = 0; d < numDocsPerCollection; d++) {
+                docs.push({
+                    _id: d,
+                    data: "test_data_" + d,
+                    dbName: dbName,
+                    collName: collName,
+                    timestamp: new Date(),
+                });
+            }
+            assert.commandWorked(coll.insertMany(docs));
+
+            // Verify insertion
+            assert.eq(
+                numDocsPerCollection,
+                coll.countDocuments({}),
+                "Document count mismatch in " + dbName + "." + collName,
+            );
+        }
+        return db;
+    }
+
+    // Helper function to verify database integrity
+    function verifyDatabaseIntegrity(dbName) {
+        const db = conn.getDB(dbName);
+        for (let c = 0; c < numCollections; c++) {
+            const collName = "coll_" + c;
+            const coll = db[collName];
+
+            // Verify document count
+            const count = coll.countDocuments({});
+            assert.eq(numDocsPerCollection, count, "Document count mismatch in " + dbName + "." + collName);
+
+            // Verify data integrity by checking a few documents
+            for (let d = 0; d < Math.min(10, numDocsPerCollection); d++) {
+                const doc = coll.findOne({_id: d});
+                assert.neq(null, doc, "Missing document _id=" + d + " in " + dbName + "." + collName);
+                assert.eq("test_data_" + d, doc.data, "Data mismatch for document _id=" + d);
+                assert.eq(dbName, doc.dbName, "dbName mismatch for document _id=" + d);
+            }
+        }
+    }
+
+    jsTestLog("Phase 1: Create databases and verify data integrity");
+
+    // Create multiple databases
+    let createdDbs = [];
+    for (let i = 0; i < numDatabases; i++) {
+        const dbName = testDbPrefix + i;
+        jsTestLog("Creating database: " + dbName);
+        createDatabaseWithData(dbName);
+        createdDbs.push(dbName);
+    }
+
+    // Verify all databases have correct data
+    for (const dbName of createdDbs) {
+        verifyDatabaseIntegrity(dbName);
+    }
+    jsTestLog("All " + numDatabases + " databases created and verified");
+
+    jsTestLog("Phase 2: Drop half of the databases");
+
+    // Drop half of the databases
+    let droppedDbs = [];
+    let remainingDbs = [];
+    for (let i = 0; i < numDatabases; i++) {
+        const dbName = testDbPrefix + i;
+        if (i % 2 === 0) {
+            jsTestLog("Dropping database: " + dbName);
+            const db = conn.getDB(dbName);
+            assert.commandWorked(db.dropDatabase());
+            droppedDbs.push(dbName);
+        } else {
+            remainingDbs.push(dbName);
+        }
+    }
+
+    jsTestLog("Phase 3: Verify remaining databases are intact");
+
+    // Verify remaining databases are still intact
+    for (const dbName of remainingDbs) {
+        verifyDatabaseIntegrity(dbName);
+    }
+    jsTestLog("All remaining databases verified after partial drop");
+
+    jsTestLog("Phase 4: Wait for deferred cleanup to run");
+
+    // Wait for deferred cleanup to run (at least 2 intervals)
+    sleep(cleanupIntervalSecs * 3 * 1000);
+
+    jsTestLog("Phase 5: Verify remaining databases are still intact after cleanup");
+
+    // Verify remaining databases are still intact after cleanup ran
+    for (const dbName of remainingDbs) {
+        verifyDatabaseIntegrity(dbName);
+    }
+
+    jsTestLog("Phase 6: Drop remaining databases");
+
+    // Drop remaining databases
+    for (const dbName of remainingDbs) {
+        jsTestLog("Dropping database: " + dbName);
+        const db = conn.getDB(dbName);
+        assert.commandWorked(db.dropDatabase());
+    }
+
+    jsTestLog("Phase 7: Wait for final cleanup");
+
+    // Wait for final cleanup
+    sleep(cleanupIntervalSecs * 3 * 1000);
+
+    jsTestLog("Phase 8: Verify all test databases are gone");
+
+    // Verify all test databases are gone
+    const finalDbs = conn.getDB("admin").adminCommand({listDatabases: 1}).databases;
+    for (const dbInfo of finalDbs) {
+        assert(!dbInfo.name.startsWith(testDbPrefix), "Test database should have been dropped: " + dbInfo.name);
+    }
+
+    jsTestLog("Phase 9: Test explicit cleanup command");
+
+    // Test that the cleanupOrphanedEncryptionKeys admin command works
+    assert.commandWorked(conn.getDB("admin").runCommand({cleanupOrphanedEncryptionKeys: 1}));
+
+    jsTestLog("Phase 10: Create new databases to verify system is still functional");
+
+    // Create new databases to verify system is still functional
+    for (let i = 0; i < 3; i++) {
+        const dbName = testDbPrefix + "final_" + i;
+        createDatabaseWithData(dbName);
+        verifyDatabaseIntegrity(dbName);
+
+        // Clean up
+        const db = conn.getDB(dbName);
+        assert.commandWorked(db.dropDatabase());
+    }
+
+    jsTestLog("Deferred key cleanup drop database test completed successfully");
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/jstests/percona/tde/deferred_key_cleanup_on_startup.js
+++ b/jstests/percona/tde/deferred_key_cleanup_on_startup.js
@@ -1,0 +1,179 @@
+/**
+ * Tests that orphaned encryption keys are cleaned up on mongod startup.
+ *
+ * This test verifies that:
+ * 1. When a database is dropped and mongod is restarted, the orphaned encryption
+ *    key is automatically cleaned up during startup (even with periodic cleanup disabled).
+ * 2. Databases that still exist are not affected.
+ * 3. The server is fully functional after startup cleanup.
+ *
+ * @tags: [
+ *   requires_wiredtiger,
+ *   requires_persistence,
+ * ]
+ */
+import {checkLog} from "src/mongo/shell/check_log.js";
+
+(function () {
+    "use strict";
+
+    const keyFile = TestData.keyFileGood || "jstests/percona/tde/ekf";
+    const cipherMode = TestData.cipherMode || "AES256-GCM";
+    const numDocsPerCollection = 50;
+    const testDbPrefix = "startup_cleanup_test_";
+    const dbpath = MongoRunner.dataPath + "deferred_key_cleanup_on_startup";
+    const logpath = dbpath + "/mongod.log";
+
+    jsTestLog("Starting deferred key cleanup on startup test with cipher mode: " + cipherMode);
+
+    // Helper function to create a database with data
+    function createDatabaseWithData(conn, dbName) {
+        const db = conn.getDB(dbName);
+        const coll = db["data"];
+        let docs = [];
+        for (let d = 0; d < numDocsPerCollection; d++) {
+            docs.push({_id: d, data: "test_data_" + d, dbName: dbName});
+        }
+        assert.commandWorked(coll.insertMany(docs));
+        assert.eq(numDocsPerCollection, coll.countDocuments({}), "Document count mismatch in " + dbName);
+    }
+
+    // Helper function to verify database integrity
+    function verifyDatabaseIntegrity(conn, dbName) {
+        const db = conn.getDB(dbName);
+        const coll = db["data"];
+        assert.eq(numDocsPerCollection, coll.countDocuments({}), "Document count mismatch in " + dbName);
+        for (let d = 0; d < Math.min(5, numDocsPerCollection); d++) {
+            const doc = coll.findOne({_id: d});
+            assert.neq(null, doc, "Missing document _id=" + d + " in " + dbName);
+            assert.eq("test_data_" + d, doc.data, "Data mismatch for document _id=" + d);
+        }
+    }
+
+    // Phase 1: Start mongod, create databases, drop some, stop mongod
+    jsTestLog("Phase 1: Create databases and drop some before shutdown");
+
+    let conn = MongoRunner.runMongod({
+        dbpath: dbpath,
+        enableEncryption: "",
+        encryptionKeyFile: keyFile,
+        encryptionCipherMode: cipherMode,
+        setParameter: {
+            // Disable periodic cleanup so we can verify that only startup cleanup runs
+            encryptionKeyCleanupIntervalSeconds: 0,
+        },
+    });
+    assert.neq(null, conn, "mongod failed to start with encryption enabled");
+
+    // Create databases: some will be dropped, some will remain
+    const droppedDbs = [];
+    const survivingDbs = [];
+    for (let i = 0; i < 6; i++) {
+        const dbName = testDbPrefix + i;
+        createDatabaseWithData(conn, dbName);
+        if (i < 3) {
+            droppedDbs.push(dbName);
+        } else {
+            survivingDbs.push(dbName);
+        }
+    }
+
+    // Verify all databases are intact
+    for (const dbName of droppedDbs.concat(survivingDbs)) {
+        verifyDatabaseIntegrity(conn, dbName);
+    }
+
+    // Drop the first 3 databases
+    for (const dbName of droppedDbs) {
+        jsTestLog("Dropping database: " + dbName);
+        assert.commandWorked(conn.getDB(dbName).dropDatabase());
+    }
+
+    // Force a checkpoint and wait for the drop-pending ident reaper to process.
+    // The clean shutdown will also do a final checkpoint, which ensures the dropped
+    // idents are fully removed from WT metadata before restart.
+    assert.commandWorked(conn.adminCommand({fsync: 1}));
+    sleep(3000);
+
+    // Verify surviving databases are still intact
+    for (const dbName of survivingDbs) {
+        verifyDatabaseIntegrity(conn, dbName);
+    }
+
+    // Stop mongod cleanly - the shutdown checkpoint finalizes ident removal.
+    // Orphaned encryption keys remain in the keydb.
+    MongoRunner.stopMongod(conn);
+
+    // Phase 2: Restart mongod with a log file and verify startup cleanup runs
+    jsTestLog("Phase 2: Restart mongod and verify startup cleanup");
+
+    conn = MongoRunner.runMongod({
+        dbpath: dbpath,
+        restart: true,
+        enableEncryption: "",
+        encryptionKeyFile: keyFile,
+        encryptionCipherMode: cipherMode,
+        logpath: logpath,
+        setParameter: {
+            // Keep periodic cleanup disabled
+            encryptionKeyCleanupIntervalSeconds: 0,
+        },
+    });
+    assert.neq(null, conn, "mongod failed to restart");
+
+    // Verify the startup cleanup deleted the orphaned keys by checking the log file.
+    // We use the log file (not the RAM buffer) because startup produces many log entries
+    // that can push cleanup messages out of the limited RAM log buffer.
+    // LOGV2 ID 29160 = "Deleting orphaned encryption key for non-existent database"
+    for (const dbName of droppedDbs) {
+        checkLog.containsJson(logpath, 29160, {keyId: dbName});
+    }
+    jsTestLog("Verified startup cleanup deleted orphaned keys for dropped databases");
+
+    // Verify surviving databases are still intact after startup cleanup
+    for (const dbName of survivingDbs) {
+        verifyDatabaseIntegrity(conn, dbName);
+    }
+    jsTestLog("Verified surviving databases are intact after startup cleanup");
+
+    // Phase 3: Verify system is fully functional after startup cleanup
+    jsTestLog("Phase 3: Verify system is functional after startup cleanup");
+
+    // Create new databases (some reusing names of previously dropped databases)
+    for (const dbName of droppedDbs) {
+        createDatabaseWithData(conn, dbName);
+        verifyDatabaseIntegrity(conn, dbName);
+    }
+    jsTestLog("Created new databases reusing previously dropped names");
+
+    // Clean up all test databases
+    for (const dbName of droppedDbs.concat(survivingDbs)) {
+        assert.commandWorked(conn.getDB(dbName).dropDatabase());
+    }
+
+    // Phase 4: Restart again to confirm cleanup of all test databases
+    jsTestLog("Phase 4: Final restart to confirm all test keys are cleaned up");
+
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod({
+        dbpath: dbpath,
+        restart: true,
+        enableEncryption: "",
+        encryptionKeyFile: keyFile,
+        encryptionCipherMode: cipherMode,
+        setParameter: {
+            encryptionKeyCleanupIntervalSeconds: 0,
+        },
+    });
+    assert.neq(null, conn, "mongod failed to restart for final verification");
+
+    // Verify all test databases are gone
+    const finalDbs = conn.getDB("admin").adminCommand({listDatabases: 1}).databases;
+    for (const dbInfo of finalDbs) {
+        assert(!dbInfo.name.startsWith(testDbPrefix), "Test database should not exist after restart: " + dbInfo.name);
+    }
+
+    jsTestLog("Deferred key cleanup on startup test completed successfully");
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/jstests/percona/tde/deferred_key_cleanup_on_startup.js
+++ b/jstests/percona/tde/deferred_key_cleanup_on_startup.js
@@ -124,9 +124,11 @@ import {checkLog} from "src/mongo/shell/check_log.js";
     // Verify the startup cleanup deleted the orphaned keys by checking the log file.
     // We use the log file (not the RAM buffer) because startup produces many log entries
     // that can push cleanup messages out of the limited RAM log buffer.
-    // LOGV2 ID 29160 = "Deleting orphaned encryption key for non-existent database"
+    // LOGV2 ID 29160 = "Deleting orphaned encryption key for non-existent database".
+    // The logged keyId is `<dbName>` (legacy bare format) or `<dbName>.<UUID>`
+    // (per-generation format). Match either with a regex anchored on dbName.
     for (const dbName of droppedDbs) {
-        checkLog.containsJson(logpath, 29160, {keyId: dbName});
+        checkLog.containsJson(logpath, 29160, {keyId: new RegExp("^" + dbName + "(\\..+)?$")});
     }
     jsTestLog("Verified startup cleanup deleted orphaned keys for dropped databases");
 

--- a/jstests/percona/tde/deferred_key_cleanup_stress.js
+++ b/jstests/percona/tde/deferred_key_cleanup_stress.js
@@ -1,0 +1,201 @@
+/**
+ * Stress test for encryption key cleanup with aggressive cleanup intervals.
+ *
+ * This test runs 16 parallel threads, each performing 200 iterations of:
+ * - Creating a unique database
+ * - Creating collections and inserting documents
+ * - Verifying data integrity
+ * - Dropping the database
+ *
+ * The periodic key cleanup runs every 1 second, exercising the race condition
+ * handling between dropDatabase and encryption key cleanup.
+ *
+ * @tags: [
+ *   requires_wiredtiger,
+ * ]
+ */
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+
+(function () {
+    "use strict";
+
+    const keyFile = TestData.keyFileGood || "jstests/percona/tde/ekf";
+    const cipherMode = TestData.cipherMode || "AES256-GCM";
+    const cleanupIntervalSecs = 1;
+    const numThreads = 16;
+    const iterationsPerThread = 200;
+    const numCollections = 2;
+    const numDocsPerCollection = 50;
+
+    jsTestLog("Starting deferred key cleanup STRESS test");
+    jsTestLog(
+        "Configuration: " +
+            numThreads +
+            " threads, " +
+            iterationsPerThread +
+            " iterations each, cipher mode: " +
+            cipherMode,
+    );
+
+    // Start mongod with encryption and aggressive periodic key cleanup
+    const conn = MongoRunner.runMongod({
+        enableEncryption: "",
+        encryptionKeyFile: keyFile,
+        encryptionCipherMode: cipherMode,
+        setParameter: {
+            encryptionKeyCleanupIntervalSeconds: cleanupIntervalSecs,
+        },
+    });
+    assert.neq(null, conn, "mongod failed to start with encryption enabled");
+
+    const testDbPrefix = "stress_test_";
+    const adminDb = conn.getDB("admin");
+
+    // Worker function that runs in parallel shell
+    function workerThread(threadId, iterations, numColls, numDocs, dbPrefix) {
+        for (let iter = 0; iter < iterations; iter++) {
+            const dbName = dbPrefix + threadId + "_iter_" + iter;
+            const testDb = db.getSiblingDB(dbName);
+
+            try {
+                // Create collections with data
+                for (let c = 0; c < numColls; c++) {
+                    const collName = "coll_" + c;
+                    const coll = testDb[collName];
+
+                    // Insert documents
+                    let docs = [];
+                    for (let d = 0; d < numDocs; d++) {
+                        docs.push({
+                            _id: d,
+                            threadId: threadId,
+                            iteration: iter,
+                            data: "stress_test_data_" + d + "_" + Math.random(),
+                            timestamp: new Date(),
+                        });
+                    }
+                    const insertResult = coll.insertMany(docs);
+                    assert.commandWorked(insertResult);
+
+                    // Verify document count
+                    const count = coll.countDocuments({});
+                    assert.eq(
+                        numDocs,
+                        count,
+                        "Thread " +
+                            threadId +
+                            " iter " +
+                            iter +
+                            ": Document count mismatch in " +
+                            dbName +
+                            "." +
+                            collName +
+                            " - expected " +
+                            numDocs +
+                            ", got " +
+                            count,
+                    );
+
+                    // Spot check a few documents for data integrity
+                    for (let d = 0; d < Math.min(5, numDocs); d++) {
+                        const doc = coll.findOne({_id: d});
+                        assert.neq(null, doc, "Thread " + threadId + " iter " + iter + ": Missing document _id=" + d);
+                        assert.eq(
+                            threadId,
+                            doc.threadId,
+                            "Thread " + threadId + " iter " + iter + ": threadId mismatch for document _id=" + d,
+                        );
+                        assert.eq(
+                            iter,
+                            doc.iteration,
+                            "Thread " + threadId + " iter " + iter + ": iteration mismatch for document _id=" + d,
+                        );
+                    }
+                }
+
+                // Drop the database
+                const dropResult = testDb.dropDatabase();
+                assert.commandWorked(dropResult);
+
+                // Periodic progress logging
+                if ((iter + 1) % 50 === 0) {
+                    print("Thread " + threadId + ": Completed " + (iter + 1) + "/" + iterations + " iterations");
+                }
+            } catch (e) {
+                print("Thread " + threadId + " iter " + iter + " ERROR: " + tojson(e));
+                throw e;
+            }
+        }
+        return {threadId: threadId, iterations: iterations, status: "success"};
+    }
+
+    jsTestLog("Starting " + numThreads + " parallel worker threads");
+
+    // Launch parallel shells
+    let threads = [];
+    for (let t = 0; t < numThreads; t++) {
+        const threadId = t;
+        const thread = startParallelShell(
+            funWithArgs(
+                workerThread,
+                threadId,
+                iterationsPerThread,
+                numCollections,
+                numDocsPerCollection,
+                testDbPrefix,
+            ),
+            conn.port,
+        );
+        threads.push(thread);
+    }
+
+    jsTestLog("All threads launched, waiting for completion...");
+
+    // Wait for all threads to complete
+    let allSucceeded = true;
+    for (let t = 0; t < threads.length; t++) {
+        try {
+            threads[t]();
+            jsTestLog("Thread " + t + " completed successfully");
+        } catch (e) {
+            jsTestLog("Thread " + t + " FAILED: " + tojson(e));
+            allSucceeded = false;
+        }
+    }
+
+    assert(allSucceeded, "One or more worker threads failed");
+
+    jsTestLog("All threads completed. Waiting for final cleanup cycle...");
+
+    // Wait for a few cleanup cycles to ensure all orphaned keys are processed
+    sleep(cleanupIntervalSecs * 5 * 1000);
+
+    jsTestLog("Verifying no test databases remain...");
+
+    // Verify no test databases remain
+    const finalDbs = adminDb.adminCommand({listDatabases: 1}).databases;
+    let testDbsRemaining = [];
+    for (const dbInfo of finalDbs) {
+        if (dbInfo.name.startsWith(testDbPrefix)) {
+            testDbsRemaining.push(dbInfo.name);
+        }
+    }
+    assert.eq(0, testDbsRemaining.length, "Test databases should have been dropped: " + tojson(testDbsRemaining));
+
+    jsTestLog("Final verification: Create and drop a few more databases");
+
+    // Final verification: system should still be fully functional
+    for (let i = 0; i < 5; i++) {
+        const dbName = testDbPrefix + "final_verify_" + i;
+        const db = conn.getDB(dbName);
+
+        assert.commandWorked(db.test.insertOne({verify: true, index: i}));
+        assert.eq(1, db.test.countDocuments({}));
+        assert.commandWorked(db.dropDatabase());
+    }
+
+    jsTestLog("Stress test completed successfully!");
+    jsTestLog("Total operations: " + numThreads * iterationsPerThread + " create/drop cycles");
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/src/mongo/db/commands/BUILD.bazel
+++ b/src/mongo/db/commands/BUILD.bazel
@@ -569,6 +569,18 @@ mongo_cc_library(
 )
 
 mongo_cc_library(
+    name = "cleanup_orphaned_encryption_keys_cmd",
+    srcs = [
+        "cleanup_orphaned_encryption_keys_cmd.cpp",
+    ],
+    deps = [
+        "//src/mongo/db:commands",
+        "//src/mongo/db/auth",
+        "//src/mongo/db/auth:authprivilege",
+    ],
+)
+
+mongo_cc_library(
     name = "set_index_commit_quorum_idl",
     srcs = [
         ":set_index_commit_quorum_gen",
@@ -992,6 +1004,7 @@ mongo_cc_library(
         "//src/mongo/db/topology/user_write_block:set_user_write_block_mode_command.cpp",
     ],
     deps = [
+        "cleanup_orphaned_encryption_keys_cmd",
         "cluster_server_parameter_commands_invocation",
         "core",
         "create_command",

--- a/src/mongo/db/commands/cleanup_orphaned_encryption_keys_cmd.cpp
+++ b/src/mongo/db/commands/cleanup_orphaned_encryption_keys_cmd.cpp
@@ -1,0 +1,94 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+#include "mongo/base/status.h"
+#include "mongo/base/string_data.h"
+#include "mongo/bson/bsonobj.h"
+#include "mongo/bson/bsonobjbuilder.h"
+#include "mongo/db/auth/action_type.h"
+#include "mongo/db/auth/authorization_session.h"
+#include "mongo/db/auth/resource_pattern.h"
+#include "mongo/db/commands.h"
+#include "mongo/db/database_name.h"
+#include "mongo/db/operation_context.h"
+#include "mongo/db/service_context.h"
+#include "mongo/db/storage/storage_engine.h"
+
+#include <string>
+
+namespace mongo {
+namespace {
+
+class CleanupOrphanedEncryptionKeysCmd : public BasicCommand {
+public:
+    CleanupOrphanedEncryptionKeysCmd() : BasicCommand("cleanupOrphanedEncryptionKeys") {}
+
+    AllowedOnSecondary secondaryAllowed(ServiceContext*) const override {
+        return AllowedOnSecondary::kAlways;
+    }
+
+    bool adminOnly() const override {
+        return true;
+    }
+
+    bool supportsWriteConcern(const BSONObj& cmd) const override {
+        return false;
+    }
+
+    std::string help() const override {
+        return "Manually triggers cleanup of orphaned encryption keys for databases "
+               "that no longer exist.";
+    }
+
+    Status checkAuthForOperation(OperationContext* opCtx,
+                                 const DatabaseName& dbName,
+                                 const BSONObj&) const override {
+        auto* as = AuthorizationSession::get(opCtx->getClient());
+        if (!as->isAuthorizedForActionsOnResource(
+                ResourcePattern::forClusterResource(dbName.tenantId()), ActionType::internal)) {
+            return {ErrorCodes::Unauthorized, "unauthorized"};
+        }
+        return Status::OK();
+    }
+
+    bool run(OperationContext* opCtx,
+             const DatabaseName&,
+             const BSONObj& cmdObj,
+             BSONObjBuilder& result) override {
+        auto* storageEngine = opCtx->getServiceContext()->getStorageEngine();
+        storageEngine->cleanupOrphanedEncryptionKeys(opCtx, "command"_sd);
+        return true;
+    }
+};
+MONGO_REGISTER_COMMAND(CleanupOrphanedEncryptionKeysCmd).forShard();
+
+}  // namespace
+}  // namespace mongo

--- a/src/mongo/db/encryption/BUILD.bazel
+++ b/src/mongo/db/encryption/BUILD.bazel
@@ -83,8 +83,8 @@ mongo_cc_library(
         "master_key_provider.cpp",
     ],
     deps = [
-        ":encryption_options",
         ":encryption_key",
+        ":encryption_options",
         ":kmip_client",
         ":read_file_to_secure_string",
         ":vault_client",

--- a/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
+++ b/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
@@ -439,15 +439,20 @@ Status dropCollectionsWithPrefix(OperationContext* opCtx,
 
     std::vector<UUID> toDrop = catalog->getAllCollectionUUIDsFromDb(dbName);
 
-    const auto status = dropCollections(opCtx, toDrop, collectionNamePrefix);
+    // NOTE: Encryption key cleanup is NOT performed here.
+    // The key cannot be safely deleted at this point because drop-pending idents
+    // (encrypted with this key) may still exist in storage and will be accessed
+    // during checkpoint cleanup. Deleting the key here would cause WT_NOTFOUND errors.
+    // Instead, orphaned encryption keys are cleaned up via three mechanisms:
+    // 1. Unconditionally on startup (after catalog initialization)
+    // 2. Periodically by a background process (when encryptionKeyCleanupIntervalSeconds > 0)
+    // 3. On demand via the cleanupOrphanedEncryptionKeys admin command
+    //
+    // Signal the periodic job that there is now work to do. Steady-state ticks
+    // with no drops since the previous scan skip the expensive metadata walk.
+    opCtx->getServiceContext()->getStorageEngine()->markEncryptionKeyCleanupDirty();
 
-    // If all collections were dropped successfully then drop database's encryption key
-    if (status.isOK()) {
-        auto storageEngine = opCtx->getServiceContext()->getStorageEngine();
-        storageEngine->keydbDropDatabase(dbName);
-    }
-
-    return status;
+    return dropCollections(opCtx, toDrop, collectionNamePrefix);
 }
 
 void shutDownCollectionCatalogAndGlobalStorageEngineCleanly(ServiceContext* service,
@@ -491,6 +496,9 @@ void startUpCollectionCatalogDeferred(OperationContext* opCtx) {
     auto storageEngine = opCtx->getServiceContext()->getStorageEngine();
     storageEngine->loadMDBCatalog(opCtx, StorageEngine::LastShutdownState::kClean);
     catalog::initializeCollectionCatalog(opCtx, storageEngine);
+
+    // Unconditionally clean up orphaned encryption keys at startup.
+    storageEngine->cleanupOrphanedEncryptionKeys(opCtx, "startup"_sd);
 }
 
 StorageEngine::LastShutdownState startUpStorageEngineAndCollectionCatalog(
@@ -505,9 +513,16 @@ StorageEngine::LastShutdownState startUpStorageEngineAndCollectionCatalog(
     auto lastShutdownState = startUpStorageEngine(
         initializeStorageEngineOpCtx.get(), initFlags, startupTimeElapsedBuilder);
 
-    Lock::GlobalWrite globalLk(initializeStorageEngineOpCtx.get());
-    catalog::initializeCollectionCatalog(initializeStorageEngineOpCtx.get(),
-                                         service->getStorageEngine());
+    {
+        Lock::GlobalWrite globalLk(initializeStorageEngineOpCtx.get());
+        catalog::initializeCollectionCatalog(initializeStorageEngineOpCtx.get(),
+                                             service->getStorageEngine());
+    }
+
+    // Unconditionally clean up orphaned encryption keys at startup.
+    // The catalog is fully initialized and no client operations are running yet.
+    service->getStorageEngine()->cleanupOrphanedEncryptionKeys(initializeStorageEngineOpCtx.get(),
+                                                               "startup"_sd);
 
     return lastShutdownState;
 }

--- a/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
+++ b/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
@@ -439,18 +439,30 @@ Status dropCollectionsWithPrefix(OperationContext* opCtx,
 
     std::vector<UUID> toDrop = catalog->getAllCollectionUUIDsFromDb(dbName);
 
-    // NOTE: Encryption key cleanup is NOT performed here.
-    // The key cannot be safely deleted at this point because drop-pending idents
-    // (encrypted with this key) may still exist in storage and will be accessed
-    // during checkpoint cleanup. Deleting the key here would cause WT_NOTFOUND errors.
-    // Instead, orphaned encryption keys are cleaned up via three mechanisms:
+    // NOTE: The encryption key row in `table:key` is NOT deleted here.
+    // Drop-pending idents (encrypted with the old key) may still exist in
+    // storage and will be accessed during checkpoint cleanup. Deleting the
+    // row here would cause WT_NOTFOUND errors. The orphan cleanup pass reaps
+    // it later, once no idents reference it. The pass runs:
     // 1. Unconditionally on startup (after catalog initialization)
     // 2. Periodically by a background process (when encryptionKeyCleanupIntervalSeconds > 0)
     // 3. On demand via the cleanupOrphanedEncryptionKeys admin command
     //
     // Signal the periodic job that there is now work to do. Steady-state ticks
     // with no drops since the previous scan skip the expensive metadata walk.
-    opCtx->getServiceContext()->getStorageEngine()->markEncryptionKeyCleanupDirty();
+    auto* storageEngine = opCtx->getServiceContext()->getStorageEngine();
+    storageEngine->markEncryptionKeyCleanupDirty();
+
+    // For full-database drops, also invalidate the in-memory active-key-id
+    // cache so the next ident creation in this `dbName` allocates a fresh
+    // `<dbName>.<UUID>` rather than reusing the dropped generation. This is
+    // safe (no on-disk state changes) and is the mechanism that makes
+    // dropDatabase + recreate produce a new key id. We intentionally do
+    // *not* invalidate when `collectionNamePrefix` is non-empty, since the
+    // database is not actually being dropped in that case.
+    if (collectionNamePrefix.empty()) {
+        storageEngine->keydbDropDatabase(dbName);
+    }
 
     return dropCollections(opCtx, toDrop, collectionNamePrefix);
 }

--- a/src/mongo/db/storage/BUILD.bazel
+++ b/src/mongo/db/storage/BUILD.bazel
@@ -730,6 +730,16 @@ mongo_cc_library(
 )
 
 mongo_cc_benchmark(
+    name = "encryption_key_cleanup_bm",
+    srcs = [
+        "encryption_key_cleanup_bm.cpp",
+    ],
+    deps = [
+        "//src/mongo/db:server_base",
+    ],
+)
+
+mongo_cc_benchmark(
     name = "storage_record_id_bm",
     srcs = [
         "record_id_bm.cpp",

--- a/src/mongo/db/storage/encryption_key_cleanup_bm.cpp
+++ b/src/mongo/db/storage/encryption_key_cleanup_bm.cpp
@@ -1,0 +1,178 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+/**
+ * Benchmark for the orphaned encryption key cleanup algorithm.
+ *
+ * Tests the core set-difference algorithm used by
+ * StorageEngineImpl::cleanupOrphanedEncryptionKeys() to find orphaned keys.
+ * The algorithm collects three sorted vectors and performs two set_difference
+ * passes in O(K + I + D) time. This benchmark verifies that performance
+ * scales linearly with input size.
+ */
+
+#include <algorithm>
+#include <cstdio>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+namespace mongo {
+namespace {
+
+// Generate a vector of unique "database name" strings like "db_00000", "db_00042", etc.
+// The indices are sampled from [0, universeSize) without replacement.
+std::vector<std::string> generateSortedNames(int count, int universeSize, std::mt19937& gen) {
+    // Generate unique indices
+    std::vector<int> indices(universeSize);
+    std::iota(indices.begin(), indices.end(), 0);
+    std::shuffle(indices.begin(), indices.end(), gen);
+    indices.resize(count);
+    std::sort(indices.begin(), indices.end());
+
+    std::vector<std::string> names;
+    names.reserve(count);
+    for (int idx : indices) {
+        // Fixed-width format ensures lexicographic order matches numeric order
+        char buf[32];
+        snprintf(buf, sizeof(buf), "db_%05d", idx);
+        names.emplace_back(buf);
+    }
+    return names;
+}
+
+// Mirrors the algorithm in StorageEngineImpl::cleanupOrphanedEncryptionKeys():
+//   Pass 1: keyIds \ existingDbNames → notInCatalog
+//   Pass 2: notInCatalog \ keyIdsInUse → orphaned
+std::vector<std::string> findOrphanedKeys(std::vector<std::string> keyIds,
+                                          const std::vector<std::string>& keyIdsInUse,
+                                          const std::vector<std::string>& existingDbNames) {
+    std::sort(keyIds.begin(), keyIds.end());
+
+    std::vector<std::string> notInCatalog;
+    std::set_difference(keyIds.begin(),
+                        keyIds.end(),
+                        existingDbNames.begin(),
+                        existingDbNames.end(),
+                        std::back_inserter(notInCatalog));
+
+    std::vector<std::string> orphaned;
+    std::set_difference(notInCatalog.begin(),
+                        notInCatalog.end(),
+                        keyIdsInUse.begin(),
+                        keyIdsInUse.end(),
+                        std::back_inserter(orphaned));
+
+    return orphaned;
+}
+
+// Benchmark: scale all three vectors together.
+// state.range(0) = total number of keys in the key database
+// 50% of keys have a matching database (existingDbNames)
+// 25% of keys are in use by idents (keyIdsInUse)
+// ~25% end up orphaned
+void BM_FindOrphanedKeys(benchmark::State& state) {
+    const int numKeys = state.range(0);
+    const int numExistingDbs = numKeys / 2;
+    const int numIdentsInUse = numKeys / 4;
+    const int universeSize = numKeys * 2;  // key names drawn from a larger universe
+
+    std::mt19937 gen(42);  // fixed seed for reproducibility
+    auto keyIds = generateSortedNames(numKeys, universeSize, gen);
+    auto existingDbNames = generateSortedNames(numExistingDbs, universeSize, gen);
+    auto keyIdsInUse = generateSortedNames(numIdentsInUse, universeSize, gen);
+
+    for (auto _ : state) {
+        auto result = findOrphanedKeys(keyIds, keyIdsInUse, existingDbNames);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                            (numKeys + numExistingDbs + numIdentsInUse));
+}
+
+BENCHMARK(BM_FindOrphanedKeys)->RangeMultiplier(10)->Range(100, 100'000);
+
+// Benchmark: many idents, few keys (typical production scenario).
+// A server with 10 databases might have thousands of idents (collections + indexes).
+void BM_FindOrphanedKeysFewKeysManyIdents(benchmark::State& state) {
+    const int numKeys = 10;
+    const int numIdents = state.range(0);
+    const int numExistingDbs = 8;  // most keys still have a database
+    const int universeSize = numIdents * 2;
+
+    std::mt19937 gen(42);
+    auto keyIds = generateSortedNames(numKeys, universeSize, gen);
+    auto existingDbNames = generateSortedNames(numExistingDbs, universeSize, gen);
+    auto keyIdsInUse = generateSortedNames(numIdents, universeSize, gen);
+
+    for (auto _ : state) {
+        auto result = findOrphanedKeys(keyIds, keyIdsInUse, existingDbNames);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                            (numKeys + numExistingDbs + numIdents));
+}
+
+BENCHMARK(BM_FindOrphanedKeysFewKeysManyIdents)->RangeMultiplier(10)->Range(1'000, 100'000);
+
+// Benchmark: no orphans (best case — both set_differences produce empty output).
+// All keys have a matching database, so Pass 1 yields nothing.
+void BM_FindOrphanedKeysNoOrphans(benchmark::State& state) {
+    const int numKeys = state.range(0);
+    const int universeSize = numKeys * 2;
+
+    std::mt19937 gen(42);
+    auto keyIds = generateSortedNames(numKeys, universeSize, gen);
+    // existingDbNames is a superset of keyIds — no orphans possible
+    auto existingDbNames = keyIds;
+    auto keyIdsInUse = generateSortedNames(numKeys / 2, universeSize, gen);
+
+    for (auto _ : state) {
+        auto result = findOrphanedKeys(keyIds, keyIdsInUse, existingDbNames);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                            (numKeys + numKeys + numKeys / 2));
+}
+
+BENCHMARK(BM_FindOrphanedKeysNoOrphans)->RangeMultiplier(10)->Range(100, 100'000);
+
+}  // namespace
+}  // namespace mongo

--- a/src/mongo/db/storage/keydb_api.h
+++ b/src/mongo/db/storage/keydb_api.h
@@ -31,9 +31,15 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include "mongo/base/string_data.h"
+
+#include <string>
+#include <vector>
+
 namespace mongo {
 class DatabaseName;
-}
+class OperationContext;
+}  // namespace mongo
 
 namespace percona {
 
@@ -45,9 +51,61 @@ struct KeyDBAPI {
     virtual ~KeyDBAPI() {}
 
     /**
-     * Returns whether the engine supports feature compatibility version 3.6
+     * Delete the encryption key for the specified database.
+     *
+     * This method is called by the deferred cleanup process after verifying:
+     * 1. The database no longer exists in the catalog
+     * 2. No storage idents (including drop-pending ones) use the key
+     *
+     * NOTE: This should NOT be called directly during dropDatabase operations
+     * because drop-pending idents may still exist and require the key for
+     * checkpoint cleanup. Use the deferred cleanup mechanism instead.
      */
     virtual void keydbDropDatabase(const mongo::DatabaseName& dbName) {
+        // do nothing for engines which do not support KeyDB
+    }
+
+    /**
+     * Returns the sorted set of encryption keyIds that exist in the key database
+     * but are not referenced by any storage ident (including drop-pending ones).
+     *
+     * Computed inside the engine because both inputs — the keydb listing and the
+     * WT-metadata scan — are engine-internal. Callers re-verify each candidate
+     * under a DB lock before deleting it; this method does not consult the
+     * CollectionCatalog.
+     */
+    virtual std::vector<std::string> findOrphanedEncryptionKeyIds() {
+        return {};  // empty for engines which do not support KeyDB
+    }
+
+    /**
+     * Returns the interval in seconds between orphaned encryption key cleanup attempts.
+     * 0 means periodic cleanup is disabled; >0 means enabled with that interval.
+     */
+    virtual int32_t getEncryptionKeyCleanupIntervalSeconds() const {
+        return 0;  // disabled for engines which do not support KeyDB
+    }
+
+    /**
+     * Cleans up orphaned encryption keys - keys that belong to databases that
+     * no longer exist and are not in use by any storage idents.
+     * Called unconditionally on startup, by the periodic cleanup process, and
+     * by the cleanupOrphanedEncryptionKeys admin command. `trigger` is a short
+     * string identifying the call site ("startup" / "periodic" / "command") so
+     * the completion summary log can be filtered/audited.
+     */
+    virtual void cleanupOrphanedEncryptionKeys(mongo::OperationContext* opCtx,
+                                               mongo::StringData trigger) {
+        // do nothing for engines which do not support KeyDB
+    }
+
+    /**
+     * Marks that an orphaned-encryption-key cleanup should run at the next
+     * periodic tick. Called from dropDatabase paths so the periodic job can
+     * skip the WT-metadata scan when nothing has been dropped since the last
+     * run.
+     */
+    virtual void markEncryptionKeyCleanupDirty() {
         // do nothing for engines which do not support KeyDB
     }
 };

--- a/src/mongo/db/storage/keydb_api.h
+++ b/src/mongo/db/storage/keydb_api.h
@@ -51,17 +51,27 @@ struct KeyDBAPI {
     virtual ~KeyDBAPI() {}
 
     /**
-     * Delete the encryption key for the specified database.
+     * Invalidate any per-process state cached for `dbName` that was bound to
+     * the database's old encryption-key generation. Called when the database
+     * is dropped at the MongoDB level so that the next ident creation in the
+     * same name allocates a fresh `<dbName>.<UUID>` key id rather than
+     * reusing the old one.
      *
-     * This method is called by the deferred cleanup process after verifying:
-     * 1. The database no longer exists in the catalog
-     * 2. No storage idents (including drop-pending ones) use the key
-     *
-     * NOTE: This should NOT be called directly during dropDatabase operations
-     * because drop-pending idents may still exist and require the key for
-     * checkpoint cleanup. Use the deferred cleanup mechanism instead.
+     * This intentionally does NOT delete the row from `table:key` - drop-
+     * pending idents encrypted with the old key may still need to be read
+     * during checkpoint cleanup. The actual row is reaped later by the
+     * orphan cleanup pass via `deleteOrphanedEncryptionKey`.
      */
     virtual void keydbDropDatabase(const mongo::DatabaseName& dbName) {
+        // do nothing for engines which do not support KeyDB
+    }
+
+    /**
+     * Delete a single encryption key by its key id. Used by the orphan
+     * cleanup pass after re-verifying under a DB lock that no live or drop-
+     * pending ident references the key.
+     */
+    virtual void deleteOrphanedEncryptionKey(mongo::StringData keyId) {
         // do nothing for engines which do not support KeyDB
     }
 

--- a/src/mongo/db/storage/storage_engine_impl.cpp
+++ b/src/mongo/db/storage/storage_engine_impl.cpp
@@ -36,10 +36,13 @@
 #include "mongo/bson/timestamp.h"
 #include "mongo/db/admission/execution_control/execution_admission_context.h"
 #include "mongo/db/client.h"
+#include "mongo/db/database_name_util.h"
 #include "mongo/db/index/multikey_paths.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/rss/replicated_storage_service.h"
+#include "mongo/db/shard_role/lock_manager/d_concurrency.h"
 #include "mongo/db/shard_role/shard_catalog/catalog_raii.h"
+#include "mongo/db/shard_role/shard_catalog/collection_catalog.h"
 #include "mongo/db/shard_role/transaction_resources.h"
 #include "mongo/db/storage/backup_cursor_hooks.h"
 #include "mongo/db/storage/disk_space_monitor.h"
@@ -63,6 +66,7 @@
 #include "mongo/util/fail_point.h"
 #include "mongo/util/log_and_backoff.h"
 #include "mongo/util/str.h"
+#include "mongo/util/timer.h"
 
 #include <algorithm>
 #include <memory>
@@ -534,6 +538,7 @@ StringData StorageEngineImpl::getIndexIdentUniqueTag(StringData ident,
 }
 
 void StorageEngineImpl::cleanShutdown(ServiceContext* svcCtx, bool memLeakAllowed) {
+    _stopEncryptionKeyCleanupJob();
     _timestampMonitor.reset();
 
     _catalog.reset();
@@ -571,11 +576,14 @@ void StorageEngineImpl::startTimestampMonitor(
     for (auto listener : listeners) {
         _timestampMonitor->addListener(listener);
     }
+
+    _startEncryptionKeyCleanupJob();
 }
 
 void StorageEngineImpl::stopTimestampMonitor() {
     _listeners = _timestampMonitor->getListeners();
     _timestampMonitor.reset();
+    _stopEncryptionKeyCleanupJob();
 }
 
 void StorageEngineImpl::restartTimestampMonitor() {
@@ -587,6 +595,8 @@ void StorageEngineImpl::restartTimestampMonitor() {
         _timestampMonitor->addListener(listener);
     }
     _listeners.clear();
+
+    _startEncryptionKeyCleanupJob();
 }
 
 void StorageEngineImpl::notifyStorageStartupRecoveryComplete() {
@@ -977,6 +987,142 @@ StorageEngine::CheckpointIteration StorageEngineImpl::getCheckpointIteration() c
 bool StorageEngineImpl::hasDataBeenCheckpointed(
     StorageEngine::CheckpointIteration checkpointIteration) const {
     return _engine->hasDataBeenCheckpointed(checkpointIteration);
+}
+
+void StorageEngineImpl::cleanupOrphanedEncryptionKeys(OperationContext* opCtx, StringData trigger) {
+    Timer timer;
+
+    // Skip cleanup during backup. Deleting a key while a backup cursor is
+    // iterating the key database could produce a backup that cannot decrypt
+    // its ident files.
+    if (_inBackupMode) {
+        LOGV2_DEBUG(29171,
+                    1,
+                    "Orphaned encryption key cleanup deferred due to backup in progress",
+                    "trigger"_attr = trigger,
+                    "reason"_attr = "inBackupMode"_sd);
+        return;
+    }
+    auto backupCursorHooks = BackupCursorHooks::get(opCtx->getServiceContext());
+    if (backupCursorHooks && backupCursorHooks->isBackupCursorOpen()) {
+        LOGV2_DEBUG(29171,
+                    1,
+                    "Orphaned encryption key cleanup deferred due to backup in progress",
+                    "trigger"_attr = trigger,
+                    "reason"_attr = "backupCursorOpen"_sd);
+        return;
+    }
+
+    // Ask the engine for keys that exist in the keydb but are not referenced by
+    // any storage ident (including drop-pending ones). Each candidate is then
+    // re-verified under a MODE_S DB lock against the CollectionCatalog before
+    // deletion — that lock is what guards against races with concurrent
+    // createDatabase / createCollection.
+    auto orphaned = _engine->findOrphanedEncryptionKeyIds();
+
+    if (orphaned.empty()) {
+        LOGV2(29169,
+              "Orphaned encryption key cleanup completed",
+              "trigger"_attr = trigger,
+              "candidates"_attr = 0,
+              "deleted"_attr = 0,
+              "durationMs"_attr = timer.millis());
+        return;
+    }
+
+    LOGV2_DEBUG(29172, 2, "Orphaned encryption key candidates", "keyIds"_attr = orphaned);
+
+    // Re-verify under lock and delete
+    size_t deleted = 0;
+    for (const auto& keyId : orphaned) {
+        try {
+            auto dbName = DatabaseNameUtil::deserialize(
+                boost::none, keyId, SerializationContext::stateDefault());
+
+            Lock::DBLock dbLock(opCtx, dbName, MODE_S);
+            auto freshCatalog = CollectionCatalog::get(opCtx);
+            auto freshDbs = freshCatalog->getAllDbNames();
+            bool dbExists = std::find(freshDbs.begin(), freshDbs.end(), dbName) != freshDbs.end();
+            bool dropPending = freshCatalog->isDropPending(dbName);
+
+            if (!dbExists && !dropPending) {
+                LOGV2(29160,
+                      "Deleting orphaned encryption key for non-existent database",
+                      "keyId"_attr = keyId);
+                _engine->keydbDropDatabase(dbName);
+                ++deleted;
+            } else {
+                LOGV2_DEBUG(29170,
+                            1,
+                            "Skipped orphaned encryption key deletion",
+                            "keyId"_attr = keyId,
+                            "reason"_attr = dbExists ? "dbExists"_sd : "dropPending"_sd);
+            }
+        } catch (const DBException& e) {
+            // Log and continue with other keys - don't let one failure stop cleanup
+            LOGV2_DEBUG(29161,
+                        1,
+                        "Failed to clean up encryption key",
+                        "keyId"_attr = keyId,
+                        "error"_attr = e.toStatus());
+        }
+    }
+
+    LOGV2(29169,
+          "Orphaned encryption key cleanup completed",
+          "trigger"_attr = trigger,
+          "candidates"_attr = orphaned.size(),
+          "deleted"_attr = deleted,
+          "durationMs"_attr = timer.millis());
+}
+
+void StorageEngineImpl::markEncryptionKeyCleanupDirty() {
+    _encryptionKeyCleanupDirty.store(true);
+}
+
+void StorageEngineImpl::_runEncryptionKeyCleanupJob(Client* client) try {
+    // Nothing dropped since the last scan — skip the expensive WT-metadata walk.
+    // exchange(false) atomically claims the "dirty" state so concurrent
+    // dropDatabase calls after this point will cause the next tick to run.
+    if (!_encryptionKeyCleanupDirty.swap(false)) {
+        LOGV2(29168,
+              "Orphaned encryption key cleanup skipped",
+              "reason"_attr = "noDropsSinceLastScan"_sd);
+        return;
+    }
+    auto uniqueOpCtx = client->makeOperationContext();
+    cleanupOrphanedEncryptionKeys(uniqueOpCtx.get(), "periodic"_sd);
+} catch (...) {
+    // Restore the dirty flag so the next tick retries. Swallowing the
+    // exception matches the pattern used by DiskSpaceMonitor; exiting the
+    // PeriodicRunner job via an uncaught exception would kill the job.
+    _encryptionKeyCleanupDirty.store(true);
+    LOGV2(29167,
+          "Caught exception in orphaned encryption-key cleanup job",
+          "error"_attr = exceptionToStatus());
+}
+
+void StorageEngineImpl::_startEncryptionKeyCleanupJob() {
+    auto intervalSeconds = _engine->getEncryptionKeyCleanupIntervalSeconds();
+    if (intervalSeconds <= 0) {
+        // Periodic cleanup disabled. Startup and the cleanupOrphanedEncryptionKeys
+        // admin command continue to work unchanged.
+        return;
+    }
+    invariant(!_encryptionKeyCleanupJob, "encryption-key cleanup job already started");
+    _encryptionKeyCleanupJob = getGlobalServiceContext()->getPeriodicRunner()->makeJob(
+        PeriodicRunner::PeriodicJob{"OrphanedEncryptionKeyCleanup",
+                                    [this](Client* client) { _runEncryptionKeyCleanupJob(client); },
+                                    Seconds(intervalSeconds),
+                                    /*isKillableByStepdown=*/true});
+    _encryptionKeyCleanupJob.start();
+}
+
+void StorageEngineImpl::_stopEncryptionKeyCleanupJob() {
+    if (_encryptionKeyCleanupJob) {
+        _encryptionKeyCleanupJob.stop();
+        _encryptionKeyCleanupJob.detach();
+    }
 }
 
 StorageEngineImpl::TimestampMonitor::TimestampMonitor(KVEngine* engine, PeriodicRunner* runner)

--- a/src/mongo/db/storage/storage_engine_impl.cpp
+++ b/src/mongo/db/storage/storage_engine_impl.cpp
@@ -131,6 +131,10 @@ void StorageEngineImpl::keydbDropDatabase(const DatabaseName& dbName) {
     _engine->keydbDropDatabase(dbName);
 }
 
+void StorageEngineImpl::deleteOrphanedEncryptionKey(StringData keyId) {
+    _engine->deleteOrphanedEncryptionKey(keyId);
+}
+
 StorageEngineImpl::StorageEngineImpl(OperationContext* opCtx,
                                      std::unique_ptr<KVEngine> engine,
                                      std::unique_ptr<KVEngine> spillEngine,
@@ -1036,8 +1040,16 @@ void StorageEngineImpl::cleanupOrphanedEncryptionKeys(OperationContext* opCtx, S
     size_t deleted = 0;
     for (const auto& keyId : orphaned) {
         try {
+            // Key id format is `<dbName>` (legacy, pre-generation) or
+            // `<dbName>.<UUID>` (per-generation). Database names cannot
+            // contain '.', so the first dot unambiguously separates the two
+            // pieces. We need the dbName only to take the right DB lock and
+            // to re-verify against the catalog; the actual deletion is by
+            // exact keyId.
+            auto dotPos = keyId.find('.');
+            std::string dbStr = (dotPos == std::string::npos) ? keyId : keyId.substr(0, dotPos);
             auto dbName = DatabaseNameUtil::deserialize(
-                boost::none, keyId, SerializationContext::stateDefault());
+                boost::none, dbStr, SerializationContext::stateDefault());
 
             Lock::DBLock dbLock(opCtx, dbName, MODE_S);
             auto freshCatalog = CollectionCatalog::get(opCtx);
@@ -1049,7 +1061,7 @@ void StorageEngineImpl::cleanupOrphanedEncryptionKeys(OperationContext* opCtx, S
                 LOGV2(29160,
                       "Deleting orphaned encryption key for non-existent database",
                       "keyId"_attr = keyId);
-                _engine->keydbDropDatabase(dbName);
+                _engine->deleteOrphanedEncryptionKey(keyId);
                 ++deleted;
             } else {
                 LOGV2_DEBUG(29170,

--- a/src/mongo/db/storage/storage_engine_impl.h
+++ b/src/mongo/db/storage/storage_engine_impl.h
@@ -50,6 +50,7 @@
 #include "mongo/db/storage/storage_engine.h"
 #include "mongo/db/tenant_id.h"
 #include "mongo/util/modules.h"
+#include "mongo/util/periodic_runner.h"
 #include "mongo/util/uuid.h"
 
 #include <cstddef>
@@ -59,7 +60,6 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -86,6 +86,10 @@ class StorageEngineImpl final : public StorageEngine {
     Status hotBackupTar(OperationContext* opCtx, const std::string& path) override;
     Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
     void keydbDropDatabase(const DatabaseName& dbName) override;
+
+    void cleanupOrphanedEncryptionKeys(OperationContext* opCtx, StringData trigger) override;
+
+    void markEncryptionKeyCleanupDirty() override;
 
 public:
     StorageEngineImpl(OperationContext* opCtx,
@@ -356,6 +360,20 @@ private:
 
     void _dumpCatalog(OperationContext* opCtx);
 
+    /**
+     * PeriodicRunner job body for orphaned encryption-key cleanup. Skips when
+     * the dirty flag is clear (no dropDatabase since last scan) and otherwise
+     * invokes cleanupOrphanedEncryptionKeys after clearing the flag.
+     */
+    void _runEncryptionKeyCleanupJob(Client* client);
+
+    /**
+     * Starts/stops the orphaned-encryption-key cleanup PeriodicRunner job.
+     * No-op if the configured interval is 0.
+     */
+    void _startEncryptionKeyCleanupJob();
+    void _stopEncryptionKeyCleanupJob();
+
     // Main KVEngine instance used for all user tables.
     // This must be the first member so it is destroyed last.
     std::unique_ptr<KVEngine> _engine;
@@ -371,6 +389,16 @@ private:
 
     // Listener for timestamp changes.
     TimestampMonitor::TimestampListener _timestampListener;
+
+    // Set by markEncryptionKeyCleanupDirty() on every dropDatabase. The
+    // periodic cleanup job clears it before running its scan, so ticks with
+    // no drops since the previous run skip the expensive metadata walk.
+    // Initialized true so the first tick after startup always runs.
+    AtomicWord<bool> _encryptionKeyCleanupDirty{true};
+
+    // Background job that runs _runEncryptionKeyCleanupJob() on the
+    // configured interval. Not scheduled when the interval is 0.
+    PeriodicJobAnchor _encryptionKeyCleanupJob;
 
     const bool _supportsCappedCollections;
 

--- a/src/mongo/db/storage/storage_engine_impl.h
+++ b/src/mongo/db/storage/storage_engine_impl.h
@@ -87,6 +87,8 @@ class StorageEngineImpl final : public StorageEngine {
     Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
     void keydbDropDatabase(const DatabaseName& dbName) override;
 
+    void deleteOrphanedEncryptionKey(StringData keyId) override;
+
     void cleanupOrphanedEncryptionKeys(OperationContext* opCtx, StringData trigger) override;
 
     void markEncryptionKeyCleanupDirty() override;

--- a/src/mongo/db/storage/wiredtiger/BUILD.bazel
+++ b/src/mongo/db/storage/wiredtiger/BUILD.bazel
@@ -285,6 +285,20 @@ mongo_cc_benchmark(
 )
 
 mongo_cc_benchmark(
+    name = "wiredtiger_encryption_key_cleanup_bm",
+    srcs = [
+        "wiredtiger_encryption_key_cleanup_bm.cpp",
+    ],
+    tags = ["storage_bm"],
+    deps = [
+        ":storage_wiredtiger_core",
+        "//src/mongo/db:service_context_test_fixture",
+        "//src/mongo/db/shard_role:service_context_non_d",
+        "//src/mongo/util:clock_source_mock",
+    ],
+)
+
+mongo_cc_benchmark(
     name = "wiredtiger_all_durable_timestamp_bm",
     srcs = [
         "wiredtiger_all_durable_timestamp_bm.cpp",

--- a/src/mongo/db/storage/wiredtiger/active_key_id.h
+++ b/src/mongo/db/storage/wiredtiger/active_key_id.h
@@ -1,0 +1,63 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+#pragma once
+
+#include <string>
+
+namespace mongo {
+class DatabaseName;
+class OperationContext;
+
+namespace encryption {
+
+/**
+ * Returns the active encryption key id for `dbName`.
+ *
+ * The lookup is backed by a per-process cache on the global `EncryptionKeyDB`:
+ *   1. Cache hit: the cached key id is returned immediately.
+ *   2. Cache miss: scan `CollectionCatalog` for any live collection in
+ *      `dbName`. If one exists, read its WT ident metadata to extract the
+ *      `keyid="..."` clause; the first key id found is cached and returned.
+ *      This preserves backward compatibility with the legacy bare-`<dbName>`
+ *      format - existing tables continue to use whatever key id they were
+ *      created with.
+ *   3. Catalog empty: a fresh key id of the form `<dbName>.<UUID>` is
+ *      generated, cached, and returned. After `dropDatabase` followed by a
+ *      recreate, this is the path that produces a new generation.
+ *
+ * The header lives in a small target so it can be included from
+ * `wiredtiger_customization_hooks.cpp` without dragging in WiredTiger headers.
+ */
+std::string activeKeyIdForDb(OperationContext* opCtx, const DatabaseName& dbName);
+
+}  // namespace encryption
+}  // namespace mongo

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
@@ -391,6 +391,7 @@ int EncryptionKeyDB::get_key_by_id(const char* keyid, size_t len, unsigned char*
         memcpy(key, v.data, encryption::Key::kLength);
         if (kDebugBuild)
             dump_key(key, encryption::Key::kLength, "loaded key from key DB");
+        invariant(pe);
         _encryptors[c_str] = pe;
         return 0;
     }
@@ -420,6 +421,7 @@ int EncryptionKeyDB::get_key_by_id(const char* keyid, size_t len, unsigned char*
 
     if (kDebugBuild)
         dump_key(key, encryption::Key::kLength, "generated and stored key");
+    invariant(pe);
     _encryptors[c_str] = pe;
     return 0;
 }
@@ -459,11 +461,52 @@ int EncryptionKeyDB::delete_key_by_id(const std::string& keyid) {
     // DB is dropped just after mongod is started and before any read/write operations)
     auto it = _encryptors.find(keyid);
     if (it != _encryptors.end()) {
+        invariant(it->second);
         percona_encryption_extension_drop_keyid(it->second);
         _encryptors.erase(it);
     }
 
     return res;
+}
+
+bool EncryptionKeyDB::isSpecialKeyId(const std::string& keyId) {
+    return keyId.empty() || keyId == "/default";
+}
+
+std::vector<std::string> EncryptionKeyDB::getAllKeyIds() {
+    std::vector<std::string> keyIds;
+
+    WT_CURSOR* cursor;
+    std::lock_guard<std::mutex> lk(_lock_sess);
+    int res = _sess->open_cursor(_sess, "table:key", nullptr, nullptr, &cursor);
+    if (res) {
+        LOGV2_ERROR(
+            29155, "getAllKeyIds: error opening cursor", "error"_attr = wiredtiger_strerror(res));
+        return keyIds;
+    }
+
+    // Create cursor close guard
+    std::unique_ptr<WT_CURSOR, std::function<void(WT_CURSOR*)>> cursor_guard(
+        cursor, [](WT_CURSOR* c) { c->close(c); });
+
+    while ((res = cursor->next(cursor)) == 0) {
+        char* k;
+        res = cursor->get_key(cursor, &k);
+        if (res == 0 && k != nullptr) {
+            std::string keyId(k);
+            if (!isSpecialKeyId(keyId)) {
+                keyIds.emplace_back(std::move(keyId));
+            }
+        }
+    }
+
+    if (res != WT_NOTFOUND) {
+        LOGV2_ERROR(
+            29156, "getAllKeyIds: error iterating cursor", "error"_attr = wiredtiger_strerror(res));
+    }
+
+    LOGV2_DEBUG(29157, 2, "getAllKeyIds: found keys", "count"_attr = keyIds.size());
+    return keyIds;
 }
 
 int EncryptionKeyDB::store_gcm_iv_reserved() {

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
@@ -32,12 +32,24 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #include "mongo/db/storage/wiredtiger/encryption_keydb.h"
 
+#include "mongo/db/database_name.h"
+#include "mongo/db/database_name_util.h"
+#include "mongo/db/operation_context.h"
+#include "mongo/db/service_context.h"
+#include "mongo/db/shard_role/shard_catalog/collection.h"
+#include "mongo/db/shard_role/shard_catalog/collection_catalog.h"
+#include "mongo/db/storage/record_store.h"
+#include "mongo/db/storage/storage_engine.h"
 #include "mongo/db/storage/wiredtiger/encryption_keydb_c_api.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_recovery_unit.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_session.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_util.h"
 #include "mongo/logv2/log.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/debug_util.h"
 #include "mongo/util/system_clock_source.h"
+#include "mongo/util/uuid.h"
 
 #include <cstring>  // memcpy
 
@@ -473,6 +485,38 @@ bool EncryptionKeyDB::isSpecialKeyId(const std::string& keyId) {
     return keyId.empty() || keyId == "/default";
 }
 
+boost::optional<std::string> EncryptionKeyDB::tryGetCachedActiveKeyId(
+    const DatabaseName& dbName) const {
+    std::lock_guard<std::mutex> lk(_activeKeyIdMutex);
+    auto it = _activeKeyIds.find(dbName);
+    if (it == _activeKeyIds.end()) {
+        return boost::none;
+    }
+    return it->second;
+}
+
+std::string EncryptionKeyDB::cacheActiveKeyIdIfAbsent(const DatabaseName& dbName,
+                                                      std::string keyId) {
+    std::lock_guard<std::mutex> lk(_activeKeyIdMutex);
+    auto [it, inserted] = _activeKeyIds.try_emplace(dbName, std::move(keyId));
+    return it->second;
+}
+
+void EncryptionKeyDB::clearCachedActiveKeyId(const DatabaseName& dbName) {
+    std::lock_guard<std::mutex> lk(_activeKeyIdMutex);
+    _activeKeyIds.erase(dbName);
+}
+
+std::vector<std::string> EncryptionKeyDB::getAllCachedActiveKeyIds() const {
+    std::vector<std::string> result;
+    std::lock_guard<std::mutex> lk(_activeKeyIdMutex);
+    result.reserve(_activeKeyIds.size());
+    for (const auto& [_, keyId] : _activeKeyIds) {
+        result.push_back(keyId);
+    }
+    return result;
+}
+
 std::vector<std::string> EncryptionKeyDB::getAllKeyIds() {
     std::vector<std::string> keyIds;
 
@@ -597,6 +641,120 @@ void EncryptionKeyDB::reconfigure(const char* newCfg) {
     _connection = std::make_unique<WiredTigerConnection>(
         conn, _fastClockSource.get(), /*sessionCacheMax=*/33000);
 }
+
+namespace encryption {
+
+namespace {
+
+// Resolve the user-data WiredTigerKVEngine via the storage engine stored on
+// `opCtx`'s service context. We avoid passing the engine in explicitly so the
+// hook stays decoupled from kv-engine selection. Returns nullptr if encryption
+// is not enabled or the engine is not WiredTiger-based.
+WiredTigerKVEngine* getWtEngine(OperationContext* opCtx) {
+    auto se = opCtx->getServiceContext()->getStorageEngine();
+    if (!se) {
+        return nullptr;
+    }
+    return dynamic_cast<WiredTigerKVEngine*>(se->getEngine());
+}
+
+// Reads the encryption key id stored in the WiredTiger metadata for the given
+// `ident`. Returns boost::none if the metadata cannot be read or contains no
+// key id, in which case the caller should fall through to the next candidate.
+boost::optional<std::string> readKeyIdFromIdent(WiredTigerSession& session, StringData ident) {
+    auto metadata =
+        WiredTigerUtil::getMetadataCreate(session, WiredTigerUtil::buildTableUri(ident));
+    if (!metadata.isOK()) {
+        LOGV2_DEBUG(29200,
+                    3,
+                    "activeKeyIdForDb: unable to read WT metadata for ident",
+                    "ident"_attr = ident,
+                    "error"_attr = metadata.getStatus());
+        return boost::none;
+    }
+    auto keyId = WiredTigerUtil::getEncryptionKeyId(metadata.getValue());
+    if (!keyId || EncryptionKeyDB::isSpecialKeyId(*keyId)) {
+        return boost::none;
+    }
+    return keyId;
+}
+
+}  // namespace
+
+std::string activeKeyIdForDb(OperationContext* opCtx, const DatabaseName& dbName) {
+    invariant(opCtx);
+
+    std::string dbStr = DatabaseNameUtil::serialize(dbName, SerializationContext::stateDefault());
+
+    // Early-startup fallback. The MDB catalog ident is created from inside the
+    // `StorageEngineImpl` constructor, *before* the StorageEngine has been
+    // registered on the ServiceContext. At that point we can't reach the
+    // EncryptionKeyDB through the storage engine, but the catalog also doesn't
+    // need per-generation key ids - its dbName ("_mdb_catalog") never gets
+    // dropped and recreated. Fall back to the legacy bare-`<dbName>` keyid in
+    // this window; it matches what the pre-generation code emitted, so the
+    // catalog ident keeps using the same key id across restarts.
+    auto* wtEngine = getWtEngine(opCtx);
+    if (!wtEngine) {
+        return dbStr;
+    }
+
+    EncryptionKeyDB* keyDb = wtEngine->getEncryptionKeyDB();
+    invariant(keyDb, "activeKeyIdForDb called when encryption is disabled");
+
+    if (auto cached = keyDb->tryGetCachedActiveKeyId(dbName)) {
+        return *cached;
+    }
+
+    // Scan the catalog for any live collection in `dbName` and reuse its key
+    // id. We pick the first one that yields a usable key id; on a healthy
+    // system every collection in a given db shares the same key id, so the
+    // choice doesn't matter. Defensive fall-through handles legacy / mixed
+    // states where some idents have no encryption clause.
+    //
+    // We use `CollectionCatalog::range` rather than `getAllCollectionNamesFromDb`
+    // because the latter requires the caller to hold the DB lock in MODE_S, which
+    // is incompatible with the MODE_IX held by an in-progress createCollection.
+    // `range` iterates an immutable snapshot and tolerates concurrent mutation.
+    boost::optional<std::string> resolved;
+    auto catalog = CollectionCatalog::get(opCtx);
+    auto range = catalog->range(dbName);
+    if (!range.empty()) {
+        auto session = wtEngine->getConnection().getUninterruptibleSession();
+        for (auto* coll : range) {
+            if (!coll) {
+                continue;
+            }
+            auto* rs = coll->getRecordStore();
+            if (!rs) {
+                continue;
+            }
+            auto keyId = readKeyIdFromIdent(*session, rs->getIdent());
+            if (keyId) {
+                resolved = std::move(*keyId);
+                break;
+            }
+        }
+    }
+
+    if (!resolved) {
+        // Fresh generation: `<dbName>.<UUID>`. The dot is unambiguous because
+        // MongoDB database names cannot contain '.'.
+        resolved = dbStr + "." + UUID::gen().toString();
+        LOGV2_DEBUG(29201,
+                    1,
+                    "activeKeyIdForDb: allocated fresh key id",
+                    logAttrs(dbName),
+                    "keyId"_attr = *resolved);
+    }
+
+    // Atomic check-and-set: another thread may have raced with us and won the
+    // insert. In that case we discard our value and use the winner's so all
+    // idents created in this WUOW agree on the same key id.
+    return keyDb->cacheActiveKeyIdIfAbsent(dbName, std::move(*resolved));
+}
+
+}  // namespace encryption
 
 }  // namespace mongo
 

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -39,6 +39,7 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 #include <map>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include <wiredtiger.h>
 
@@ -88,6 +89,15 @@ public:
 
     // drop key for specific keyid (used in dropDatabase)
     int delete_key_by_id(const std::string& keyid);
+
+    // Returns all key IDs (database names) stored in the key database.
+    // Excludes the master key (empty keyid) and special keys like "/default".
+    // Used for deferred encryption key cleanup.
+    std::vector<std::string> getAllKeyIds();
+
+    // Returns true if the key ID is a special/reserved key that should not be
+    // included in user key lists (empty key for master key, "/default" key).
+    static bool isSpecialKeyId(const std::string& keyId);
 
     // get new counter value for IV in GCM mode
     int get_iv_gcm(uint8_t* buf, int len);

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -31,6 +31,7 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include "mongo/db/database_name.h"
 #include "mongo/db/encryption/key.h"
 #include "mongo/db/storage/storage_engine.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_connection.h"
@@ -44,6 +45,7 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 #include <wiredtiger.h>
 
 #include <boost/multiprecision/cpp_int.hpp>
+#include <boost/optional.hpp>
 
 namespace mongo {
 
@@ -98,6 +100,30 @@ public:
     // Returns true if the key ID is a special/reserved key that should not be
     // included in user key lists (empty key for master key, "/default" key).
     static bool isSpecialKeyId(const std::string& keyId);
+
+    // Returns the cached active key id for the database, if any. The cache is
+    // populated by `cacheActiveKeyIdIfAbsent` during the catalog-scan based
+    // resolution and cleared by `clearCachedActiveKeyId` when the database is
+    // dropped. A cache miss does not imply the database has no key id - it only
+    // means this process has not resolved one yet.
+    boost::optional<std::string> tryGetCachedActiveKeyId(const DatabaseName& dbName) const;
+
+    // Inserts `keyId` as the active key id for `dbName` only if no entry
+    // exists yet, and returns whatever value is in the cache after the
+    // operation. This atomicity matters when concurrent threads race to
+    // resolve the active key id of the same database; only one of them will
+    // win the insert and all callers will agree on the value.
+    std::string cacheActiveKeyIdIfAbsent(const DatabaseName& dbName, std::string keyId);
+
+    // Removes the cached active key id for `dbName`. The next call to
+    // `encryption::activeKeyIdForDb` will cold-miss, scan the (now empty)
+    // catalog and allocate a fresh key id.
+    void clearCachedActiveKeyId(const DatabaseName& dbName);
+
+    // Returns a snapshot of all currently-cached active key id values. Used by
+    // the orphan key cleanup pass to avoid reaping a freshly-allocated key id
+    // before it has had a chance to attach to an ident on disk.
+    std::vector<std::string> getAllCachedActiveKeyIds() const;
 
     // get new counter value for IV in GCM mode
     int get_iv_gcm(uint8_t* buf, int len);
@@ -178,8 +204,39 @@ private:
     // delete_key_by_it lets encryptor know that DB was deleted and deletes entry
     std::map<std::string, void*> _encryptors;
 
+    // Cache of resolved active key ids per database, scoped to the lifetime of
+    // this `EncryptionKeyDB` instance. This is the source of truth for "which
+    // key id should new idents in dbName X use" once warmed up; on a miss
+    // `encryption::activeKeyIdForDb` consults the catalog and populates it.
+    mutable std::mutex _activeKeyIdMutex;
+    std::map<DatabaseName, std::string> _activeKeyIds;
+
     std::unique_ptr<WiredTigerSession> _backupSession;
     WT_CURSOR* _backupCursor;
 };
+
+namespace encryption {
+
+/**
+ * Returns the active encryption key id for the given database.
+ *
+ * The lookup goes through the per-process cache on the global `EncryptionKeyDB`:
+ *   1. Cache hit: the cached key id is returned immediately.
+ *   2. Cache miss: scan the `CollectionCatalog` for any live collection in
+ *      `dbName`. If one exists, read its WT ident metadata to extract the
+ *      `keyid="..."` clause; that key id is cached and returned. The first key
+ *      id found wins, so a database that already contains tables continues to
+ *      use the same key id its tables were created with (this preserves
+ *      backward compatibility with the legacy bare-`<dbName>` format).
+ *   3. Catalog empty: a fresh key id of the form `<dbName>.<UUID>` is
+ *      generated, cached and returned. After a `dropDatabase` followed by a
+ *      recreate this is the path that produces a new generation.
+ *
+ * Requires `opCtx` to be non-null and to carry a `WiredTigerRecoveryUnit` so
+ * that the catalog scan and any per-ident metadata reads can be performed.
+ */
+std::string activeKeyIdForDb(OperationContext* opCtx, const DatabaseName& dbName);
+
+}  // namespace encryption
 
 }  // namespace mongo

--- a/src/mongo/db/storage/wiredtiger/spill_wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/spill_wiredtiger_kv_engine.cpp
@@ -138,8 +138,8 @@ std::unique_ptr<RecordStore> SpillWiredTigerKVEngine::makeInternalRecordStore(Re
     wtTableConfig.logEnabled = false;
     wtTableConfig.blockCompressor = gSpillWiredTigerBlockCompressor;
     wtTableConfig.extraCreateOptions = _rsOptions;
-    std::string config =
-        WiredTigerRecordStore::generateCreateString({} /* internal table */, wtTableConfig);
+    std::string config = WiredTigerRecordStore::generateCreateString(
+        nullptr, {} /* internal table */, wtTableConfig);
 
     std::string uri = WiredTigerUtil::buildTableUri(ident);
     LOGV2_DEBUG(10158008,

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp
@@ -34,7 +34,9 @@
 #include "mongo/db/database_name_util.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/namespace_string_util.h"
+#include "mongo/db/operation_context.h"
 #include "mongo/db/service_context.h"
+#include "mongo/db/storage/wiredtiger/active_key_id.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/decorable.h"
 #include "mongo/util/str.h"
@@ -60,17 +62,32 @@ public:
      *  Gets an additional configuration string for the provided table name on a
      *  `WT_SESSION::create` call.
      */
-    std::string getTableCreateConfig(StringData tableName) override {
+    std::string getTableCreateConfig(OperationContext* opCtx, StringData tableName) override {
         NamespaceString ns = NamespaceStringUtil::deserialize(
             boost::none, tableName, SerializationContext::stateDefault());
         std::string keyIdStr =
             DatabaseNameUtil::serialize(ns.dbName(), SerializationContext::stateDefault());
         StringData keyid(keyIdStr);
-        // Keep compatibility with v3.6 after SERVER-34617
+        // System tables ("system" + tables whose URI shape starts with "table:")
+        // share a single key id. SERVER-34617 / v3.6 compat: the "system" check
+        // is on the resolved dbname, not the URI.
         const size_t minsize = 6;  // Minimum size which allows following condition to be true
-        if (keyid.size() >= minsize && (keyid == "system"_sd || keyid.starts_with("table:"_sd)))
-            keyid = "/default"_sd;
-        return str::stream() << "encryption=(name=percona,keyid=\"" << keyid << "\"),";
+        if (keyid.size() >= minsize && (keyid == "system"_sd || keyid.starts_with("table:"_sd))) {
+            return str::stream() << "encryption=(name=percona,keyid=\"/default\"),";
+        }
+
+        // No `OperationContext`: caller is an internal / startup-time path
+        // (e.g. spill engine internal record stores, the WT open config string,
+        // the size storer table). The catalog-scan path needs an OpCtx, so we
+        // fall back to the legacy bare-`<dbName>` keyid - which for the empty
+        // tableNames passed by these callers is the empty string, matching
+        // pre-generation behavior.
+        if (!opCtx) {
+            return str::stream() << "encryption=(name=percona,keyid=\"" << keyid << "\"),";
+        }
+
+        std::string activeKeyId = encryption::activeKeyIdForDb(opCtx, ns.dbName());
+        return str::stream() << "encryption=(name=percona,keyid=\"" << activeKeyId << "\"),";
     }
 };
 
@@ -106,10 +123,11 @@ void WiredTigerCustomizationHooksRegistry::addHook(
     _hooks.push_back(std::move(custHook));
 }
 
-std::string WiredTigerCustomizationHooksRegistry::getTableCreateConfig(StringData tableName) const {
+std::string WiredTigerCustomizationHooksRegistry::getTableCreateConfig(OperationContext* opCtx,
+                                                                       StringData tableName) const {
     str::stream config;
     for (const auto& h : _hooks) {
-        config << h->getTableCreateConfig(tableName);
+        config << h->getTableCreateConfig(opCtx, tableName);
     }
     return config;
 }
@@ -131,7 +149,8 @@ bool WiredTigerCustomizationHooks::enabled() const {
     return false;
 }
 
-std::string WiredTigerCustomizationHooks::getTableCreateConfig(StringData tableName) {
+std::string WiredTigerCustomizationHooks::getTableCreateConfig(OperationContext* opCtx,
+                                                               StringData tableName) {
     return "";
 }
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.h
@@ -38,6 +38,7 @@
 namespace mongo {
 class StringData;
 class ServiceContext;
+class OperationContext;
 
 // Interface and default implementation for WiredTiger customization hooks
 class WiredTigerCustomizationHooks {
@@ -57,8 +58,13 @@ public:
     /**
      *  Gets an additional configuration string for the provided table name on a
      *  `WT_SESSION::create` call.
+     *
+     *  `opCtx` may be nullptr for startup-time / internal-table callers (e.g.
+     *  the WT open config string, the size storer table). User-table callers
+     *  should pass their `OperationContext` so that the encryption layer can
+     *  resolve the active per-database key id via the catalog.
      */
-    virtual std::string getTableCreateConfig(StringData tableName);
+    virtual std::string getTableCreateConfig(OperationContext* opCtx, StringData tableName);
 };
 
 /**
@@ -78,7 +84,7 @@ public:
      * Gets a combined configuration string from all hooks in the registry for
      * the provided table name during the `WT_SESSION::create` call.
      */
-    std::string getTableCreateConfig(StringData tableName) const;
+    std::string getTableCreateConfig(OperationContext* opCtx, StringData tableName) const;
 
 private:
     std::vector<std::unique_ptr<WiredTigerCustomizationHooks>> _hooks;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_encryption_key_cleanup_bm.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_encryption_key_cleanup_bm.cpp
@@ -1,0 +1,239 @@
+/*======
+This file is part of Percona Server for MongoDB.
+
+Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the Server Side Public License, version 1,
+    as published by MongoDB, Inc.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    Server Side Public License for more details.
+
+    You should have received a copy of the Server Side Public License
+    along with this program. If not, see
+    <http://www.mongodb.com/licensing/server-side-public-license>.
+
+    As a special exception, the copyright holders give permission to link the
+    code of portions of this program with the OpenSSL library under certain
+    conditions as described in each individual source file and distribute
+    linked combinations including the program with the OpenSSL library. You
+    must comply with the Server Side Public License in all respects for
+    all of the code used other than as permitted herein. If you modify file(s)
+    with this exception, you may extend this exception to your version of the
+    file(s), but you are not obligated to do so. If you do not wish to do so,
+    delete this exception statement from your version. If you delete this
+    exception statement from all source files in the program, then also delete
+    it in the license file.
+======= */
+
+/**
+ * Benchmark for the WT-side work of orphaned encryption key cleanup.
+ *
+ * Targets the part that dominates wall time in production:
+ * the WT metadata cursor scan + per-ident getMetadataCreate + keyid extraction
+ * that runs inside WiredTigerKVEngine::findOrphanedEncryptionKeyIds(). The
+ * keydb listing and final set_difference are O(K) and negligible by
+ * comparison.
+ */
+
+#include "mongo/base/string_data.h"
+#include "mongo/db/service_context_test_fixture.h"
+#include "mongo/db/storage/wiredtiger/encryption_keydb.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_connection.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_error_util.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_recovery_unit.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_session.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_util.h"
+#include "mongo/unittest/temp_dir.h"
+#include "mongo/util/assert_util.h"
+#include "mongo/util/clock_source_mock.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <wiredtiger.h>
+
+#include <benchmark/benchmark.h>
+
+namespace mongo {
+namespace {
+
+// Opens a raw WT connection in a temp dir and wraps it with the same
+// WiredTigerConnection/RecoveryUnit/Session machinery the production code uses,
+// so we can call WiredTigerUtil helpers directly.
+class WtMetadataHarness : public ScopedGlobalServiceContextForTest {
+public:
+    WtMetadataHarness(int numIdents, bool withEncryptionConfig) {
+        std::string config = "create,log=(enabled=true,file_max=1m,prealloc=false)";
+        int ret = wiredtiger_open(_tempDir.path().c_str(), nullptr, config.c_str(), &_conn);
+        invariant(wtRCToStatus(ret, nullptr));
+
+        _connection =
+            std::make_unique<WiredTigerConnection>(_conn, &_clockSource, /*sessionCacheMax=*/33000);
+        _ru = std::make_unique<WiredTigerRecoveryUnit>(_connection.get(), nullptr);
+        _session = _ru->getSession();
+
+        // 100 distinct keyids, each used by many idents — this mirrors the
+        // typical production shape (few databases, thousands of idents).
+        constexpr int kNumKeys = 100;
+        for (int i = 0; i < numIdents; ++i) {
+            char uri[64];
+            std::snprintf(uri, sizeof(uri), "table:collection-%06d", i);
+
+            std::ostringstream createConfig;
+            createConfig << "key_format=q,value_format=u";
+            if (withEncryptionConfig) {
+                createConfig << ",encryption=(name=none,keyid=\"db_" << (i % kNumKeys) << "\")";
+            }
+
+            auto s = createConfig.str();
+            invariant(wtRCToStatus(_session->create(uri, s.c_str()), *_session));
+        }
+        _ru->abandonSnapshot();
+    }
+
+    ~WtMetadataHarness() override {
+        _ru.reset();
+        _connection.reset();
+        _conn->close(_conn, nullptr);
+    }
+
+    WiredTigerSession& session() {
+        return *_session;
+    }
+
+private:
+    unittest::TempDir _tempDir{"wt_encryption_key_cleanup_bm"};
+    ClockSourceMock _clockSource;
+    WT_CONNECTION* _conn = nullptr;
+    std::unique_ptr<WiredTigerConnection> _connection;
+    std::unique_ptr<WiredTigerRecoveryUnit> _ru;
+    WiredTigerSession* _session = nullptr;
+};
+
+// Mirrors the body of WiredTigerKVEngineBase::_wtGetAllIdents at
+// src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp:1068 so the
+// benchmark exercises the same cursor-scan cost as production.
+std::vector<std::string> wtGetAllIdents(WiredTigerSession& session) {
+    std::vector<std::string> all;
+    WT_CURSOR* c = nullptr;
+    auto ret = session.open_cursor("metadata:", nullptr, nullptr, &c);
+    uassertStatusOK(wtRCToStatus(ret, session));
+    if (!c) {
+        return all;
+    }
+    while ((ret = c->next(c)) == 0) {
+        const char* raw;
+        c->get_key(c, &raw);
+        StringData key(raw);
+        size_t idx = key.find(':');
+        if (idx == std::string::npos) {
+            continue;
+        }
+        if (key.substr(0, idx) != "table") {
+            continue;
+        }
+        all.emplace_back(std::string{key.substr(idx + 1)});
+    }
+    c->close(c);
+    return all;
+}
+
+// Mirrors the cursor-scan + per-ident metadata fetch + keyid extraction
+// portion of WiredTigerKVEngine::findOrphanedEncryptionKeyIds. The keydb
+// listing and the final set_difference are excluded; this is the cost that
+// scales with ident count.
+std::vector<std::string> scanIdentsForKeyIdsInUse(WiredTigerSession& session) {
+    std::vector<std::string> keyIdsInUse;
+    auto idents = wtGetAllIdents(session);
+    for (const auto& ident : idents) {
+        auto metadata =
+            WiredTigerUtil::getMetadataCreate(session, WiredTigerUtil::buildTableUri(ident));
+        if (!metadata.isOK()) {
+            continue;
+        }
+        auto keyId = WiredTigerUtil::getEncryptionKeyId(metadata.getValue());
+        if (keyId && !EncryptionKeyDB::isSpecialKeyId(*keyId)) {
+            keyIdsInUse.emplace_back(std::move(*keyId));
+        }
+    }
+    std::sort(keyIdsInUse.begin(), keyIdsInUse.end());
+    keyIdsInUse.erase(std::unique(keyIdsInUse.begin(), keyIdsInUse.end()), keyIdsInUse.end());
+    return keyIdsInUse;
+}
+
+// WT-scan portion of findOrphanedEncryptionKeyIds: cursor scan + per-ident
+// getMetadataCreate + getEncryptionKeyId extraction + sort/dedup. Excludes
+// the keydb listing and final set_difference, which are O(K).
+void BM_ScanIdentsForKeyIdsInUse(benchmark::State& state) {
+    WtMetadataHarness harness(static_cast<int>(state.range(0)),
+                              /*withEncryptionConfig=*/true);
+    for (auto _ : state) {
+        auto keyIds = scanIdentsForKeyIdsInUse(harness.session());
+        benchmark::DoNotOptimize(keyIds);
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
+}
+
+BENCHMARK(BM_ScanIdentsForKeyIdsInUse)->RangeMultiplier(10)->Range(100, 10'000);
+
+// Only the cursor scan, with no per-ident metadata fetch or keyid parsing.
+// Isolates the WT metadata iteration cost from the per-ident work.
+void BM_WtGetAllIdents(benchmark::State& state) {
+    WtMetadataHarness harness(static_cast<int>(state.range(0)),
+                              /*withEncryptionConfig=*/false);
+    for (auto _ : state) {
+        auto idents = wtGetAllIdents(harness.session());
+        benchmark::DoNotOptimize(idents);
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
+}
+
+BENCHMARK(BM_WtGetAllIdents)->RangeMultiplier(10)->Range(100, 10'000);
+
+// Only the per-ident metadata:create point lookup, iterating over a
+// pre-built ident list. Isolates the getMetadataCreate cost from the
+// initial cursor scan and from keyid parsing.
+void BM_GetMetadataCreate(benchmark::State& state) {
+    WtMetadataHarness harness(static_cast<int>(state.range(0)),
+                              /*withEncryptionConfig=*/true);
+    auto idents = wtGetAllIdents(harness.session());
+    for (auto _ : state) {
+        for (const auto& ident : idents) {
+            auto metadata = WiredTigerUtil::getMetadataCreate(harness.session(),
+                                                              WiredTigerUtil::buildTableUri(ident));
+            benchmark::DoNotOptimize(metadata);
+        }
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
+}
+
+BENCHMARK(BM_GetMetadataCreate)->RangeMultiplier(10)->Range(100, 10'000);
+
+// Only getEncryptionKeyId parsing overhead, on a synthetic config string that
+// mirrors the shape WT stores for an encrypted ident. Isolates the string-
+// parser cost from the WT I/O cost.
+void BM_GetEncryptionKeyIdParse(benchmark::State& state) {
+    std::string config =
+        "key_format=q,value_format=u,encryption=(name=percona,keyid=\"db_000042\")";
+    for (auto _ : state) {
+        auto keyId = WiredTigerUtil::getEncryptionKeyId(config);
+        benchmark::DoNotOptimize(keyId);
+    }
+}
+
+BENCHMARK(BM_GetEncryptionKeyIdParse);
+
+}  // namespace
+}  // namespace mongo

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_global_options.idl
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_global_options.idl
@@ -299,6 +299,21 @@ server_parameters:
         default: false
         redact: false
 
+    encryptionKeyCleanupIntervalSeconds:
+        description: >-
+            The interval in seconds between periodic orphaned encryption key cleanup
+            attempts. Set to 0 to disable periodic cleanup. Non-zero enables periodic
+            cleanup with that interval. Startup cleanup always runs regardless of
+            this setting.
+        set_at: [startup, runtime]
+        cpp_vartype: "AtomicWord<std::int32_t>"
+        cpp_varname: gEncryptionKeyCleanupIntervalSeconds
+        default: 0
+        validator:
+            gte: 0
+            lte: 86400
+        redact: false
+
     spillWiredTigerEngineRuntimeConfig:
         description: "Spill WiredTiger Configuration"
         set_at: runtime

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp
@@ -154,7 +154,8 @@ std::string WiredTigerIndex::generateAppMetadataString(const IndexConfig& config
 }
 
 // static
-StatusWith<std::string> WiredTigerIndex::generateCreateString(const std::string& engineName,
+StatusWith<std::string> WiredTigerIndex::generateCreateString(OperationContext* opCtx,
+                                                              const std::string& engineName,
                                                               const std::string& sysIndexConfig,
                                                               const std::string& collIndexConfig,
                                                               StringData tableName,
@@ -171,9 +172,9 @@ StatusWith<std::string> WiredTigerIndex::generateCreateString(const std::string&
     }
 
     ss << WiredTigerCustomizationHooks::get(getGlobalServiceContext())
-              ->getTableCreateConfig(tableName);
+              ->getTableCreateConfig(opCtx, tableName);
     ss << WiredTigerCustomizationHooksRegistry::get(getGlobalServiceContext())
-              .getTableCreateConfig(tableName);
+              .getTableCreateConfig(opCtx, tableName);
     ss << sysIndexConfig << ",";
     ss << collIndexConfig << ",";
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_index.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_index.h
@@ -91,7 +91,8 @@ public:
      * Note that even if this function returns an OK status, WT_SESSION:create() may still
      * fail with the constructed configuration string.
      */
-    static StatusWith<std::string> generateCreateString(const std::string& engineName,
+    static StatusWith<std::string> generateCreateString(OperationContext* opCtx,
+                                                        const std::string& engineName,
                                                         const std::string& sysIndexConfig,
                                                         const std::string& collIndexConfig,
                                                         StringData tableName,

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_index_test_harness.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_index_test_harness.cpp
@@ -97,7 +97,8 @@ public:
                            ordering};
 
         StatusWith<std::string> result =
-            WiredTigerIndex::generateCreateString(std::string{kWiredTigerEngineName},
+            WiredTigerIndex::generateCreateString(opCtx,
+                                                  std::string{kWiredTigerEngineName},
                                                   "",
                                                   "",
                                                   NamespaceStringUtil::serializeForCatalog(nss),
@@ -140,7 +141,8 @@ public:
                            indexName,
                            ordering};
         StatusWith<std::string> result =
-            WiredTigerIndex::generateCreateString(std::string{kWiredTigerEngineName},
+            WiredTigerIndex::generateCreateString(opCtx,
+                                                  std::string{kWiredTigerEngineName},
                                                   "",
                                                   "",
                                                   NamespaceStringUtil::serializeForCatalog(nss),

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -3642,15 +3642,88 @@ void WiredTigerKVEngine::dropIdentForImport(Interruptible& interruptible,
 }
 
 void WiredTigerKVEngine::keydbDropDatabase(const DatabaseName& dbName) {
-    if (_restEncr) {
-        int res = _restEncr->keyDb()->delete_key_by_id(
-            DatabaseNameUtil::serialize(dbName, SerializationContext::stateDefault()));
-        if (res) {
-            // we cannot throw exceptions here because we are inside WUOW::commit
-            // every other part of DB is already dropped so we just log error message
-            LOGV2_ERROR(29001, "failed to delete encryption key for db", logAttrs(dbName));
+    if (!_restEncr) {
+        return;
+    }
+
+    // Delete the encryption key for this database.
+    // This method is called by the deferred cleanup process after verifying:
+    // 1. The database no longer exists in the catalog
+    // 2. No storage idents (including drop-pending ones) use the key
+    int res = _restEncr->keyDb()->delete_key_by_id(
+        DatabaseNameUtil::serialize(dbName, SerializationContext::stateDefault()));
+    if (res) {
+        LOGV2_ERROR(29001, "Failed to delete encryption key for database", logAttrs(dbName));
+    } else {
+        LOGV2_DEBUG(29158, 1, "Deleted encryption key for database", logAttrs(dbName));
+    }
+}
+
+std::vector<std::string> WiredTigerKVEngine::findOrphanedEncryptionKeyIds() {
+    if (!_restEncr) {
+        return {};
+    }
+
+    auto keyIds = _restEncr->keyDb()->getAllKeyIds();
+    if (keyIds.empty()) {
+        return {};
+    }
+    std::sort(keyIds.begin(), keyIds.end());
+
+    auto session = _connection->getUninterruptibleSession();
+    auto idents = _wtGetAllIdents(*session);
+
+    LOGV2_DEBUG(
+        29163, 2, "Scanning idents for encryption keys in use", "identCount"_attr = idents.size());
+
+    std::vector<std::string> keyIdsInUse;
+    for (const auto& ident : idents) {
+        // getMetadataCreate returns the original creation config, which carries
+        // the encryption=(...) clause; the metadata: cursor value does not.
+        auto metadata =
+            WiredTigerUtil::getMetadataCreate(*session, WiredTigerUtil::buildTableUri(ident));
+        if (!metadata.isOK()) {
+            LOGV2_DEBUG(29164,
+                        3,
+                        "Failed to get metadata for ident",
+                        "ident"_attr = ident,
+                        "error"_attr = metadata.getStatus());
+            continue;
+        }
+
+        auto keyId = WiredTigerUtil::getEncryptionKeyId(metadata.getValue());
+        if (keyId && !EncryptionKeyDB::isSpecialKeyId(*keyId)) {
+            keyIdsInUse.emplace_back(std::move(*keyId));
+            LOGV2_DEBUG(29166,
+                        3,
+                        "Found ident using encryption key",
+                        "ident"_attr = ident,
+                        "keyId"_attr = keyIdsInUse.back());
         }
     }
+
+    std::sort(keyIdsInUse.begin(), keyIdsInUse.end());
+    keyIdsInUse.erase(std::unique(keyIdsInUse.begin(), keyIdsInUse.end()), keyIdsInUse.end());
+
+    std::vector<std::string> orphaned;
+    std::set_difference(keyIds.begin(),
+                        keyIds.end(),
+                        keyIdsInUse.begin(),
+                        keyIdsInUse.end(),
+                        std::back_inserter(orphaned));
+
+    LOGV2_DEBUG(29165,
+                2,
+                "Encryption key cleanup scan",
+                "keysInKeyDb"_attr = keyIds.size(),
+                "keysInUseByIdents"_attr = keyIdsInUse.size(),
+                "orphaned"_attr = orphaned.size());
+
+    return orphaned;
+}
+
+int32_t WiredTigerKVEngine::getEncryptionKeyCleanupIntervalSeconds() const {
+    return gEncryptionKeyCleanupIntervalSeconds.load();
 }
 
 void WiredTigerKVEngine::_checkpoint(WiredTigerSession& session, bool useTimestamp) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -919,8 +919,11 @@ std::string generateWTOpenConfigString(const WiredTigerKVEngineBase::WiredTigerC
            << ",read_size=" << wtConfig.liveRestoreReadSizeMB << "MB" << "),";
     }
 
+    // Startup-time call: no `OperationContext` exists yet. The "system" tableName
+    // resolves to the `/default` keyid in the encryption hook, which does not
+    // require a catalog lookup, so passing nullptr is safe here.
     ss << WiredTigerCustomizationHooks::get(getGlobalServiceContext())
-              ->getTableCreateConfig("system");
+              ->getTableCreateConfig(nullptr, "system");
     ss << std::string{extensionsConfig};
     ss << wtConfig.extraOpenOptions;
 
@@ -3150,8 +3153,15 @@ Status WiredTigerKVEngine::_createRecordStore(const rss::PersistenceProvider& pr
         wtTableConfig.memoryPageMax = provider.getWTMemoryPageMaxForOplogStrValue();
     }
 
+    // Resolve the active operation context from the recovery unit's client. The
+    // KVEngine interface does not currently take an OpCtx in its createRecordStore
+    // path, but in normal user-table flow the calling thread always has one
+    // (either the user's command OpCtx or the OpCtx that is driving the storage
+    // operation). The encryption hook needs it to look up the per-database key id.
+    OperationContext* opCtxForHook =
+        Client::getCurrent() ? Client::getCurrent()->getOperationContext() : nullptr;
     std::string config = WiredTigerRecordStore::generateCreateString(
-        NamespaceStringUtil::serializeForCatalog(nss), wtTableConfig, nss.isOplog());
+        opCtxForHook, NamespaceStringUtil::serializeForCatalog(nss), wtTableConfig, nss.isOplog());
     string uri = WiredTigerUtil::buildTableUri(ident);
     LOGV2_DEBUG(22331,
                 2,
@@ -3358,7 +3368,10 @@ Status WiredTigerKVEngine::createSortedDataInterface(
                                .str();
     }
 
+    OperationContext* opCtxForHook =
+        Client::getCurrent() ? Client::getCurrent()->getOperationContext() : nullptr;
     StatusWith<std::string> result = WiredTigerIndex::generateCreateString(
+        opCtxForHook,
         _canonicalName,
         _indexOptions,
         collIndexOptions,
@@ -3493,8 +3506,8 @@ std::unique_ptr<RecordStore> WiredTigerKVEngine::makeInternalRecordStore(Recover
     wtTableConfig.logEnabled = false;
     wtTableConfig.extraCreateOptions = _rsOptions;
 
-    std::string config =
-        WiredTigerRecordStore::generateCreateString({} /* internal table */, wtTableConfig);
+    std::string config = WiredTigerRecordStore::generateCreateString(
+        nullptr, {} /* internal table */, wtTableConfig);
 
     std::string uri = WiredTigerUtil::buildTableUri(ident);
     LOGV2_DEBUG(22337,
@@ -3646,16 +3659,29 @@ void WiredTigerKVEngine::keydbDropDatabase(const DatabaseName& dbName) {
         return;
     }
 
-    // Delete the encryption key for this database.
-    // This method is called by the deferred cleanup process after verifying:
-    // 1. The database no longer exists in the catalog
-    // 2. No storage idents (including drop-pending ones) use the key
-    int res = _restEncr->keyDb()->delete_key_by_id(
-        DatabaseNameUtil::serialize(dbName, SerializationContext::stateDefault()));
+    // The actual key row in `table:key` is left intact - drop-pending idents
+    // encrypted with the old key may still exist and would be unreadable
+    // during checkpoint cleanup if we removed the key now. The orphan cleanup
+    // pass (cleanupOrphanedEncryptionKeys) reaps the row later, once no idents
+    // (live or drop-pending) reference it.
+    //
+    // What we do here is invalidate the in-memory cache so that the next
+    // ident creation in this `dbName` cold-misses, scans the (now-empty)
+    // catalog, and allocates a fresh `<dbName>.<UUID>` key id. That is the
+    // mechanism that makes `dropDatabase` + recreate produce a new generation.
+    LOGV2_DEBUG(29202, 1, "Clearing cached active key id for dropped database", logAttrs(dbName));
+    _restEncr->keyDb()->clearCachedActiveKeyId(dbName);
+}
+
+void WiredTigerKVEngine::deleteOrphanedEncryptionKey(StringData keyId) {
+    if (!_restEncr) {
+        return;
+    }
+    int res = _restEncr->keyDb()->delete_key_by_id(std::string{keyId});
     if (res) {
-        LOGV2_ERROR(29001, "Failed to delete encryption key for database", logAttrs(dbName));
+        LOGV2_ERROR(29203, "Failed to delete orphaned encryption key", "keyId"_attr = keyId);
     } else {
-        LOGV2_DEBUG(29158, 1, "Deleted encryption key for database", logAttrs(dbName));
+        LOGV2_DEBUG(29204, 1, "Deleted orphaned encryption key", "keyId"_attr = keyId);
     }
 }
 
@@ -3701,6 +3727,18 @@ std::vector<std::string> WiredTigerKVEngine::findOrphanedEncryptionKeyIds() {
                         "keyId"_attr = keyIdsInUse.back());
         }
     }
+
+    // Merge in any key ids that are currently cached as the active id for
+    // some database but have not yet been bound to an ident on disk. Without
+    // this we would race: a freshly allocated `<dbName>.<UUID>` is cached
+    // *before* the ident-create commits, so a cleanup pass that fires in the
+    // same window would see the key in `table:key` (write happens in the
+    // first ident's create_table call) but not in the ident scan, and reap
+    // it. The cache snapshot is the canonical "in-flight" set.
+    auto cachedActiveKeyIds = _restEncr->keyDb()->getAllCachedActiveKeyIds();
+    keyIdsInUse.insert(keyIdsInUse.end(),
+                       std::make_move_iterator(cachedActiveKeyIds.begin()),
+                       std::make_move_iterator(cachedActiveKeyIds.end()));
 
     std::sort(keyIdsInUse.begin(), keyIdsInUse.end());
     keyIdsInUse.erase(std::unique(keyIdsInUse.begin(), keyIdsInUse.end()), keyIdsInUse.end());

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -560,6 +560,10 @@ public:
 
     void keydbDropDatabase(const DatabaseName& dbName) override;
 
+    std::vector<std::string> findOrphanedEncryptionKeyIds() override;
+
+    int32_t getEncryptionKeyCleanupIntervalSeconds() const override;
+
     void flushAllFiles(OperationContext* opCtx, bool callerHoldsReadLock) override;
 
     Status beginBackup() override;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -560,6 +560,8 @@ public:
 
     void keydbDropDatabase(const DatabaseName& dbName) override;
 
+    void deleteOrphanedEncryptionKey(StringData keyId) override;
+
     std::vector<std::string> findOrphanedEncryptionKeyIds() override;
 
     int32_t getEncryptionKeyCleanupIntervalSeconds() const override;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_encryption_key_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_encryption_key_test.cpp
@@ -59,8 +59,10 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <sys/stat.h>  // for `::chmod`
 
@@ -1658,6 +1660,167 @@ TEST_F(WiredTigerKVEngineEncryptionKeyKmipPollStateTest,
 #undef ASSERT_CREATE_ENGINE_THROWS_REASON_REGEX
 #undef ASSERT_CREATE_ENGINE_THROWS_REASON_CONTAINS
 #undef ASSERT_CREATE_ENGINE_THROWS_WHAT
+
+// =============================================================================
+// Tests for EncryptionKeyDB::getAllKeyIds() and WiredTigerKVEngine key management
+// =============================================================================
+
+/**
+ * Test fixture for encryption key management operations.
+ * Extends WiredTigerKVEngineEncryptionKeyFileTest to get a fully configured
+ * encrypted engine.
+ */
+class WiredTigerKVEngineEncryptionKeyManagementTest
+    : public WiredTigerKVEngineEncryptionKeyFileTest {
+protected:
+    void _setUpPreconfiguredEngine() override {
+        // Set up encryption params and create the engine, but don't reset it
+        // We want to keep the engine running for our tests
+        _setUpEncryptionParams();
+        _engine = _createWiredTigerKVEngine();
+        WtKeyIds::instance().configured = std::move(WtKeyIds::instance().futureConfigured);
+    }
+
+    // Helper to trigger key creation by calling get_key_by_id
+    // This simulates what happens when an encrypted ident is created.
+    // get_key_by_id requires a non-null PERCONA_ENCRYPTOR pointer (it is stored
+    // in EncryptionKeyDB::_encryptors). Tests using this helper must not call
+    // delete_key_by_id on the resulting keys, since the fake pointer would be
+    // passed to percona_encryption_extension_drop_keyid.
+    void triggerKeyCreation(const std::string& keyId) {
+        auto keyDb = _engine->getEncryptionKeyDB();
+        ASSERT(keyDb);
+        unsigned char keyBuf[32];  // 256-bit key
+        static int fakeEncryptor;
+        int res = keyDb->get_key_by_id(keyId.c_str(), keyId.length(), keyBuf, &fakeEncryptor);
+        ASSERT_EQ(0, res) << "Failed to create/get key with id: " << keyId;
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Tests for EncryptionKeyDB::getAllKeyIds()
+// -----------------------------------------------------------------------------
+
+TEST_F(WiredTigerKVEngineEncryptionKeyManagementTest, GetAllKeyIdsInitiallyEmpty) {
+    // A fresh encrypted engine should have no user database keys
+    // (only the master key which is excluded)
+    auto keyDb = _engine->getEncryptionKeyDB();
+    ASSERT(keyDb);
+
+    auto keyIds = keyDb->getAllKeyIds();
+    ASSERT_TRUE(keyIds.empty());
+}
+
+TEST_F(WiredTigerKVEngineEncryptionKeyManagementTest, GetAllKeyIdsSingleKey) {
+    triggerKeyCreation("testdb1");
+
+    auto keyDb = _engine->getEncryptionKeyDB();
+    auto keyIds = keyDb->getAllKeyIds();
+
+    ASSERT_EQ(keyIds.size(), 1u);
+    ASSERT_EQ(keyIds[0], "testdb1");
+}
+
+TEST_F(WiredTigerKVEngineEncryptionKeyManagementTest, GetAllKeyIdsMultipleKeys) {
+    triggerKeyCreation("db_alpha");
+    triggerKeyCreation("db_beta");
+    triggerKeyCreation("db_gamma");
+
+    auto keyDb = _engine->getEncryptionKeyDB();
+    auto keyIds = keyDb->getAllKeyIds();
+
+    ASSERT_EQ(keyIds.size(), 3u);
+
+    // Convert to set for easier checking (order not guaranteed)
+    std::set<std::string> keyIdSet(keyIds.begin(), keyIds.end());
+    ASSERT_TRUE(keyIdSet.count("db_alpha") > 0);
+    ASSERT_TRUE(keyIdSet.count("db_beta") > 0);
+    ASSERT_TRUE(keyIdSet.count("db_gamma") > 0);
+}
+
+TEST_F(WiredTigerKVEngineEncryptionKeyManagementTest, GetAllKeyIdsExcludesDefaultKey) {
+    // Create a key with "/default" keyid - this should be excluded from results
+    triggerKeyCreation("/default");
+    triggerKeyCreation("regular_db");
+
+    auto keyDb = _engine->getEncryptionKeyDB();
+    auto keyIds = keyDb->getAllKeyIds();
+
+    // Should only contain the regular_db key, not /default
+    ASSERT_EQ(keyIds.size(), 1u);
+    ASSERT_EQ(keyIds[0], "regular_db");
+}
+
+// -----------------------------------------------------------------------------
+// Tests for WiredTigerKVEngine::findOrphanedEncryptionKeyIds()
+// -----------------------------------------------------------------------------
+
+TEST_F(WiredTigerKVEngineEncryptionKeyManagementTest, FindOrphanedEncryptionKeyIdsEmpty) {
+    // No keys in keydb at all → nothing to consider orphaned.
+    auto orphaned = _engine->findOrphanedEncryptionKeyIds();
+    ASSERT_TRUE(orphaned.empty());
+}
+
+TEST_F(WiredTigerKVEngineEncryptionKeyManagementTest,
+       FindOrphanedEncryptionKeyIdsAllOrphanedWhenNoIdents) {
+    // Keys exist in keydb but no encrypted idents reference them — all are orphaned.
+    triggerKeyCreation("engine_test_db1");
+    triggerKeyCreation("engine_test_db2");
+
+    auto orphaned = _engine->findOrphanedEncryptionKeyIds();
+
+    ASSERT_EQ(orphaned.size(), 2u);
+    std::set<std::string> orphanedSet(orphaned.begin(), orphaned.end());
+    ASSERT_TRUE(orphanedSet.count("engine_test_db1") > 0);
+    ASSERT_TRUE(orphanedSet.count("engine_test_db2") > 0);
+}
+
+// -----------------------------------------------------------------------------
+// Test for engine without encryption
+// -----------------------------------------------------------------------------
+
+class WiredTigerKVEngineNoEncryptionKeyManagementTest : public WiredTigerKVEngineEncryptionKeyTest {
+protected:
+    void _setUpPreconfiguredEngine() override {
+        // Don't set up encryption - create engine without encryption
+    }
+
+    void _setUpEncryptionParams() override {
+        // Don't enable encryption
+        encryptionGlobalParams = EncryptionGlobalParams();
+        encryptionGlobalParams.enableEncryption = false;
+    }
+
+    std::unique_ptr<WiredTigerKVEngine> _createNonEncryptedEngine() {
+        WiredTigerKVEngine::WiredTigerConfig wtConfig;
+        wtConfig.extraOpenOptions = "log=(file_max=1m,prealloc=false)";
+        wtConfig.cacheSizeMB = 1;
+
+        auto& provider =
+            rss::ReplicatedStorageService::get(getServiceContext()).getPersistenceProvider();
+        auto engine = std::make_unique<WiredTigerKVEngine>(
+            "wiredTiger",
+            _tempDir->path(),
+            _clockSource.get(),
+            std::move(wtConfig),
+            WiredTigerExtensions::get(getServiceContext()),
+            provider,
+            false,
+            getGlobalReplSettings().isReplSet(),
+            repl::ReplSettings::shouldRecoverFromOplogAsStandalone(),
+            getReplSetMemberInStandaloneMode(getGlobalServiceContext()),
+            _runner.get());
+        engine->notifyStorageStartupRecoveryComplete();
+        return engine;
+    }
+};
+
+TEST_F(WiredTigerKVEngineNoEncryptionKeyManagementTest, FindOrphanedEncryptionKeyIdsNoEncryption) {
+    _engine = _createNonEncryptedEngine();
+
+    auto orphaned = _engine->findOrphanedEncryptionKeyIds();
+    ASSERT_TRUE(orphaned.empty());
+}
 
 }  // namespace
 }  // namespace mongo

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
@@ -214,6 +214,7 @@ StatusWith<std::string> WiredTigerRecordStore::parseOptionsField(const BSONObj o
 }
 
 std::string WiredTigerRecordStore::generateCreateString(
+    OperationContext* opCtx,
     StringData tableName,
     const WiredTigerRecordStore::WiredTigerTableConfig& wtTableConfig,
     bool isOplog) {
@@ -233,9 +234,9 @@ std::string WiredTigerRecordStore::generateCreateString(
     ss << "block_compressor=" << wtTableConfig.blockCompressor << ",";
 
     ss << WiredTigerCustomizationHooks::get(getGlobalServiceContext())
-              ->getTableCreateConfig(tableName);
+              ->getTableCreateConfig(opCtx, tableName);
     ss << WiredTigerCustomizationHooksRegistry::get(getGlobalServiceContext())
-              .getTableCreateConfig(tableName);
+              .getTableCreateConfig(opCtx, tableName);
 
     ss << wtTableConfig.extraCreateOptions << ",";
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
@@ -152,8 +152,12 @@ public:
      * It is possible for 'tableName' to be an empty string, in the case of internal-only temporary
      * tables. Configuration string is constructed from the parameters of 'wtTableConfig', with
      * extra settings when 'isOplog' is true.
+     *
+     * `opCtx` may be nullptr for internal-only temporary tables; user-table callers should pass
+     * their `OperationContext` so that the encryption hook can resolve the per-database key id.
      */
     static std::string generateCreateString(
+        OperationContext* opCtx,
         StringData tableName,
         const WiredTigerRecordStore::WiredTigerTableConfig& wtTableConfig,
         bool isOplog = false);

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store_test.cpp
@@ -710,7 +710,7 @@ TEST(WiredTigerRecordStoreTest, CreateOnExistingIdentFails) {
     wtTableConfig.logEnabled = WiredTigerUtil::useTableLogging(
         provider, nss, isReplSet, shouldRecoverFromOplogAsStandalone);
     const std::string config = WiredTigerRecordStore::generateCreateString(
-        NamespaceStringUtil::serializeForCatalog(nss), wtTableConfig);
+        opCtx.get(), NamespaceStringUtil::serializeForCatalog(nss), wtTableConfig);
     {
         WriteUnitOfWork uow(opCtx.get());
         WiredTigerRecoveryUnit* ru =
@@ -753,7 +753,7 @@ TEST(WiredTigerRecordStoreTest, ClusteredRecordStore) {
     wtTableConfig.logEnabled = WiredTigerUtil::useTableLogging(
         provider, nss, isReplSet, shouldRecoverFromOplogAsStandalone);
     const std::string config = WiredTigerRecordStore::generateCreateString(
-        NamespaceStringUtil::serializeForCatalog(nss), wtTableConfig);
+        opCtx.get(), NamespaceStringUtil::serializeForCatalog(nss), wtTableConfig);
     {
         StorageWriteTransaction txn(ru);
         WiredTigerRecoveryUnit* ru =
@@ -963,8 +963,8 @@ TEST(WiredTigerRecordStoreTest, EnforceTableCreateExclusiveSameConfiguration) {
     const NamespaceString nss = NamespaceString::createNamespaceString_forTest("testRecordStore");
     WiredTigerRecordStore::WiredTigerTableConfig wtTableConfig;
     wtTableConfig.blockCompressor = wiredTigerGlobalOptions.collectionBlockCompressor;
-    const auto config =
-        WiredTigerRecordStore::generateCreateString(nss.toString_forTest(), wtTableConfig);
+    const auto config = WiredTigerRecordStore::generateCreateString(
+        opCtx.get(), nss.toString_forTest(), wtTableConfig);
     const std::string ident = "uniqueIdentifierForTableFile";
     const std::string uri = std::string(WiredTigerUtil::kTableUriPrefix) + ident;
 
@@ -989,8 +989,8 @@ TEST(WiredTigerRecordStoreTest, EnforceTableCreateExclusiveDifferentConfiguratio
     const NamespaceString nss = NamespaceString::createNamespaceString_forTest("testRecordStore");
     WiredTigerRecordStore::WiredTigerTableConfig wtTableConfig;
     wtTableConfig.blockCompressor = wiredTigerGlobalOptions.collectionBlockCompressor;
-    const std::string config =
-        WiredTigerRecordStore::generateCreateString(nss.toString_forTest(), wtTableConfig);
+    const std::string config = WiredTigerRecordStore::generateCreateString(
+        opCtx.get(), nss.toString_forTest(), wtTableConfig);
     const std::string ident = "uniqueIdentifierForTableFile";
     const std::string uri = std::string(WiredTigerUtil::kTableUriPrefix) + ident;
 
@@ -1003,8 +1003,8 @@ TEST(WiredTigerRecordStoreTest, EnforceTableCreateExclusiveDifferentConfiguratio
     // Generate a different table configuration than the original.
     WiredTigerRecordStore::WiredTigerTableConfig newWtTableConfig = wtTableConfig;
     newWtTableConfig.keyFormat = KeyFormat::String;
-    const std::string newConfig =
-        WiredTigerRecordStore::generateCreateString(nss.toString_forTest(), newWtTableConfig);
+    const std::string newConfig = WiredTigerRecordStore::generateCreateString(
+        opCtx.get(), nss.toString_forTest(), newWtTableConfig);
     ASSERT_NE(newConfig, config);
 
     // The uri for the ident is occupied, fail to create a new table with the ident.

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_size_storer.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_size_storer.cpp
@@ -57,8 +57,11 @@ namespace mongo {
 WiredTigerSizeStorer::WiredTigerSizeStorer(WiredTigerConnection* conn,
                                            const std::string& storageUri)
     : _conn(conn), _storageUri(storageUri), _tableId(WiredTigerUtil::genTableId()) {
+    // The size storer URI ("table:sizeStorer") starts with "table:" and so
+    // resolves to the `/default` keyid in the encryption hook. No
+    // `OperationContext` is available at this construction site.
     std::string config = WiredTigerCustomizationHooks::get(getGlobalServiceContext())
-                             ->getTableCreateConfig(_storageUri);
+                             ->getTableCreateConfig(nullptr, _storageUri);
 
     WiredTigerSession session(_conn);
     invariantWTOK(session.create(_storageUri.c_str(), config.c_str()), session);

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_standard_record_store_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_standard_record_store_test.cpp
@@ -94,8 +94,9 @@ TEST(WiredTigerRecordStoreTest, UpdateLargeUnloggedRecordAndReadBack) {
         StorageWriteTransaction txn(ru);
         WiredTigerSession* s = ru.getSession();
         invariantWTOK(
-            s->create(uri.c_str(),
-                      WiredTigerRecordStore::generateCreateString(ns, wtTableConfig).c_str()),
+            s->create(
+                uri.c_str(),
+                WiredTigerRecordStore::generateCreateString(nullptr, ns, wtTableConfig).c_str()),
             *s);
         txn.commit();
     }

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
@@ -157,6 +157,40 @@ StatusWith<std::string> WiredTigerUtil::getMetadata(WiredTigerSession& session, 
     return _getMetadata(cursor, uri);
 }
 
+boost::optional<std::string> WiredTigerUtil::getEncryptionKeyId(StringData config) {
+    WiredTigerConfigParser parser(config);
+
+    // Get the "encryption" key which contains a nested struct
+    WT_CONFIG_ITEM encryptionValue;
+    if (parser.get("encryption", &encryptionValue) != 0) {
+        // No encryption key found
+        return boost::none;
+    }
+
+    // Encryption value must be a struct: encryption=(name=percona,keyid="...")
+    if (encryptionValue.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRUCT) {
+        return boost::none;
+    }
+
+    // Parse the nested encryption struct
+    WiredTigerConfigParser encryptionParser(encryptionValue);
+
+    // Get the "keyid" sub-key
+    WT_CONFIG_ITEM keyidValue;
+    if (encryptionParser.get("keyid", &keyidValue) != 0) {
+        // No keyid found in encryption config
+        return boost::none;
+    }
+
+    // keyid is typically a STRING type (quoted like keyid="...") but could also be ID type
+    if (keyidValue.type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRING ||
+        keyidValue.type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_ID) {
+        return std::string(keyidValue.str, keyidValue.len);
+    }
+
+    return boost::none;
+}
+
 StatusWith<std::string> WiredTigerUtil::getSourceMetadata(WiredTigerSession& session,
                                                           StringData uri) {
     if (uri.starts_with("file:")) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.h
@@ -214,6 +214,15 @@ public:
     static StatusWith<std::string> getMetadata(WiredTigerSession& session, StringData uri);
 
     /**
+     * Extracts the encryption keyid from a WiredTiger config string.
+     * The keyid is found within the encryption config: encryption=(name=percona,keyid="...")
+     *
+     * @param config The WiredTiger configuration string (from getMetadata or getMetadataCreate)
+     * @return The keyid if found, boost::none otherwise. Empty string indicates master key.
+     */
+    static boost::optional<std::string> getEncryptionKeyId(StringData config);
+
+    /**
      * Gets the source metadata string for collection or index at URI.
      *
      * This is the WiredTiger config string for a specific file. If given a table: URI, it will

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util_test.cpp
@@ -1293,5 +1293,99 @@ TEST(SimpleWiredTigerUtilTest, SpillCacheSize) {
         WiredTigerUtil::getSpillCacheSizeMB(1024 * 8, 5, 101, 100), DBException, 10698700);
 }
 
+// =============================================================================
+// Tests for WiredTigerUtil::getEncryptionKeyId()
+// =============================================================================
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, EmptyConfigReturnsNone) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("");
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, ConfigWithoutEncryptionReturnsNone) {
+    auto result = WiredTigerUtil::getEncryptionKeyId(
+        "access_pattern_hint=none,allocation_size=4KB,app_metadata=,block_allocation=best");
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, EncryptionWithoutKeyIdReturnsNone) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona)");
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, QuotedKeyIdExtracted) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"testdb\")");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "testdb");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, UnquotedKeyIdExtracted) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=testdb)");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "testdb");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, DefaultKeyExtracted) {
+    auto result =
+        WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"/default\")");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "/default");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, EmptyKeyIdExtracted) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"\")");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, ComplexConfigKeyIdExtracted) {
+    auto result = WiredTigerUtil::getEncryptionKeyId(
+        "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=12,infoObj={ "
+        "\"v\" : 2, \"key\" : { \"_id\" : 1 }, \"name\" : \"_id_\" }),"
+        "block_allocation=best,block_compressor=snappy,encryption=(name=percona,keyid=\"mydb\"),"
+        "format=btree,huffman_value=none");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "mydb");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, EncryptionNotStructReturnsNone) {
+    // If encryption= is followed by something other than '(', should return none
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=none,other=value");
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, KeyIdAtStartOfEncryptionStruct) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=(keyid=\"firstdb\",name=percona)");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "firstdb");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, DatabaseNameWithSpecialChars) {
+    auto result =
+        WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"my-test_db.123\")");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "my-test_db.123");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, SystemDatabaseKey) {
+    auto result = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"admin\")");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "admin");
+}
+
+TEST(WiredTigerUtilGetEncryptionKeyIdTest, RealWorldCollectionConfig) {
+    // A realistic config string from a collection
+    auto result = WiredTigerUtil::getEncryptionKeyId(
+        "access_pattern_hint=none,allocation_size=4KB,"
+        "app_metadata=(formatVersion=12,infoObj={ \"v\" : 2, \"key\" : { \"_id\" : 1 }, "
+        "\"name\" : \"_id_\" }),assert=(commit_timestamp=none,durable_timestamp=none,"
+        "read_timestamp=none,write_timestamp=off),block_allocation=best,"
+        "block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,"
+        "collator=,columns=,dictionary=0,encryption=(name=percona,keyid=\"production_db\"),"
+        "exclusive=false,extractor=,format=btree");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(*result, "production_db");
+}
+
 }  // namespace
 }  // namespace mongo


### PR DESCRIPTION
Fixes a race between encryption-key deletion and WiredTiger checkpointing during                                                                                                                                                                            
  `dropDatabase`: the old code deleted the per-database key row from `table:key`
  synchronously, but a checkpoint that still held references to the encrypted                                                                                                                                                                                 
  idents could then fail to decrypt them and crash the server.                                                                                                                                                                                                
  
  This PR splits key lifecycle into two phases:                                                                                                                                                                                                               
                  
  - **`dropDatabase` is now non-destructive for the key row.** `keydbDropDatabase`                                                                                                                                                                            
    only evicts the WT keyed-encryptor cache entry; the row in `table:key` is left
    as an orphan and reaped later by `cleanupOrphanedEncryptionKeys`, after the                                                                                                                                                                               
    checkpoint that referenced the encrypted idents has completed.                                                                                                                                                                                            
  - **Each `dropDatabase` + recreate of a dbName mints a fresh keyId** of the form
    `<dbName>.<UUID>`. Previously the keyId was just `<dbName>`, so a recreated                                                                                                                                                                               
    database would collide with the still-orphaned key in the WT cache. The
    `CollectionCatalog` is now the single source of truth for "which keyId is                                                                                                                                                                                 
    live for dbName X right now": on a user-table create, the encryption hook
    scans the catalog for any live collection in the dbName, reads its WT ident                                                                                                                                                                               
    metadata to extract the existing keyId, and caches it; if the catalog is                                                                                                                                                                                  
    empty for that dbName, a fresh `<dbName>.<UUID>` is generated.
                                                                                                                                                                                                                                                              
  Backward compatibility with the legacy bare-`<dbName>` format is preserved —
  existing data files keep working, and the orphan reaper handles both formats.                                                                                                                                                                               
                                                                                                                                                                                                                                                              
  The orphan cleanup runs three ways: a periodic background pass, on startup,
  and on demand via the new `cleanupOrphanedEncryptionKeys` admin command. 