### PR TITLE
PSMDB-2091 Pin GpgSign actions to local execution under psmdb_buildfarm

### DIFF
--- a/.bazelrc.psmdb
+++ b/.bazelrc.psmdb
@@ -268,8 +268,11 @@ common:psmdb_buildfarm --spawn_strategy=remote,local
 #                compiles back to local.
 #   CppLink    : pinned local — remote ~2x slowdown vs local.
 #   CppArchive : not pinned — PSMDB sets --skip_archive=True (no actions emitted).
+#   GpgSign    : pinned local — gpg-agent daemon + agent IPC are a poor fit for
+#                hermetic RBE containers; remote execution is >10x slower than local.
 common:psmdb_buildfarm --strategy=CppCompile=remote,local
 common:psmdb_buildfarm --strategy=CppLink=local
+common:psmdb_buildfarm --strategy=GpgSign=local
 
 ################################################################################
 # End of Percona-specific build profiles


### PR DESCRIPTION
GpgSign actions (which sign test extension .so files via gpg-agent) were inheriting the spawn_strategy=remote,local default and running on RBE workers. Those containers are purpose-built for C++ compilation and are a poor fit for gpg-agent daemon + IPC, causing signing to take >10 minutes per action vs. <10 seconds locally. Pin GpgSign=local, matching the existing CppLink=local pattern for the same reason.