### PR TITLE
Psmdb 2054 psmdb rbe support in build routines  v8.3

### DIFF
--- a/percona-packaging/debian/rules
+++ b/percona-packaging/debian/rules
@@ -11,11 +11,8 @@ export TOOLS_TAGS=ssl sasl
 export PORTABLE=1
 export USE_SSE=1
 export PATH := /usr/local/go/bin:$(PATH)
-export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 -B/opt/mongodbtoolchain/v4/bin"
 
 $(info GLIBC_TUNABLES is $(GLIBC_TUNABLES))
-CC = gcc-5
-CXX = g++-5
 #
 %:
 	dh $@

--- a/percona-packaging/debian/rules
+++ b/percona-packaging/debian/rules
@@ -34,7 +34,8 @@ override_dh_auto_clean:
 	find $(PSMSRC) -name '*.pyc' -delete
 
 percona-server-mongodb:
-	bazel build --config=psmdb_opt_release --define=MONGO_VERSION=$(PSMDB_VERSION) --define=GIT_COMMIT_HASH=$(PSMDB_GIT_HASH) install-dist-test
+	# PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
+	bazel build --config=psmdb_opt_release $(PSMDB_RBE_BAZEL_FLAGS) --define=MONGO_VERSION=$(PSMDB_VERSION) --define=GIT_COMMIT_HASH=$(PSMDB_GIT_HASH) install-dist-test
 
 compile-mongo-tools:
 	mkdir $(PSMSRC)/bin || true;

--- a/percona-packaging/debian/rules
+++ b/percona-packaging/debian/rules
@@ -31,7 +31,6 @@ override_dh_auto_clean:
 	find $(PSMSRC) -name '*.pyc' -delete
 
 percona-server-mongodb:
-	# PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
 	bazel build --config=psmdb_opt_release $(PSMDB_RBE_BAZEL_FLAGS) --define=MONGO_VERSION=$(PSMDB_VERSION) --define=GIT_COMMIT_HASH=$(PSMDB_GIT_HASH) install-dist-test
 
 compile-mongo-tools:

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -59,12 +59,6 @@ BuildRoot:      /var/tmp/%{name}-%{version}-%{release}
 
 BuildRequires: gcc, make, cmake, gcc-c++, openssl-devel, cyrus-sasl-devel
 BuildRequires: snappy-devel, zlib-devel, bzip2-devel, libpcap-devel, openldap-devel, xz-devel
-%if 0%{?rhel} == 7
-BuildRequires: /usr/bin/scons
-%endif
-#%if 0%{?rhel} >= 8
-#BuildRequires: /usr/bin/scons-3
-#%endif
 
 Requires: %{name}-mongos = %{version}-%{release}
 Requires: %{name}-server = %{version}-%{release}
@@ -155,8 +149,6 @@ export GOBINPATH="/usr/local/go/bin"
 
 # Build PSfMDB with Bazel
 pushd $RPM_BUILD_DIR/%{src_dir}
-poetry install --no-root --sync
-# PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
 bazel build --config=psmdb_opt_release ${PSMDB_RBE_BAZEL_FLAGS:-} --define=MONGO_VERSION=%{version}-@@RELEASE@@ --define=GIT_COMMIT_HASH=@@PSMDB_GIT_HASH@@ install-dist-test
 rm -fr resmoke.ini
 popd

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -187,7 +187,8 @@ poetry install --no-root --sync
 poetry env use /opt/mongodbtoolchain/v4/bin/python3
 poetry install --no-root --sync
 %endif
-bazel build --config=psmdb_opt_release --define=MONGO_VERSION=%{version}-@@RELEASE@@ --define=GIT_COMMIT_HASH=@@PSMDB_GIT_HASH@@ install-dist-test
+# PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
+bazel build --config=psmdb_opt_release ${PSMDB_RBE_BAZEL_FLAGS:-} --define=MONGO_VERSION=%{version}-@@RELEASE@@ --define=GIT_COMMIT_HASH=@@PSMDB_GIT_HASH@@ install-dist-test
 rm -fr resmoke.ini
 popd
 

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -138,21 +138,13 @@ bazel clean --expunge || true
 
 %build
 
-export CC=${CC:-gcc}
-export CXX=${CXX:-g++}
 export PSM_TARGETS="install-mongod install-mongos install-mongo install-perconadecrypt build/install/bin/mongobridge"
 export INSTALLDIR=$RPM_BUILD_DIR/install
-export INSTALLDIR_AWS=$RPM_BUILD_DIR/install_aws
-export AWS_LIBS="/usr/local"
 export TOOLS_TAGS="ssl sasl"
 export PORTABLE=1
 export USE_SSE=1
 export PATH=/usr/local/go/bin:$PATH
-%if  0%{?amzn} == 2023
 export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1"
-%else
-export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 -B/opt/mongodbtoolchain/v4/bin"
-%endif
 export GLIBC_TUNABLES=${GLIBC_TUNABLES}
 
 export PATH=/usr/local/go/bin:${PATH}
