### PR TITLE
PSMDB-1997: Do not delete encryption key when dropping a database

### DIFF
--- a/jstests/percona/tde/index_build_spill.js
+++ b/jstests/percona/tde/index_build_spill.js
@@ -1,0 +1,85 @@
+/**
+ * PSMDB-1997
+ * Index-build spill on a TDE-enabled database.
+ *
+ * Regression test for an EncryptionKeyDB invariant crash that no other
+ * jstest exercises. The crash path is:
+ *
+ *   index build exceeds maxIndexBuildMemoryUsageMegabytes
+ *     -> FileBasedSpiller<...>::protectTmpData() with the collection's
+ *        DatabaseName threaded into the sorter
+ *     -> WiredTigerEncryptionHooks::dbKey(dbName, buf)
+ *     -> EncryptionKeyDB::get_key_by_id(..., pe=nullptr)
+ *
+ * The "Most other spillers ($sort, $group, $bucketAuto, SBE sort, near,
+ * text_or, spool, percentile_algo_accurate) pass dbName = boost::none,
+ * which short-circuits in dbKey() before get_key_by_id is called. Only
+ * the external-sort index build threads a real dbName through. This
+ * makes the dbKey()->get_key_by_id(..., pe=nullptr) call the lone way
+ * to ever trip an `invariant(pe)` on the per-DB path - so without this
+ * test any future regression that adds such an invariant would pass CI.
+ *
+ * @tags: [requires_wiredtiger, requires_persistence]
+ */
+(function () {
+    "use strict";
+
+    run("chmod", "600", TestData.keyFileGood);
+
+    const dbPath = MongoRunner.dataPath + "psmdb1997-index-build-spill";
+
+    // 50 MB is the minimum effective value enforced by
+    // validateMaxIndexBuildMemoryUsageMegabytesSetting() - see
+    // src/mongo/db/index_builds/multi_index_block.idl.
+    const maxMemUsageMB = 50;
+
+    const conn = MongoRunner.runMongod({
+        dbpath: dbPath,
+        enableEncryption: "",
+        encryptionKeyFile: TestData.keyFileGood,
+        encryptionCipherMode: TestData.cipherMode,
+        setParameter: {maxIndexBuildMemoryUsageMegabytes: maxMemUsageMB},
+    });
+
+    const testDB = conn.getDB("psmdb1997_spill_db");
+    const coll = testDB.spill_target;
+
+    // Each document carries a ~3 KiB unique string. With 30 000 docs the
+    // bulk index builder accumulates ~90 MiB of key data, well past the
+    // 50 MiB spill threshold.
+    const docs = 30 * 1000;
+    const filler = "x".repeat(3 * 1024);
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < docs; i++) {
+        bulk.insert({a: i, b: i.toString() + filler});
+    }
+    assert.commandWorked(bulk.execute());
+
+    // Build the index on the long field. Without the fix this crashes
+    // inside WiredTigerEncryptionHooks::protectTmpData the first time the
+    // bulk builder spills; with the fix it returns successfully.
+    assert.commandWorked(coll.createIndex({b: 1}));
+
+    // Sanity check: a spill actually happened, so we know the test
+    // exercised the encrypted-spill path rather than building entirely
+    // in memory.
+    const ss = testDB.serverStatus();
+    assert(ss.hasOwnProperty("indexBulkBuilder"), "serverStatus is missing indexBulkBuilder section: " + tojson(ss));
+    assert.gt(
+        ss.indexBulkBuilder.spilledRanges,
+        0,
+        "expected at least one spilled range during the index build; got: " + tojson(ss.indexBulkBuilder),
+    );
+
+    // Verify the index actually works - this also forces a scan that
+    // would surface decryption errors on the just-built index files.
+    assert.eq(
+        docs,
+        coll
+            .find({b: {$exists: true}})
+            .hint({b: 1})
+            .itcount(),
+    );
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/jstests/percona/tde/orphan_key_cleanup.js
+++ b/jstests/percona/tde/orphan_key_cleanup.js
@@ -1,0 +1,121 @@
+/**
+ * PSMDB-1997
+ * Startup orphan encryption-key cleanup.
+ *
+ * Verifies:
+ *   1. dropDatabase leaves the encryption key in the keystore (the fix's
+ *      whole point - inline deletion races with checkpoint cleanup).
+ *   2. On the next startup, the orphan-key cleanup deletes the keys.
+ *   3. The cleanup runs AFTER abandoned WT idents are dropped, so a single
+ *      restart suffices - the keys do not leak to the next startup.
+ *   4. The cleanup is idempotent (a second restart deletes nothing).
+ *
+ * @tags: [requires_wiredtiger, requires_persistence]
+ */
+(function () {
+    "use strict";
+
+    run("chmod", "600", TestData.keyFileGood);
+
+    const dbPath = MongoRunner.dataPath + "psmdb1997-orphan-key-cleanup";
+    const dbNames = ["psmdb1997_a", "psmdb1997_b", "psmdb1997_c"];
+
+    const startOpts = {
+        dbpath: dbPath,
+        enableEncryption: "",
+        encryptionKeyFile: TestData.keyFileGood,
+        encryptionCipherMode: TestData.cipherMode,
+    };
+
+    // First run: create then drop each database. The keys remain in the
+    // keystore because per-database keys are no longer deleted inline.
+    let conn = MongoRunner.runMongod(startOpts);
+    for (const name of dbNames) {
+        const sdb = conn.getDB(name);
+        assert.commandWorked(sdb.c.insert({x: 1}));
+        assert.commandWorked(sdb.c.createIndex({x: 1}));
+        assert.commandWorked(sdb.dropDatabase());
+    }
+    MongoRunner.stopMongod(conn);
+
+    // Second run: same dbpath, same keyfile. Startup must drop abandoned
+    // idents (if any) and then clean up the orphan keys.
+    conn = MongoRunner.runMongod(
+        Object.merge(startOpts, {
+            restart: true,
+            cleanData: false,
+        }),
+    );
+
+    const log = assert.commandWorked(conn.adminCommand({getLog: "global"})).log;
+    let lastDropIdx = -1;
+    let cleanupIdx = -1;
+    let cleanupDeleted = -1;
+    let cleanupCandidates = -1;
+    for (let i = 0; i < log.length; i++) {
+        const line = log[i];
+        // 22251 = "Dropping unknown ident" (reconcileCatalogAndIdents)
+        if (line.indexOf('"id":22251') !== -1) {
+            lastDropIdx = i;
+        }
+        // 29169 = "Orphaned encryption key cleanup completed"
+        if (line.indexOf('"id":29169') !== -1) {
+            cleanupIdx = i;
+            const m = line.match(/"deleted":(\d+)/);
+            if (m) cleanupDeleted = parseInt(m[1]);
+            const c = line.match(/"candidates":(\d+)/);
+            if (c) cleanupCandidates = parseInt(c[1]);
+        }
+    }
+
+    // The cleanup completion log line must be present.
+    assert.gte(cleanupIdx, 0, 'expected "Orphaned encryption key cleanup completed" (logId 29169) in log');
+
+    // Ordering: if reconcile dropped any idents this startup, the cleanup
+    // line must come AFTER the last "Dropping unknown ident" line. This is
+    // the property the PR enforces - cleanup runs after reconcile so keys
+    // for the just-dropped idents are reclaimed in this same startup.
+    if (lastDropIdx >= 0) {
+        assert.lt(
+            lastDropIdx,
+            cleanupIdx,
+            "orphan-key cleanup (logId 29169) must come after the last 'Dropping " + "unknown ident' (logId 22251)",
+        );
+    }
+
+    // We dropped three databases in the first run, so at least three keys
+    // must have been reclaimed (special keys like the master key are
+    // excluded by EncryptionKeyDB::isSpecialKeyId, so they do not inflate
+    // the count).
+    assert.gte(
+        cleanupDeleted,
+        dbNames.length,
+        "expected at least " +
+            dbNames.length +
+            " orphan keys deleted, got: " +
+            cleanupDeleted +
+            " (candidates=" +
+            cleanupCandidates +
+            ")",
+    );
+
+    // Third run: idempotency. Nothing to clean.
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod(
+        Object.merge(startOpts, {
+            restart: true,
+            cleanData: false,
+        }),
+    );
+    const log2 = assert.commandWorked(conn.adminCommand({getLog: "global"})).log;
+    let cleanupDeleted2 = -1;
+    for (const line of log2) {
+        if (line.indexOf('"id":29169') !== -1) {
+            const m = line.match(/"deleted":(\d+)/);
+            if (m) cleanupDeleted2 = parseInt(m[1]);
+        }
+    }
+    assert.eq(cleanupDeleted2, 0, "on a second restart cleanup should find no orphans, got deleted=" + cleanupDeleted2);
+
+    MongoRunner.stopMongod(conn);
+})();

--- a/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
+++ b/src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp
@@ -439,15 +439,14 @@ Status dropCollectionsWithPrefix(OperationContext* opCtx,
 
     std::vector<UUID> toDrop = catalog->getAllCollectionUUIDsFromDb(dbName);
 
-    const auto status = dropCollections(opCtx, toDrop, collectionNamePrefix);
+    // NOTE: Encryption key cleanup is NOT performed here.
+    // The key cannot be safely deleted at this point because drop-pending idents
+    // (encrypted with this key) may still exist in storage and will be accessed
+    // during checkpoint cleanup. Deleting the key here would cause WT_NOTFOUND errors.
+    // Orphaned encryption keys are instead cleaned up unconditionally on startup,
+    // after catalog initialization.
 
-    // If all collections were dropped successfully then drop database's encryption key
-    if (status.isOK()) {
-        auto storageEngine = opCtx->getServiceContext()->getStorageEngine();
-        storageEngine->keydbDropDatabase(dbName);
-    }
-
-    return status;
+    return dropCollections(opCtx, toDrop, collectionNamePrefix);
 }
 
 void shutDownCollectionCatalogAndGlobalStorageEngineCleanly(ServiceContext* service,

--- a/src/mongo/db/startup_recovery.cpp
+++ b/src/mongo/db/startup_recovery.cpp
@@ -904,6 +904,19 @@ void startupRecovery(OperationContext* opCtx,
     reconcileCatalogAndRestartUnfinishedIndexBuilds(
         opCtx, storageEngine, lastShutdownState, startupTimeElapsedBuilder);
 
+    // Clean up orphaned encryption keys.
+    //
+    // This MUST run after reconcileCatalogAndRestartUnfinishedIndexBuilds.
+    // That call drops WT idents that the catalog no longer references (the
+    // typical case: a database was dropped but its WT files survived because
+    // the drop-pending reaper had not yet unlinked them when mongod stopped).
+    // The orphan-key scan compares keys in the keystore against the keyIds
+    // still referenced by WT idents - so it must see the post-reconcile ident
+    // set. If we ran it before reconcile, the about-to-be-dropped idents
+    // would still be visible in WT and their keys would be misclassified as
+    // in-use, deferring their cleanup to the *next* startup.
+    storageEngine->cleanupOrphanedEncryptionKeys(opCtx, "startup"_sd);
+
     const bool usingReplication =
         repl::ReplicationCoordinator::get(opCtx)->getSettings().isReplSet();
 

--- a/src/mongo/db/storage/keydb_api.h
+++ b/src/mongo/db/storage/keydb_api.h
@@ -31,9 +31,14 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 
 #pragma once
 
+#include "mongo/base/string_data.h"
+
+#include <string>
+#include <vector>
+
 namespace mongo {
-class DatabaseName;
-}
+class OperationContext;
+}  // namespace mongo
 
 namespace percona {
 
@@ -45,9 +50,50 @@ struct KeyDBAPI {
     virtual ~KeyDBAPI() {}
 
     /**
-     * Returns whether the engine supports feature compatibility version 3.6
+     * Delete the keystore entry with the given keyId.
+     *
+     * Returns true if the entry was deleted (or no entry was present),
+     * false if the deletion failed in the underlying key store. Engines
+     * that do not support KeyDB always return true.
+     *
+     * Called by the deferred cleanup process after verifying:
+     * 1. The database whose name serializes to this keyId no longer
+     *    exists in the catalog (or the keyId is not a valid serialized
+     *    DatabaseName, e.g. a legacy/corrupted entry)
+     * 2. No storage idents (including drop-pending ones) use the key
+     *
+     * NOTE: This should NOT be called directly during dropDatabase
+     * operations because drop-pending idents may still exist and require
+     * the key for checkpoint cleanup. Use the deferred cleanup mechanism
+     * instead.
      */
-    virtual void keydbDropDatabase(const mongo::DatabaseName& dbName) {
+    virtual bool keydbDropKeyId(mongo::StringData keyId) {
+        // do nothing for engines which do not support KeyDB
+        return true;
+    }
+
+    /**
+     * Returns the sorted set of encryption keyIds that exist in the key database
+     * but are not referenced by any storage ident (including drop-pending ones).
+     *
+     * Computed inside the engine because both inputs — the keydb listing and the
+     * WT-metadata scan — are engine-internal. Callers re-verify each candidate
+     * under a DB lock before deleting it; this method does not consult the
+     * CollectionCatalog.
+     */
+    virtual std::vector<std::string> findOrphanedEncryptionKeyIds() {
+        return {};  // empty for engines which do not support KeyDB
+    }
+
+    /**
+     * Cleans up orphaned encryption keys - keys that belong to databases that
+     * no longer exist and are not in use by any storage idents. Called
+     * unconditionally on startup. `trigger` is a short string identifying the
+     * call site ("startup") so the completion summary log can be
+     * filtered/audited.
+     */
+    virtual void cleanupOrphanedEncryptionKeys(mongo::OperationContext* opCtx,
+                                               mongo::StringData trigger) {
         // do nothing for engines which do not support KeyDB
     }
 };

--- a/src/mongo/db/storage/storage_engine_impl.cpp
+++ b/src/mongo/db/storage/storage_engine_impl.cpp
@@ -36,10 +36,13 @@
 #include "mongo/bson/timestamp.h"
 #include "mongo/db/admission/execution_control/execution_admission_context.h"
 #include "mongo/db/client.h"
+#include "mongo/db/database_name_util.h"
 #include "mongo/db/index/multikey_paths.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/rss/replicated_storage_service.h"
+#include "mongo/db/shard_role/lock_manager/d_concurrency.h"
 #include "mongo/db/shard_role/shard_catalog/catalog_raii.h"
+#include "mongo/db/shard_role/shard_catalog/collection_catalog.h"
 #include "mongo/db/shard_role/transaction_resources.h"
 #include "mongo/db/storage/backup_cursor_hooks.h"
 #include "mongo/db/storage/disk_space_monitor.h"
@@ -63,6 +66,7 @@
 #include "mongo/util/fail_point.h"
 #include "mongo/util/log_and_backoff.h"
 #include "mongo/util/str.h"
+#include "mongo/util/timer.h"
 
 #include <algorithm>
 #include <memory>
@@ -123,8 +127,8 @@ Status StorageEngineImpl::hotBackup(OperationContext* opCtx,
     return _engine->hotBackup(opCtx, s3params);
 }
 
-void StorageEngineImpl::keydbDropDatabase(const DatabaseName& dbName) {
-    _engine->keydbDropDatabase(dbName);
+bool StorageEngineImpl::keydbDropKeyId(StringData keyId) {
+    return _engine->keydbDropKeyId(keyId);
 }
 
 StorageEngineImpl::StorageEngineImpl(OperationContext* opCtx,
@@ -977,6 +981,108 @@ StorageEngine::CheckpointIteration StorageEngineImpl::getCheckpointIteration() c
 bool StorageEngineImpl::hasDataBeenCheckpointed(
     StorageEngine::CheckpointIteration checkpointIteration) const {
     return _engine->hasDataBeenCheckpointed(checkpointIteration);
+}
+
+void StorageEngineImpl::cleanupOrphanedEncryptionKeys(OperationContext* opCtx, StringData trigger) {
+    Timer timer;
+
+    // Skip cleanup during backup. Deleting a key while a backup cursor is
+    // iterating the key database could produce a backup that cannot decrypt
+    // its ident files.
+    auto backupCursorHooks = BackupCursorHooks::get(opCtx->getServiceContext());
+    if (_inBackupMode || (backupCursorHooks && backupCursorHooks->isBackupCursorOpen())) {
+        LOGV2_DEBUG(29171,
+                    1,
+                    "Orphaned encryption key cleanup deferred due to backup in progress",
+                    "trigger"_attr = trigger,
+                    "reason"_attr = _inBackupMode ? "inBackupMode"_sd : "backupCursorOpen"_sd);
+        return;
+    }
+
+    // Ask the engine for keys that exist in the keydb but are not referenced by
+    // any storage ident (including drop-pending ones). Each candidate is then
+    // re-verified under a MODE_S DB lock against the CollectionCatalog before
+    // deletion - that lock is what guards against races with concurrent
+    // createDatabase / createCollection.
+    auto orphaned = _engine->findOrphanedEncryptionKeyIds();
+
+    size_t dbCount = 0;
+    {
+        Lock::GlobalLock globalLock(opCtx, MODE_IS);
+        dbCount = CollectionCatalog::get(opCtx)->getAllDbNames().size();
+    }
+
+    LOGV2_DEBUG(29172, 2, "Orphaned encryption key candidates", "keyIds"_attr = orphaned);
+
+    // Re-verify under lock and delete
+    size_t deleted = 0;
+    for (const auto& keyId : orphaned) {
+        // Step 1: deserialize the keyId to a DatabaseName. If this fails the
+        // key cannot belong to any database that the catalog could ever hold
+        // (db names with invalid characters are rejected at create time), so
+        // no DB-lock dance is needed - drop the entry directly by raw keyId.
+        // Skipping it would leak the key indefinitely.
+        DatabaseName dbName;
+        try {
+            dbName = DatabaseNameUtil::deserialize(
+                boost::none, keyId, SerializationContext::stateDefault());
+        } catch (const DBException& e) {
+            LOGV2_WARNING(29173,
+                          "Encryption keystore contains an entry whose keyId is "
+                          "not a valid serialized DatabaseName; deleting it by "
+                          "raw keyId",
+                          "keyId"_attr = keyId,
+                          "error"_attr = e.toStatus());
+            if (_engine->keydbDropKeyId(keyId)) {
+                ++deleted;
+            }
+            continue;
+        }
+
+        // Step 2: verify under a DB-S lock that the database still doesn't
+        // exist and isn't drop-pending. The lock is what guards against a
+        // concurrent createDatabase/createCollection sneaking in between
+        // findOrphanedEncryptionKeyIds() and the delete below.
+        try {
+            Lock::DBLock dbLock(opCtx, dbName, MODE_S);
+            auto freshCatalog = CollectionCatalog::get(opCtx);
+            auto freshDbs = freshCatalog->getAllDbNames();
+            // getAllDbNames() returns a sorted vector - binary_search keeps
+            // the per-key check O(log dbs) instead of O(dbs).
+            bool dbExists = std::binary_search(freshDbs.begin(), freshDbs.end(), dbName);
+            bool dropPending = freshCatalog->isDropPending(dbName);
+
+            if (!dbExists && !dropPending) {
+                LOGV2(29160,
+                      "Deleting orphaned encryption key for non-existent database",
+                      "keyId"_attr = keyId);
+                if (_engine->keydbDropKeyId(keyId)) {
+                    ++deleted;
+                }
+            } else {
+                LOGV2_DEBUG(29170,
+                            1,
+                            "Skipped orphaned encryption key deletion",
+                            "keyId"_attr = keyId,
+                            "reason"_attr = dbExists ? "dbExists"_sd : "dropPending"_sd);
+            }
+        } catch (const DBException& e) {
+            // Log and continue with other keys - don't let one failure stop cleanup
+            LOGV2_DEBUG(29161,
+                        1,
+                        "Failed to clean up encryption key",
+                        "keyId"_attr = keyId,
+                        "error"_attr = e.toStatus());
+        }
+    }
+
+    LOGV2(29169,
+          "Orphaned encryption key cleanup completed",
+          "trigger"_attr = trigger,
+          "dbCount"_attr = dbCount,
+          "candidates"_attr = orphaned.size(),
+          "deleted"_attr = deleted,
+          "durationMs"_attr = timer.millis());
 }
 
 StorageEngineImpl::TimestampMonitor::TimestampMonitor(KVEngine* engine, PeriodicRunner* runner)

--- a/src/mongo/db/storage/storage_engine_impl.h
+++ b/src/mongo/db/storage/storage_engine_impl.h
@@ -59,7 +59,6 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -85,7 +84,9 @@ class StorageEngineImpl final : public StorageEngine {
     Status hotBackup(OperationContext* opCtx, const std::string& path) override;
     Status hotBackupTar(OperationContext* opCtx, const std::string& path) override;
     Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
-    void keydbDropDatabase(const DatabaseName& dbName) override;
+    bool keydbDropKeyId(StringData keyId) override;
+
+    void cleanupOrphanedEncryptionKeys(OperationContext* opCtx, StringData trigger) override;
 
 public:
     StorageEngineImpl(OperationContext* opCtx,

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.cpp
@@ -391,7 +391,12 @@ int EncryptionKeyDB::get_key_by_id(const char* keyid, size_t len, unsigned char*
         memcpy(key, v.data, encryption::Key::kLength);
         if (kDebugBuild)
             dump_key(key, encryption::Key::kLength, "loaded key from key DB");
-        _encryptors[c_str] = pe;
+        // pe is null for callers that only want the key bytes (e.g. dbKey()
+        // in the temp-data encryption hooks). Only cache real encryptor
+        // handles - those are populated by WT's customize callback.
+        if (pe) {
+            _encryptors[c_str] = pe;
+        }
         return 0;
     }
     if (res != WT_NOTFOUND) {
@@ -420,7 +425,9 @@ int EncryptionKeyDB::get_key_by_id(const char* keyid, size_t len, unsigned char*
 
     if (kDebugBuild)
         dump_key(key, encryption::Key::kLength, "generated and stored key");
-    _encryptors[c_str] = pe;
+    if (pe) {
+        _encryptors[c_str] = pe;
+    }
     return 0;
 }
 
@@ -446,7 +453,13 @@ int EncryptionKeyDB::delete_key_by_id(const std::string& keyid) {
     // delete key
     cursor->set_key(cursor, keyid.c_str());
     res = cursor->remove(cursor);
-    if (res) {
+    if (res == WT_NOTFOUND) {
+        // The key is already gone (e.g. a concurrent cleanup raced with us,
+        // or the caller did not check before deleting). Treat as success so
+        // callers can use this idempotently.
+        LOGV2_DEBUG(29059, 2, "delete_key_by_id: keyid not present", "id"_attr = keyid);
+        res = 0;
+    } else if (res) {
         LOGV2_ERROR(29046,
                     "cursor->remove error {code}: {desc}",
                     "code"_attr = res,
@@ -459,11 +472,53 @@ int EncryptionKeyDB::delete_key_by_id(const std::string& keyid) {
     // DB is dropped just after mongod is started and before any read/write operations)
     auto it = _encryptors.find(keyid);
     if (it != _encryptors.end()) {
-        percona_encryption_extension_drop_keyid(it->second);
+        if (it->second) {
+            percona_encryption_extension_drop_keyid(it->second);
+        }
         _encryptors.erase(it);
     }
 
     return res;
+}
+
+bool EncryptionKeyDB::isSpecialKeyId(const std::string& keyId) {
+    return keyId.empty() || keyId == "/default";
+}
+
+std::vector<std::string> EncryptionKeyDB::getAllKeyIds() {
+    std::vector<std::string> keyIds;
+
+    WT_CURSOR* cursor;
+    std::lock_guard<std::mutex> lk(_lock_sess);
+    int res = _sess->open_cursor(_sess, "table:key", nullptr, nullptr, &cursor);
+    if (res) {
+        LOGV2_ERROR(
+            29155, "getAllKeyIds: error opening cursor", "error"_attr = wiredtiger_strerror(res));
+        return keyIds;
+    }
+
+    // Create cursor close guard
+    std::unique_ptr<WT_CURSOR, std::function<void(WT_CURSOR*)>> cursor_guard(
+        cursor, [](WT_CURSOR* c) { c->close(c); });
+
+    while ((res = cursor->next(cursor)) == 0) {
+        char* k;
+        res = cursor->get_key(cursor, &k);
+        if (res == 0 && k != nullptr) {
+            std::string keyId(k);
+            if (!isSpecialKeyId(keyId)) {
+                keyIds.emplace_back(std::move(keyId));
+            }
+        }
+    }
+
+    if (res != WT_NOTFOUND) {
+        LOGV2_ERROR(
+            29156, "getAllKeyIds: error iterating cursor", "error"_attr = wiredtiger_strerror(res));
+    }
+
+    LOGV2_DEBUG(29157, 2, "getAllKeyIds: found keys", "count"_attr = keyIds.size());
+    return keyIds;
 }
 
 int EncryptionKeyDB::store_gcm_iv_reserved() {

--- a/src/mongo/db/storage/wiredtiger/encryption_keydb.h
+++ b/src/mongo/db/storage/wiredtiger/encryption_keydb.h
@@ -39,6 +39,7 @@ Copyright (C) 2018-present Percona and/or its affiliates. All rights reserved.
 #include <map>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include <wiredtiger.h>
 
@@ -86,8 +87,19 @@ public:
     // return key from keyfile if len == 0
     int get_key_by_id(const char* keyid, size_t len, unsigned char* key, void* pe);
 
-    // drop key for specific keyid (used in dropDatabase)
+    // drop key for specific keyid (called from the deferred startup
+    // orphan-key cleanup path; not called during dropDatabase, which
+    // would race with WT checkpoint cleanup of drop-pending idents)
     int delete_key_by_id(const std::string& keyid);
+
+    // Returns all key IDs (database names) stored in the key database.
+    // Excludes the master key (empty keyid) and special keys like "/default".
+    // Used for deferred encryption key cleanup.
+    std::vector<std::string> getAllKeyIds();
+
+    // Returns true if the key ID is a special/reserved key that should not be
+    // included in user key lists (empty key for master key, "/default" key).
+    static bool isSpecialKeyId(const std::string& keyId);
 
     // get new counter value for IV in GCM mode
     int get_iv_gcm(uint8_t* buf, int len);

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -3659,16 +3659,94 @@ void WiredTigerKVEngine::dropIdentForImport(Interruptible& interruptible,
     invariant(dropStatus);
 }
 
-void WiredTigerKVEngine::keydbDropDatabase(const DatabaseName& dbName) {
-    if (_restEncr) {
-        int res = _restEncr->keyDb()->delete_key_by_id(
-            DatabaseNameUtil::serialize(dbName, SerializationContext::stateDefault()));
-        if (res) {
-            // we cannot throw exceptions here because we are inside WUOW::commit
-            // every other part of DB is already dropped so we just log error message
-            LOGV2_ERROR(29001, "failed to delete encryption key for db", logAttrs(dbName));
+bool WiredTigerKVEngine::keydbDropKeyId(StringData keyId) {
+    if (!_restEncr) {
+        return true;
+    }
+    int res = _restEncr->keyDb()->delete_key_by_id(std::string{keyId});
+    if (res) {
+        LOGV2_ERROR(29174, "Failed to delete encryption key by raw keyId", "keyId"_attr = keyId);
+        return false;
+    }
+    LOGV2_DEBUG(29175, 1, "Deleted encryption key by raw keyId", "keyId"_attr = keyId);
+    return true;
+}
+
+std::vector<std::string> WiredTigerKVEngine::findOrphanedEncryptionKeyIds() {
+    if (!_restEncr) {
+        return {};
+    }
+
+    // candidates starts as every keyId in the keystore and shrinks as we
+    // encounter idents that reference one. Using a sorted vector (kept
+    // sorted because getAllKeyIds returns keys in WT cursor order, which
+    // is lexicographic for string keys) lets us binary_search + erase per
+    // ident and short-circuit once it's empty. This avoids the
+    // O(idents * unique-keys) memory blowup of building a parallel
+    // keyIdsInUse vector when many idents share the same key.
+    auto candidates = _restEncr->keyDb()->getAllKeyIds();
+    if (candidates.empty()) {
+        return {};
+    }
+    std::sort(candidates.begin(), candidates.end());
+    const size_t initialCandidates = candidates.size();
+
+    auto session = _connection->getUninterruptibleSession();
+    auto idents = _wtGetAllIdents(*session);
+
+    LOGV2_DEBUG(
+        29163, 2, "Scanning idents for encryption keys in use", "identCount"_attr = idents.size());
+
+    for (const auto& ident : idents) {
+        if (candidates.empty()) {
+            // Every key in the keystore is referenced - no orphans possible.
+            break;
+        }
+
+        // Must use getMetadataCreate (returns the original WT_SESSION::create
+        // config string) rather than reading the value out of a "metadata:"
+        // cursor: only the original-create config preserves the
+        // encryption=(name=..., keyid="...") clause that identifies the keyId.
+        auto metadata =
+            WiredTigerUtil::getMetadataCreate(*session, WiredTigerUtil::buildTableUri(ident));
+        if (!metadata.isOK()) {
+            // If we cannot read metadata for any ident we cannot know which
+            // keys it uses, so we cannot prove a key is orphaned.
+            // Returning an empty list skips this cleanup pass entirely - the
+            // next startup or trigger will retry. The alternative (continuing)
+            // risks deleting a key that is still referenced and leaving its
+            // ident files undecryptable.
+            LOGV2_WARNING(29164,
+                          "Aborting orphaned encryption key scan: failed to read metadata "
+                          "for an ident. Cleanup will be retried on next trigger.",
+                          "ident"_attr = ident,
+                          "error"_attr = metadata.getStatus());
+            return {};
+        }
+
+        auto keyId = WiredTigerUtil::getEncryptionKeyId(metadata.getValue());
+        if (!keyId || EncryptionKeyDB::isSpecialKeyId(*keyId)) {
+            continue;
+        }
+
+        auto it = std::lower_bound(candidates.begin(), candidates.end(), *keyId);
+        if (it != candidates.end() && *it == *keyId) {
+            LOGV2_DEBUG(29166,
+                        3,
+                        "Found ident using encryption key",
+                        "ident"_attr = ident,
+                        "keyId"_attr = *keyId);
+            candidates.erase(it);
         }
     }
+
+    LOGV2_DEBUG(29165,
+                2,
+                "Encryption key cleanup scan",
+                "keysInKeyDb"_attr = initialCandidates,
+                "orphaned"_attr = candidates.size());
+
+    return candidates;
 }
 
 void WiredTigerKVEngine::_checkpoint(WiredTigerSession& session, bool useTimestamp) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -565,7 +565,9 @@ public:
 
     Status alterMetadata(StringData uri, StringData config) override;
 
-    void keydbDropDatabase(const DatabaseName& dbName) override;
+    bool keydbDropKeyId(StringData keyId) override;
+
+    std::vector<std::string> findOrphanedEncryptionKeyIds() override;
 
     void flushAllFiles(OperationContext* opCtx, bool callerHoldsReadLock) override;
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_encryption_key_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_encryption_key_test.cpp
@@ -31,6 +31,7 @@ Copyright (C) 2022-present Percona and/or its affiliates. All rights reserved.
 
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonmisc.h"
+#include "mongo/db/database_name.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/encryption/error.h"
 #include "mongo/db/encryption/key.h"
@@ -1658,6 +1659,132 @@ TEST_F(WiredTigerKVEngineEncryptionKeyKmipPollStateTest,
 #undef ASSERT_CREATE_ENGINE_THROWS_REASON_REGEX
 #undef ASSERT_CREATE_ENGINE_THROWS_REASON_CONTAINS
 #undef ASSERT_CREATE_ENGINE_THROWS_WHAT
+
+//
+// PSMDB-1997 - lifecycle of per-database encryption keys (orphan scan,
+// cleanup, isSpecialKeyId helper). These tests need a live engine, so
+// the fixture overrides _setUpPreconfiguredEngine() to NOT reset the
+// engine after construction.
+//
+
+TEST(EncryptionKeyDBStatic, IsSpecialKeyId) {
+    // The two reserved keyIds the engine creates for itself. Either of
+    // them showing up in a "in-use" or "orphan" set would corrupt the
+    // master/default key, so the filter is security-critical.
+    ASSERT_TRUE(EncryptionKeyDB::isSpecialKeyId(""));
+    ASSERT_TRUE(EncryptionKeyDB::isSpecialKeyId("/default"));
+
+    // Anything else is a real per-database key.
+    ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId("admin"));
+    ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId("user.db"));
+    ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId("/"));
+    ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId("default"));  // no leading slash
+    ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId("/default/sub"));
+}
+
+class WiredTigerKVEngineKeyLifecycleTest : public WiredTigerKVEngineEncryptionKeyTest {
+protected:
+    void _setUpPreconfiguredEngine() override {
+        _setUpEncryptionParams();
+        _engine = _createWiredTigerKVEngine();
+        WtKeyIds::instance().configured = std::move(WtKeyIds::instance().futureConfigured);
+        // Intentionally do NOT reset _engine here - tests need the live
+        // engine to call into EncryptionKeyDB and findOrphanedEncryptionKeyIds.
+    }
+    void _setUpEncryptionParams() override {
+        encryptionGlobalParams = encryptionParamsKeyFile(*_keyFilePath);
+    }
+
+    EncryptionKeyDB* keyDb() {
+        return _engine->getEncryptionKeyDB();
+    }
+
+    void insertKey(StringData id) {
+        unsigned char buf[encryption::Key::kLength];
+        // get_key_by_id with pe=nullptr creates the entry if missing and
+        // does NOT poison _encryptors (this is the post-fix behavior).
+        ASSERT_EQ(0, keyDb()->get_key_by_id(id.data(), id.size(), buf, nullptr));
+    }
+};
+
+TEST_F(WiredTigerKVEngineKeyLifecycleTest, GetAllKeyIdsReturnsInsertedKeys) {
+    // Key IDs in the keystore are normally serialized DatabaseNames, so use
+    // plain identifiers (no '.', '/', etc.) that round-trip cleanly through
+    // DatabaseName validation.
+    insertKey("alpha");
+    insertKey("bravo");
+
+    auto ids = keyDb()->getAllKeyIds();
+
+    // The keystore may also contain special entries (master / "/default"),
+    // which the helper excludes. We assert that our two non-special keys
+    // are present and that no special keyId leaks through.
+    ASSERT_TRUE(std::find(ids.begin(), ids.end(), "alpha") != ids.end());
+    ASSERT_TRUE(std::find(ids.begin(), ids.end(), "bravo") != ids.end());
+    for (const auto& id : ids) {
+        ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId(id))
+            << "getAllKeyIds returned special keyId '" << id << "'";
+    }
+}
+
+TEST_F(WiredTigerKVEngineKeyLifecycleTest, FindOrphanedReturnsKeysWithNoIdents) {
+    insertKey("orphan_a");
+    insertKey("orphan_b");
+
+    // No collection has been created in this engine, so no WT ident
+    // references either key. Both must be reported as orphan candidates.
+    auto orphans = _engine->findOrphanedEncryptionKeyIds();
+
+    ASSERT_TRUE(std::find(orphans.begin(), orphans.end(), "orphan_a") != orphans.end())
+        << "orphan_a missing from: " << orphans.size() << " candidates";
+    ASSERT_TRUE(std::find(orphans.begin(), orphans.end(), "orphan_b") != orphans.end())
+        << "orphan_b missing from: " << orphans.size() << " candidates";
+
+    // The scan must never classify special keys as orphan - deleting the
+    // master key would brick the keystore.
+    for (const auto& id : orphans) {
+        ASSERT_FALSE(EncryptionKeyDB::isSpecialKeyId(id))
+            << "findOrphanedEncryptionKeyIds returned special keyId '" << id << "'";
+    }
+}
+
+TEST_F(WiredTigerKVEngineKeyLifecycleTest, KeydbDropKeyIdDeletesKey) {
+    insertKey("tempdb");
+    auto before = keyDb()->getAllKeyIds();
+    ASSERT_TRUE(std::find(before.begin(), before.end(), "tempdb") != before.end());
+
+    ASSERT_TRUE(_engine->keydbDropKeyId("tempdb"));
+
+    auto after = keyDb()->getAllKeyIds();
+    ASSERT_TRUE(std::find(after.begin(), after.end(), "tempdb") == after.end())
+        << "tempdb still in keystore after keydbDropKeyId";
+}
+
+TEST_F(WiredTigerKVEngineKeyLifecycleTest, KeydbDropKeyIdDeletesNonDatabaseNameKey) {
+    // keyIds in the keystore are normally serialized DatabaseNames, but a
+    // corrupted or legacy keystore could carry an entry whose keyId is not
+    // a valid serialized DatabaseName (e.g. "table:foo" - the colon makes
+    // DatabaseName validation reject it). The startup cleanup path drops
+    // such entries by raw keyId; without this they would leak indefinitely.
+    const StringData weirdKey = "table:foo";
+    insertKey(weirdKey);
+
+    auto before = keyDb()->getAllKeyIds();
+    ASSERT_TRUE(std::find(before.begin(), before.end(), std::string{weirdKey}) != before.end());
+
+    ASSERT_TRUE(_engine->keydbDropKeyId(weirdKey));
+
+    auto after = keyDb()->getAllKeyIds();
+    ASSERT_TRUE(std::find(after.begin(), after.end(), std::string{weirdKey}) == after.end())
+        << "'table:foo' still in keystore after keydbDropKeyId";
+}
+
+TEST_F(WiredTigerKVEngineKeyLifecycleTest, KeydbDropKeyIdTrueWhenKeyMissing) {
+    // The cleanup path may legitimately race a key disappearing between
+    // scan and delete; treating a missing key as a successful no-op keeps
+    // the deleted counter accurate.
+    ASSERT_TRUE(_engine->keydbDropKeyId("never_inserted"));
+}
 
 }  // namespace
 }  // namespace mongo

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
@@ -157,6 +157,50 @@ StatusWith<std::string> WiredTigerUtil::getMetadata(WiredTigerSession& session, 
     return _getMetadata(cursor, uri);
 }
 
+boost::optional<std::string> WiredTigerUtil::getEncryptionKeyId(StringData config) {
+    WiredTigerConfigParser parser(config);
+
+    // Get the "encryption" key which contains a nested struct.
+    // Distinguish WT_NOTFOUND (no encryption clause - return boost::none) from
+    // other errors (programmer / corruption errors - assert so we don't silently
+    // misclassify an in-use key as orphaned). See isTableLoggingEnabled() for
+    // the same pattern.
+    WT_CONFIG_ITEM encryptionValue;
+    if (auto retCode = parser.get("encryption", &encryptionValue); retCode != 0) {
+        invariant(retCode == WT_NOTFOUND,
+                  fmt::format("expected WT_NOTFOUND from WT_CONFIG_PARSER::get() but got {} "
+                              "instead while looking up 'encryption' in WT config",
+                              retCode));
+        return boost::none;
+    }
+
+    // Encryption value must be a struct: encryption=(name=percona,keyid="...")
+    if (encryptionValue.type != WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRUCT) {
+        return boost::none;
+    }
+
+    // Parse the nested encryption struct
+    WiredTigerConfigParser encryptionParser(encryptionValue);
+
+    // Get the "keyid" sub-key
+    WT_CONFIG_ITEM keyidValue;
+    if (auto retCode = encryptionParser.get("keyid", &keyidValue); retCode != 0) {
+        invariant(retCode == WT_NOTFOUND,
+                  fmt::format("expected WT_NOTFOUND from WT_CONFIG_PARSER::get() but got {} "
+                              "instead while looking up 'keyid' in encryption sub-config",
+                              retCode));
+        return boost::none;
+    }
+
+    // keyid is typically a STRING type (quoted like keyid="...") but could also be ID type
+    if (keyidValue.type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRING ||
+        keyidValue.type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_ID) {
+        return std::string(keyidValue.str, keyidValue.len);
+    }
+
+    return boost::none;
+}
+
 StatusWith<std::string> WiredTigerUtil::getSourceMetadata(WiredTigerSession& session,
                                                           StringData uri) {
     if (uri.starts_with("file:")) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.h
@@ -214,6 +214,15 @@ public:
     static StatusWith<std::string> getMetadata(WiredTigerSession& session, StringData uri);
 
     /**
+     * Extracts the encryption keyid from a WiredTiger config string.
+     * The keyid is found within the encryption config: encryption=(name=percona,keyid="...")
+     *
+     * @param config The WiredTiger configuration string (from getMetadata or getMetadataCreate)
+     * @return The keyid if found, boost::none otherwise. Empty string indicates master key.
+     */
+    static boost::optional<std::string> getEncryptionKeyId(StringData config);
+
+    /**
      * Gets the source metadata string for collection or index at URI.
      *
      * This is the WiredTiger config string for a specific file. If given a table: URI, it will

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util_test.cpp
@@ -508,6 +508,50 @@ TEST_F(WiredTigerUtilTest, RemoveEncryptionFromConfigString) {
     }
 }
 
+TEST_F(WiredTigerUtilTest, GetEncryptionKeyId) {
+    {  // No encryption clause -> none.
+        auto out = WiredTigerUtil::getEncryptionKeyId(
+            "debug_mode=(table_logging=true,checkpoint_retention=4)");
+        ASSERT_FALSE(out.has_value());
+    }
+    {  // Empty config -> none.
+        auto out = WiredTigerUtil::getEncryptionKeyId("");
+        ASSERT_FALSE(out.has_value());
+    }
+    {  // encryption present but as bare value (not a struct) -> none.
+        auto out = WiredTigerUtil::getEncryptionKeyId("encryption=foo");
+        ASSERT_FALSE(out.has_value());
+    }
+    {  // encryption struct without keyid -> none.
+        auto out = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona)");
+        ASSERT_FALSE(out.has_value());
+    }
+    {  // keyid as quoted STRING.
+        auto out = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"db.foo\")");
+        ASSERT_TRUE(out.has_value());
+        ASSERT_EQUALS(*out, "db.foo");
+    }
+    {  // keyid as unquoted ID.
+        auto out = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=systemkey)");
+        ASSERT_TRUE(out.has_value());
+        ASSERT_EQUALS(*out, "systemkey");
+    }
+    {  // Empty keyid string - special "master key" marker. Caller filters via
+       // EncryptionKeyDB::isSpecialKeyId.
+        auto out = WiredTigerUtil::getEncryptionKeyId("encryption=(name=percona,keyid=\"\")");
+        ASSERT_TRUE(out.has_value());
+        ASSERT_EQUALS(*out, "");
+    }
+    {  // Encryption sandwiched between other options.
+        auto out = WiredTigerUtil::getEncryptionKeyId(
+            "debug_mode=(table_logging=true),"
+            "encryption=(name=AES256-CBC,keyid=\".system\"),"
+            "extensions=[local={entry=mongo_addWiredTigerEncryptors,early_load=true}]");
+        ASSERT_TRUE(out.has_value());
+        ASSERT_EQUALS(*out, ".system");
+    }
+}
+
 TEST_F(WiredTigerUtilTest, GetSanitizedStorageOptionsForSecondaryReplication) {
     {  // Empty storage options.
         auto input = BSONObj();


### PR DESCRIPTION
Deleting a database's encryption key inline during dropDatabase races with checkpoint cleanup: drop-pending idents encrypted with that key may still be accessed when the next checkpoint reaps them, producing WT_NOTFOUND errors and sporadic test failures.

Stop deleting the key from KeyDB in the dropDatabase path. To avoid unbounded accumulation of orphan keys across drops, scan the key database once on server startup - after catalog initialization and before client operations begin - and delete any keys whose database no longer exists and whose idents are no longer referenced (including drop-pending ones).

