### PR TITLE
PSMDB-2090 bazel: bump RBE container images to mongo-SHA 07c5bd008df3

### DIFF
--- a/bazel/platforms/psmdb_rbe_containers.bzl
+++ b/bazel/platforms/psmdb_rbe_containers.bzl
@@ -85,21 +85,21 @@
 
 PSMDB_REMOTE_EXECUTION_CONTAINERS = {
     "amazon_linux_2023": {
-        "container-url": "docker://docker.io/perconalab/psmdb-rbe:amazonlinux-2023-8.0-4f903c5eb2b598da55a69bbc70f786238302aa14",
+        "container-url": "docker://docker.io/perconalab/psmdb-rbe:amazonlinux-2023-8.0-07c5bd008df3acb6e853ebd7c4fefa609c0d03ef",
     },
     "debian12": {
-        "container-url": "docker://docker.io/perconalab/psmdb-rbe:debian-bookworm-8.0-4f903c5eb2b598da55a69bbc70f786238302aa14",
+        "container-url": "docker://docker.io/perconalab/psmdb-rbe:debian-bookworm-8.0-07c5bd008df3acb6e853ebd7c4fefa609c0d03ef",
     },
     "rhel8": {
-        "container-url": "docker://docker.io/perconalab/psmdb-rbe:oraclelinux-8-8.0-4f903c5eb2b598da55a69bbc70f786238302aa14",
+        "container-url": "docker://docker.io/perconalab/psmdb-rbe:oraclelinux-8-8.0-07c5bd008df3acb6e853ebd7c4fefa609c0d03ef",
     },
     "rhel9": {
-        "container-url": "docker://docker.io/perconalab/psmdb-rbe:oraclelinux-9-8.0-4f903c5eb2b598da55a69bbc70f786238302aa14",
+        "container-url": "docker://docker.io/perconalab/psmdb-rbe:oraclelinux-9-8.0-07c5bd008df3acb6e853ebd7c4fefa609c0d03ef",
     },
     "ubuntu22": {
-        "container-url": "docker://docker.io/perconalab/psmdb-rbe:ubuntu-jammy-8.0-4f903c5eb2b598da55a69bbc70f786238302aa14",
+        "container-url": "docker://docker.io/perconalab/psmdb-rbe:ubuntu-jammy-8.0-07c5bd008df3acb6e853ebd7c4fefa609c0d03ef",
     },
     "ubuntu24": {
-        "container-url": "docker://docker.io/perconalab/psmdb-rbe:ubuntu-noble-8.0-4f903c5eb2b598da55a69bbc70f786238302aa14",
+        "container-url": "docker://docker.io/perconalab/psmdb-rbe:ubuntu-noble-8.0-07c5bd008df3acb6e853ebd7c4fefa609c0d03ef",
     },
 }


### PR DESCRIPTION
Point bazel/platforms/psmdb_rbe_containers.bzl at the runner images built from PSMDB-2090_install_deps_mirror_upstream_RBE_container_deps__v8.0 so v8.0 PSMDB builds pick up the libncurses /
percona-release 1.0-33 fixes baked into those images.

Anything in this description will be included in the commit message. Replace or delete this text
before merging. Add links to testing in the comments of the PR.