@@ -161,32 +153,9 @@ export GOPATH=$(pwd)/
 export PATH="/usr/local/go/bin:$PATH:$GOPATH"
 export GOBINPATH="/usr/local/go/bin"
 
-#aws-sdk-cpp
-pushd $RPM_BUILD_DIR/%{src_dir}/aws-sdk-cpp
-    pushd build
-%if  0%{?amzn} == 2023 || 0%{?rhel} >= 7
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3;transfer" -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX="${INSTALLDIR_AWS}" -DAUTORUN_UNIT_TESTS=OFF
-        cmake --build . --target install
-%else
-        cmake3 CC=${CC} CXX=${CXX} .. -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3;transfer" -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX="${INSTALLDIR_AWS}" -DAUTORUN_UNIT_TESTS=OFF
-        cmake3 --build . --target install
-%endif
-
-    popd
-popd
-mkdir -p ${INSTALLDIR}/include/
-mkdir -p ${INSTALLDIR}/lib/
-mv ${INSTALLDIR_AWS}/include/* ${INSTALLDIR}/include/
-mv ${INSTALLDIR_AWS}/lib*/* ${INSTALLDIR}/lib/
-
-# Build PSfMDB with SCons
+# Build PSfMDB with Bazel
 pushd $RPM_BUILD_DIR/%{src_dir}
-%if  0%{?amzn} == 2023
 poetry install --no-root --sync
-%else
-poetry env use /opt/mongodbtoolchain/v4/bin/python3
-poetry install --no-root --sync
-%endif
 # PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
 bazel build --config=psmdb_opt_release ${PSMDB_RBE_BAZEL_FLAGS:-} --define=MONGO_VERSION=%{version}-@@RELEASE@@ --define=GIT_COMMIT_HASH=@@PSMDB_GIT_HASH@@ install-dist-test
 rm -fr resmoke.ini

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -180,15 +180,7 @@ get_sources(){
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
     sed -i 's:build-id:build-id=sha1:' SConstruct
-
-        git clone https://github.com/aws/aws-sdk-cpp.git
-            cd aws-sdk-cpp
-                git reset --hard
-                git clean -xdf
-                git checkout 1.9.379
-                git submodule update --init --recursive
-                mkdir build
-    cd ../../
+    cd ..
     tar --owner=0 --group=0 --exclude=.* -czf ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}.tar.gz ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}
     echo "UPLOAD=UPLOAD/experimental/BUILDS/${PRODUCT}-8.3/${PRODUCT}-${PSM_VER}-${PSM_RELEASE}/${PSM_BRANCH}/${REVISION}/${BUILD_ID}" >> percona-server-mongodb-83.properties
     mkdir -p $WORKDIR/source_tarball
@@ -298,47 +290,6 @@ install_gcc_deb(){
     fi
 }
 
-set_compiler(){
-    if [ x"$RHEL" != x2023 ]; then
-        export CC=/opt/mongodbtoolchain/v4/bin/gcc
-        export CXX=/opt/mongodbtoolchain/v4/bin/g++
-    fi
-    return
-}
-
-fix_rules(){
-    sed -i 's|CC = gcc-5|CC = /opt/mongodbtoolchain/v4/bin/gcc|' debian/rules
-    sed -i 's|CXX = g++-5|CXX = /opt/mongodbtoolchain/v4/bin/g++|' debian/rules
-    return
-}
-
-aws_sdk_build(){
-    cd $WORKDIR
-        git clone https://github.com/aws/aws-sdk-cpp.git
-        cd aws-sdk-cpp
-            git reset --hard
-            git clean -xdf
-            git checkout 1.9.379
-            git submodule update --init --recursive
-            mkdir build
-            cd build
-            CMAKE_CMD="cmake"
-            set_compiler
-            CMAKE_CXX_FLAGS=""
-            if [ x"${DEBIAN}" = xjammy -o x"${DEBIAN}" = xbookworm -o x"${DEBIAN}" = xnoble ]; then
-                CMAKE_CXX_FLAGS=" -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations -Wno-error=uninitialized "
-                CMAKE_C_FLAGS=" -Wno-error=maybe-uninitialized -Wno-error=maybe-uninitialized -Wno-error=uninitialized "
-            fi
-            if [ -z "${CC}" -a -z "${CXX}" ]; then
-                ${CMAKE_CMD} .. -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3;transfer" -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DAUTORUN_UNIT_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/usr || exit $?
-            else
-                ${CMAKE_CMD} CC=${CC} CXX=${CXX} .. -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3;transfer" -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DAUTORUN_UNIT_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/usr || exit $?
-            fi
-            make -j${NCPU} || exit $?
-            make install
-    cd ${WORKDIR}
-}
-
 install_deps() {
     if [ $INSTALL = 0 ]
     then
@@ -363,11 +314,6 @@ install_deps() {
       fi
       yum -y install wget sudo
       yum -y install perl
-      # PSMDB-2054: skip toolchain install for RBE — Bazel pulls hermetic
-      # mongo_toolchain_v5 from CAS at action time; runner image doesn't need v4.
-      #if [ x"$RHEL" != x2023 ]; then
-      #    install_mongodbtoolchain
-      #fi
       if [ x"$ARCH" = "xx86_64" ]; then
         yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
         percona-release enable tools testing
@@ -386,8 +332,6 @@ install_deps() {
         yum-config-manager --enable centos-sclo-rh-testing
         yum -y install devtoolset-9
         yum -y install devtoolset-11-elfutils devtoolset-11-dwz
-
-        #PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
 
         pip install --upgrade pip
         pip install --user setuptools --upgrade
@@ -473,42 +417,10 @@ install_deps() {
       done
       apt-get -y install libext2fs-dev || apt-get -y install e2fslibs-dev
       install_golang
-
-      # PSMDB-2054: skip toolchain install for RBE — Bazel pulls hermetic
-      # mongo_toolchain_v5 from CAS at action time. The legacy get-pip.py
-      # bootstrap below also relied on a `python` symlink created by the
-      # toolchain installer and now silently fails (`command not found`)
-      # without it; pip + setuptools come from the python3-pip apt package.
-      #install_mongodbtoolchain
-      #PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
-      #update-alternatives --install /usr/bin/python python /opt/mongodbtoolchain/v4/bin/python3.10 1
-
-      #wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
-      #python get-pip.py
-      #easy_install pip
-      #pip install setuptools
     fi
-    # PSMDB-2054: aws-cpp-sdk now vendored in-tree starting from PSMDB 8.0;
-    # no need to build it from source here.
-    #aws_sdk_build
     #keep symbol table in the binary
     sed -i 's:$strip, "--remove-section=.comment":$strip, "--strip-debug", "--remove-section=.comment":g' /usr/bin/dh_strip
     return;
-}
-
-install_mongodbtoolchain(){
-    #curl -o toolchain_installer.sh https://jenkins.percona.com/downloads/mongodbtoolchain/installer.sh
-    curl -O https://downloads.percona.com/downloads/packaging/toolchain_installer.tar.gz
-    tar -zxvf toolchain_installer.tar.gz
-    if [ ! -z "${RHEL}" ]; then
-        OS_CODE_NAME=${RHEL}
-    else
-        OS_CODE_NAME=${DEBIAN}
-    fi
-    export USER=$(whoami)
-    #bash -x ./toolchain_installer.sh -k --download-url https://jenkins.percona.com/downloads/mongodbtoolchain/${OS_CODE_NAME}_mongodbtoolchain_${ARCH}.tar.gz || exit 1
-    bash -x ./installer.sh --keep-download --download-dir /tmp/ --download-url https://downloads.percona.com/downloads/packaging/${OS_CODE_NAME}_mongodbtoolchain_${ARCH}.tar.gz || exit 1
-    export PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
 }
 
 get_tar(){
@@ -691,12 +603,7 @@ build_rpm(){
         pip install --user -r etc/pip/evgtest-requirements.txt
         pip install --user -r etc/pip/compile-requirements.txt
         export PYTHONPATH="/usr/local/lib64/python3.11/site-packages:/usr/local/lib/python3.11/site-packages:$PYTHONPATH"
-#        export CC=/usr/bin/gcc
-#        export CXX=/usr/bin/g++
-    else
-         PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
     fi
-#        PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
 
     python3 buildscripts/install_bazel.py
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
@@ -713,16 +620,6 @@ build_rpm(){
     pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
     pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
 
-
-    if [ "x${RHEL}" != "x2023" ]; then
-        echo "CC and CXX should be modified once correct compiller would be installed on Centos"
-        export CC=/opt/mongodbtoolchain/v4/bin/gcc
-        export CXX=/opt/mongodbtoolchain/v4/bin/g++
-        #update toolchain pathes to know about installed poetry
-        toolchain_revision=$(tar -ztf /tmp/mongodbtoolchain.tar.gz | head -1 | sed 's/\/$//')
-        /opt/mongodbtoolchain/revisions/${toolchain_revision}/scripts/install.sh
-    fi
-    #
     cd $WORKDIR
 
     echo "RHEL=${RHEL}" >> percona-server-mongodb-83.properties
@@ -736,11 +633,7 @@ build_rpm(){
     export GOBINPATH="/usr/local/go/bin"
 
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-    if [ "x${RHEL}" == "x2023" ]; then
-        export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 "
-    else
-        export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 -B/opt/mongodbtoolchain/v4/bin"
-    fi
+    export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1"
     rpmbuild --define "_topdir ${WORKDIR}/rpmbuild" --define "dist .$OS_NAME" --rebuild rpmbuild/SRPMS/$SRC_RPM
 
     return_code=$?
@@ -793,7 +686,6 @@ build_source_deb(){
     mv ${TARFILE} ${PRODUCT}_${VERSION}.orig.tar.gz
     cd ${BUILDDIR}
 
-    export PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
     pip install --upgrade pip
 
     # PyYAML pkg installation fix, more info: https://github.com/yaml/pyyaml/issues/724
@@ -804,14 +696,7 @@ build_source_deb(){
     pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
     pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
 
-    #update toolchain pathes to know about installed poetry
-    toolchain_revision=$(tar -ztf /tmp/mongodbtoolchain.tar.gz | head -1 | sed 's/\/$//')
-    /opt/mongodbtoolchain/revisions/${toolchain_revision}/scripts/install.sh
-    poetry env use /opt/mongodbtoolchain/v4/bin/python3
     poetry install --no-root --sync
-
-    set_compiler
-    fix_rules
 
     dch -D unstable --force-distribution -v "${VERSION}-${RELEASE}" "Update to new Percona Server for MongoDB version ${VERSION}"
     dpkg-buildpackage -S
@@ -859,7 +744,6 @@ build_deb(){
     dpkg-source -x ${DSC}
     #
     cd ${PRODUCT}-${VERSION}
-    export PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
 
     pip install --upgrade pip
 
@@ -871,10 +755,6 @@ build_deb(){
     pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
     pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
 
-    #update toolchain pathes to know about installed poetry
-    toolchain_revision=$(tar -ztf /tmp/mongodbtoolchain.tar.gz | head -1 | sed 's/\/$//')
-    /opt/mongodbtoolchain/revisions/${toolchain_revision}/scripts/install.sh
-    poetry env use /opt/mongodbtoolchain/v4/bin/python3
     poetry install --no-root --sync
 
     #
@@ -889,8 +769,6 @@ build_deb(){
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
     cp -av percona-packaging/debian/rules debian/
-    set_compiler
-    fix_rules
 
     if [ x"${DEBIAN}" = "xbullseye" -o x"${DEBIAN}" = "xbookworm" -o x"${DEBIAN}" = "xjammy" -o x"${DEBIAN}" = "xnoble" ]; then
         sed -i 's:dh-systemd,::' debian/control
@@ -907,7 +785,7 @@ build_deb(){
     dch -m -D "${DEBIAN}" --force-distribution -v "${VERSION}-${RELEASE}.${DEBIAN}" 'Update distribution'
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-    export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 -B/opt/mongodbtoolchain/v4/bin"
+    export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1"
 
     cd debian/
         wget https://raw.githubusercontent.com/Percona-Lab/telemetry-agent/phase-0/call-home.sh
@@ -971,30 +849,13 @@ build_tarball(){
     if [ ${DEBUG} = 1 ]; then
     TARBALL_SUFFIX=".dbg"
     fi
-    if [ -f /etc/debian_version ]; then
-        set_compiler
-    fi
     #
     if [ -f /etc/redhat-release -o -f /etc/amazon-linux-release ]; then
-    #export OS_RELEASE="centos$(lsb_release -sr | awk -F'.' '{print $1}')"
-        if [ x"$RHEL" = x7 ]; then
-            if [ -f /opt/rh/devtoolset-9/enable ]; then
-              source /opt/rh/devtoolset-9/enable
-              source /opt/rh/devtoolset-11/enable
-            fi
-        elif [ x"$RHEL" = x8 ]; then
+        if [ x"$RHEL" = x8 ]; then
             if [ -f /opt/rh/gcc-toolset-9/enable ]; then
               source /opt/rh/gcc-toolset-9/enable
               source /opt/rh/gcc-toolset-11/enable
             fi
-        fi
-        if [ "x${RHEL}" != "x2023" ]; then
-            echo "CC and CXX should be modified once correct compiller would be installed on Centos"
-            export CC=/opt/mongodbtoolchain/v4/bin/gcc
-            export CXX=/opt/mongodbtoolchain/v4/bin/g++
-        else
-            export CC=/usr/bin/gcc
-            export CXX=/usr/bin/g++
         fi
     fi
     #
@@ -1024,12 +885,9 @@ build_tarball(){
     export USE_SSE=1
     #
 
-    # Finally build Percona Server for MongoDB with SCons
+    # Finally build Percona Server for MongoDB with Bazel
     cd ${PSMDIR_ABS}
-    if [ "x${RHEL}" != "x2023" ]; then
-        export PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
-        pip install --upgrade pip
-    fi
+    pip install --upgrade pip
     # PyYAML pkg installation fix, more info: https://github.com/yaml/pyyaml/issues/724
     pip install pyyaml==5.4.1 --no-build-isolation
     pip install 'referencing<0.30.0' --no-build-isolation
@@ -1038,67 +896,10 @@ build_tarball(){
     pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
     pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
 
-    #update toolchain pathes to know about installed poetry
-    if [ "x${RHEL}" != "x2023" ]; then
-    toolchain_revision=$(tar -ztf /tmp/mongodbtoolchain.tar.gz | head -1 | sed 's/\/$//')
-        /opt/mongodbtoolchain/revisions/${toolchain_revision}/scripts/install.sh
-        poetry env use /opt/mongodbtoolchain/v4/bin/python3
-    fi
     poetry install --no-root --sync
 
-    if [ -f /etc/redhat-release -o -f /etc/amazon-linux-release ]; then
-        if [ $RHEL = 7 -o $RHEL = 8 ]; then
-            if [ -d aws-sdk-cpp ]; then
-                rm -rf aws-sdk-cpp
-            fi
-            export INSTALLDIR=$PWD/../install
-            export INSTALLDIR_AWS=$PWD/../install_aws
-            git clone https://github.com/aws/aws-sdk-cpp.git
-            cd aws-sdk-cpp
-            git reset --hard
-            git clean -xdf
-            git checkout 1.9.379
-            git submodule update --init --recursive
-            if [[ x"${RHEL}" =~ ^x(7|8|9|2023)$ ]]; then
-                sed -i 's:v0.4.42:v0.6.10:' third-party/CMakeLists.txt
-                sed -i 's:"-Werror" ::' cmake/compiler_settings.cmake
-            fi
-            mkdir build
-            cd build
-            set_compiler
-            if [ x"${DEBIAN}" = xjammy ]; then
-                CMAKE_CXX_FLAGS=" -Wno-error=maybe-uninitialized -Wno-error=deprecated-declarations -Wno-error=uninitialized "
-                CMAKE_C_FLAGS=" -Wno-error=maybe-uninitialized -Wno-error=maybe-uninitialized -Wno-error=uninitialized "
-            fi
-            CMAKE_CMD="cmake"
-#            if [ x"$RHEL" = x7 ]; then
-#                CMAKE_CMD="cmake3"
-#            fi
-            if [ -z "${CC}" -a -z "${CXX}" ]; then
-                ${CMAKE_CMD} .. -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3;transfer" -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX="${INSTALLDIR_AWS}" -DAUTORUN_UNIT_TESTS=OFF || exit $?
-            else
-                ${CMAKE_CMD} CC=${CC} CXX=${CXX} .. -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3;transfer" -DBUILD_SHARED_LIBS=OFF -DMINIMIZE_SIZE=ON -DCMAKE_INSTALL_PREFIX="${INSTALLDIR_AWS}" -DAUTORUN_UNIT_TESTS=OFF || exit $?
-            fi
-            make -j${NCPU} || exit $?
-            make install
-            mkdir -p ${INSTALLDIR}/include/
-            mkdir -p ${INSTALLDIR}/lib/
-            mv ${INSTALLDIR_AWS}/include/* ${INSTALLDIR}/include/
-            mv ${INSTALLDIR_AWS}/lib*/* ${INSTALLDIR}/lib/
-            cd ../../
-
-        fi
-    fi
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-    if [ "x${RHEL}" == "x2023" ]; then
-        export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 "
-    else
-        export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1 -B/opt/mongodbtoolchain/v4/bin"
-    fi
-    if [ x"${DEBIAN}" = "xstretch" ]; then
-      CURL_LINKFLAGS=$(pkg-config libcurl --static --libs)
-      export OPT_LINKFLAGS="${OPT_LINKFLAGS} ${CURL_LINKFLAGS}"
-    fi
+    export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1"
     wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelignore
     wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazeliskrc
     wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -179,9 +179,19 @@ get_sources(){
     python3 buildscripts/install_bazel.py
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
-    sed -i 's:build-id:build-id=sha1:' SConstruct
+
+    KEEP_DOTFILES='\.bazelrc|\.bazelrc\.psmdb|\.bazelrc\.fuzztest|\.bazelrc\.sync|\.bazelversion|\.bazeliskrc|\.bazelignore|\.npmrc|\.prettierrc|\.prettierignore|\.clang-format|\.clang-tidy\.in'
+    DROP_DOTFILES=$(ls -A | grep -E '^\.' | grep -vE "^(${KEEP_DOTFILES})$" || true)
+    if [ -n "$DROP_DOTFILES" ]; then
+        echo "Source-tarball dotfile cleanup — stripping:" >&2
+        echo "$DROP_DOTFILES" | sed 's/^/  /' >&2
+        echo "$DROP_DOTFILES" | xargs -r rm -rf
+    fi
+    # Scrub nested .git (submodules, mongo-tools clone) regardless of whitelist.
+    find . -name '.git' -prune -exec rm -rf {} +
+
     cd ..
-    tar --owner=0 --group=0 --exclude=.* -czf ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}.tar.gz ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}
+    tar --owner=0 --group=0 -czf ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}.tar.gz ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}
     echo "UPLOAD=UPLOAD/experimental/BUILDS/${PRODUCT}-8.3/${PRODUCT}-${PSM_VER}-${PSM_RELEASE}/${PSM_BRANCH}/${REVISION}/${BUILD_ID}" >> percona-server-mongodb-83.properties
     mkdir -p $WORKDIR/source_tarball
     mkdir -p $CURDIR/source_tarball
@@ -320,23 +330,7 @@ install_deps() {
         yum clean all
         yum install -y patchelf
       fi
-      if [ x"$RHEL" = x7 ]; then
-        yum -y install epel-release
-        yum -y install rpmbuild rpm-build libpcap-devel gcc make cmake gcc-c++ openssl-devel
-        yum -y install cyrus-sasl-devel cyrus-sasl-plain snappy-devel zlib-devel bzip2-devel rpmlint
-        yum -y install rpm-build git libopcodes libcurl-devel rpmlint e2fsprogs-devel expat-devel lz4-devel which
-        yum -y install openldap-devel krb5-devel xz-devel
-        yum -y install libzstd
-
-        yum -y install centos-release-scl
-        yum-config-manager --enable centos-sclo-rh-testing
-        yum -y install devtoolset-9
-        yum -y install devtoolset-11-elfutils devtoolset-11-dwz
-
-        pip install --upgrade pip
-        pip install --user setuptools --upgrade
-        pip install --user typing pyyaml regex Cheetah3
-      elif [ x"$RHEL" = x8 ]; then
+      if [ x"$RHEL" = x8 ]; then
         yum-config-manager --enable ol8_codeready_builder
         yum -y install epel-release
         yum -y install bzip2-devel libpcap-devel snappy-devel rpm-build rpmlint
@@ -350,8 +344,6 @@ install_deps() {
         yum -y install python3.11 python3.11-devel python3.11-pip
         alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 11
         alternatives --set python3 /usr/bin/python3.11
-
-        python3 -m pip install --user typing pyyaml regex Cheetah3
       elif [ x"$RHEL" = x9  -o x"$RHEL" = x2023 ]; then
         dnf config-manager --enable ol9_codeready_builder
 
@@ -363,9 +355,6 @@ install_deps() {
         yum -y install $OPENSSL_EXCLUDE redhat-rpm-config which e2fsprogs-devel expat-devel lz4-devel
         yum -y install $OPENSSL_EXCLUDE openldap-devel krb5-devel xz-devel
         yum -y install $OPENSSL_EXCLUDE perl
-        /usr/bin/pip install --upgrade pip setuptools --ignore-installed
-        /usr/bin/pip install --user typing pyyaml==5.3.1 regex Cheetah3
-
       fi
       wget https://curl.se/download/curl-7.77.0.tar.gz -O curl-7.77.0.tar.gz
       tar -xzf curl-7.77.0.tar.gz
@@ -389,7 +378,6 @@ install_deps() {
           alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10
           alternatives --auto python3
       fi
-      pip install --upgrade pip
 
     else
       apt-get -y update
@@ -404,8 +392,6 @@ install_deps() {
       fi
       INSTALL_LIST="${INSTALL_LIST} git valgrind liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev libsasl2-dev gcc g++ cmake curl"
       INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev liblzma-dev patchelf libexpat1-dev sudo libfile-copy-recursive-perl"
-      # PSMDB-2054: native python3 is >= 3.10 on jammy / bookworm / noble (>= 3.9
-      # required for PEP 585 generics in buildscripts/), so no deadsnakes PPA needed.
       INSTALL_LIST="${INSTALL_LIST} python3 python3-dev python3-pip python3-venv"
       until apt-get -y install dirmngr; do
         sleep 1
@@ -481,15 +467,6 @@ build_srpm(){
     SRC_DIR=${TARFILE%.tar.gz}
     tar xzf ${WORKDIR}/${TARFILE}
     source ${WORKDIR}/percona-server-mongodb-83.properties
-    cd ${PRODUCT_FULL}
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelignore
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazeliskrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelversion
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc.psmdb
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.npmrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.prettierignore 
-    cd ..
     tar --owner=0 --group=0 -czf ${PRODUCT_FULL}.tar.gz ${PRODUCT_FULL}
     #
     mkdir -vp rpmbuild/{SOURCES,SPECS,BUILD,SRPMS,RPMS}
@@ -596,29 +573,11 @@ build_rpm(){
     elif [ x"$RHEL" = x9 ]; then
       mv /usr/bin/python3 /usr/bin/python3_old
     fi
-    if [ "x${RHEL}" == "x2023" ]; then
-        pip install --upgrade pip
-        pip install --user  requirements_parser
-        pip install --user -r etc/pip/dev-requirements.txt
-        pip install --user -r etc/pip/evgtest-requirements.txt
-        pip install --user -r etc/pip/compile-requirements.txt
-        export PYTHONPATH="/usr/local/lib64/python3.11/site-packages:/usr/local/lib/python3.11/site-packages:$PYTHONPATH"
-    fi
 
     python3 buildscripts/install_bazel.py
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
     rm -rf install_bazel.py
-
-    pip install --upgrade pip
-
-    # PyYAML pkg installation fix, more info: https://github.com/yaml/pyyaml/issues/724
-    pip install pyyaml==5.4.1 --no-build-isolation
-    pip install 'referencing<0.30.0' --no-build-isolation
-    pip install 'jsonschema-specifications<=2023.07.1' --no-build-isolation
-
-    pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
-    pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
 
     cd $WORKDIR
 
@@ -686,18 +645,6 @@ build_source_deb(){
     mv ${TARFILE} ${PRODUCT}_${VERSION}.orig.tar.gz
     cd ${BUILDDIR}
 
-    pip install --upgrade pip
-
-    # PyYAML pkg installation fix, more info: https://github.com/yaml/pyyaml/issues/724
-    pip install pyyaml==5.4.1 --no-build-isolation
-    pip install 'referencing<0.30.0' --no-build-isolation
-    pip install 'jsonschema-specifications<=2023.07.1' --no-build-isolation
-
-    pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
-    pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
-
-    poetry install --no-root --sync
-
     dch -D unstable --force-distribution -v "${VERSION}-${RELEASE}" "Update to new Percona Server for MongoDB version ${VERSION}"
     dpkg-buildpackage -S
     cd ../
@@ -745,26 +692,6 @@ build_deb(){
     #
     cd ${PRODUCT}-${VERSION}
 
-    pip install --upgrade pip
-
-    # PyYAML pkg installation fix, more info: https://github.com/yaml/pyyaml/issues/724
-    pip install pyyaml==5.4.1 --no-build-isolation
-    pip install 'referencing<0.30.0' --no-build-isolation
-    pip install 'jsonschema-specifications<=2023.07.1' --no-build-isolation
-
-    pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
-    pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
-
-    poetry install --no-root --sync
-
-    #
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelignore
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazeliskrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelversion
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc.psmdb
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.npmrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.prettierignore
     python3 buildscripts/install_bazel.py
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
@@ -887,31 +814,14 @@ build_tarball(){
 
     # Finally build Percona Server for MongoDB with Bazel
     cd ${PSMDIR_ABS}
-    pip install --upgrade pip
-    # PyYAML pkg installation fix, more info: https://github.com/yaml/pyyaml/issues/724
-    pip install pyyaml==5.4.1 --no-build-isolation
-    pip install 'referencing<0.30.0' --no-build-isolation
-    pip install 'jsonschema-specifications<=2023.07.1' --no-build-isolation
-
-    pip install 'poetry==2.0.0' 'pyproject-hooks==1.2.0'
-    pip install 'mongo_tooling_metrics==1.0.8' 'retry' 'psutil' 'Cheetah3'
-
-    poetry install --no-root --sync
 
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1"
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelignore
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazeliskrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelversion
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.bazelrc.psmdb
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.npmrc
-    wget https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/${BRANCH}/.prettierignore
     python3 buildscripts/install_bazel.py
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
+
     bazel clean --expunge || true
-    # PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
     bazel build --config=psmdb_opt_release ${PSMDB_RBE_BAZEL_FLAGS:-} --define=MONGO_VERSION=${VERSION}-${RELEASE} --define=GIT_COMMIT_HASH=${REVISION_LONG} install-dist-test
     rm -rf .[^.]*
     mkdir -p ${PSMDIR}/bin

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -568,10 +568,7 @@ build_rpm(){
       if [ -f /opt/rh/gcc-toolset-9/enable ]; then
         source /opt/rh/gcc-toolset-9/enable
         source /opt/rh/gcc-toolset-11/enable
-        mv /usr/bin/python3 /usr/bin/python3_old
       fi
-    elif [ x"$RHEL" = x9 ]; then
-      mv /usr/bin/python3 /usr/bin/python3_old
     fi
 
     python3 buildscripts/install_bazel.py

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -363,9 +363,11 @@ install_deps() {
       fi
       yum -y install wget sudo
       yum -y install perl
-      if [ x"$RHEL" != x2023 ]; then
-          install_mongodbtoolchain
-      fi
+      # PSMDB-2054: skip toolchain install for RBE — Bazel pulls hermetic
+      # mongo_toolchain_v5 from CAS at action time; runner image doesn't need v4.
+      #if [ x"$RHEL" != x2023 ]; then
+      #    install_mongodbtoolchain
+      #fi
       if [ x"$ARCH" = "xx86_64" ]; then
         yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
         percona-release enable tools testing
@@ -385,7 +387,7 @@ install_deps() {
         yum -y install devtoolset-9
         yum -y install devtoolset-11-elfutils devtoolset-11-dwz
 
-        PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
+        #PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
 
         pip install --upgrade pip
         pip install --user setuptools --upgrade
@@ -400,10 +402,12 @@ install_deps() {
         yum -y install openldap-devel krb5-devel xz-devel
         yum -y install gcc-toolset-9 gcc-c++
         yum -y install gcc-toolset-11-dwz gcc-toolset-11-elfutils
-        yum -y install python38 python38-devel python38-pip
 
-        PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
-        /usr/bin/pip install --user typing pyyaml regex Cheetah3
+        yum -y install python3.11 python3.11-devel python3.11-pip
+        alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 11
+        alternatives --set python3 /usr/bin/python3.11
+
+        python3 -m pip install --user typing pyyaml regex Cheetah3
       elif [ x"$RHEL" = x9  -o x"$RHEL" = x2023 ]; then
         dnf config-manager --enable ol9_codeready_builder
 
@@ -456,6 +460,9 @@ install_deps() {
       fi
       INSTALL_LIST="${INSTALL_LIST} git valgrind liblz4-dev devscripts debhelper debconf libpcap-dev libbz2-dev libsnappy-dev pkg-config zlib1g-dev libzlcore-dev libsasl2-dev gcc g++ cmake curl"
       INSTALL_LIST="${INSTALL_LIST} libssl-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev liblzma-dev patchelf libexpat1-dev sudo libfile-copy-recursive-perl"
+      # PSMDB-2054: native python3 is >= 3.10 on jammy / bookworm / noble (>= 3.9
+      # required for PEP 585 generics in buildscripts/), so no deadsnakes PPA needed.
+      INSTALL_LIST="${INSTALL_LIST} python3 python3-dev python3-pip python3-venv"
       until apt-get -y install dirmngr; do
         sleep 1
         echo "waiting"
@@ -467,16 +474,23 @@ install_deps() {
       apt-get -y install libext2fs-dev || apt-get -y install e2fslibs-dev
       install_golang
 
-      install_mongodbtoolchain
-      PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
-      update-alternatives --install /usr/bin/python python /opt/mongodbtoolchain/v4/bin/python3.10 1
+      # PSMDB-2054: skip toolchain install for RBE — Bazel pulls hermetic
+      # mongo_toolchain_v5 from CAS at action time. The legacy get-pip.py
+      # bootstrap below also relied on a `python` symlink created by the
+      # toolchain installer and now silently fails (`command not found`)
+      # without it; pip + setuptools come from the python3-pip apt package.
+      #install_mongodbtoolchain
+      #PATH=/opt/mongodbtoolchain/v4/bin/:$PATH
+      #update-alternatives --install /usr/bin/python python /opt/mongodbtoolchain/v4/bin/python3.10 1
 
-      wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
-      python get-pip.py
-      easy_install pip
-      pip install setuptools
+      #wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
+      #python get-pip.py
+      #easy_install pip
+      #pip install setuptools
     fi
-    aws_sdk_build
+    # PSMDB-2054: aws-cpp-sdk now vendored in-tree starting from PSMDB 8.0;
+    # no need to build it from source here.
+    #aws_sdk_build
     #keep symbol table in the binary
     sed -i 's:$strip, "--remove-section=.comment":$strip, "--strip-debug", "--remove-section=.comment":g' /usr/bin/dh_strip
     return;

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -1110,7 +1110,8 @@ build_tarball(){
     export PATH=\/root/.local/bin:$PATH >> ~/.bashrc
     source ~/.bashrc
     bazel clean --expunge || true
-    bazel build --config=psmdb_opt_release --define=MONGO_VERSION=${VERSION}-${RELEASE} --define=GIT_COMMIT_HASH=${REVISION_LONG} install-dist-test
+    # PSMDB-2054: optional RBE injection. Empty when PSMDB_RBE_BAZEL_FLAGS is unset.
+    bazel build --config=psmdb_opt_release ${PSMDB_RBE_BAZEL_FLAGS:-} --define=MONGO_VERSION=${VERSION}-${RELEASE} --define=GIT_COMMIT_HASH=${REVISION_LONG} install-dist-test
     rm -rf .[^.]*
     mkdir -p ${PSMDIR}/bin
     for target in ${PSM_TARGETS[@]}; do


### PR DESCRIPTION
## Summary

Adds optional RBE injection into the existing rpm/deb build pipelines so `psmdb_builder.sh` can offload Bazel actions to the
RBE cluster without touching native build paths. Pair PR: PSMDB-2034.

When `PSMDB_RBE_BAZEL_FLAGS` is empty, behaviour is byte-identical to the legacy local build (no opt-in tax). When set, the flags are appended to every `bazel build` invocation in the source tarball, srpm, and rpm/deb stages. Dotfiles (`.bazelrc.psmdb`, `.bazelrc`) are now shipped inside the source tarball via the existing whitelist — without that, an extracted tarball couldn't run RBE.

## File-by-file canges

| Change | What it brings |
|---|---|
| `percona-packaging/scripts/psmdb_builder.sh` | Refactored `build_tarball` / `build_srpm` / `build_rpm` to accept `PSMDB_RBE_BAZEL_FLAGS`. Drops stale `python3 → python3_old` shuffles left over from the bazel-bootstrap removal. |
| `percona-packaging/debian/rules` | `PSMDB_RBE_BAZEL_FLAGS` pass-through for the Debian build path; ships the dotfiles via the whitelist. |
| `percona-packaging/redhat/percona-server-mongodb.spec.template` | Mirrors the `debian/rules` change for rpm: dotfiles whitelist + `PSMDB_RBE_BAZEL_FLAGS` pass-through to the `%build` Bazel call. |

## Test plan

- [x] `psmdb_builder.sh --build_tarball` with empty `PSMDB_RBE_BAZEL_FLAGS` produces a byte-identical tarball vs main.
- [x] Same with `PSMDB_RBE_BAZEL_FLAGS=--config=psmdb_buildfarm` succeeds against `RBE cluster` (verified end-to-end via build of `hetzner-psmdb83-autobuild-RELEASE-RBE`).