### PR TITLE
PSMDB-2071 Use non-strict oplog entry parser in openBackupCursor

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.cpp
@@ -34,6 +34,7 @@ Copyright (C) 2021-present Percona and/or its affiliates. All rights reserved.
 
 #include "mongo/db/dbhelpers.h"
 #include "mongo/db/operation_context.h"
+#include "mongo/db/repl/oplog_entry.h"
 #include "mongo/db/repl/storage_interface.h"
 #include "mongo/db/replication_state_transition_lock_guard.h"
 #include "mongo/db/shard_role/lock_manager/lock_manager_defs.h"
@@ -168,8 +169,8 @@ BackupCursorState WiredTigerBackupCursorHooks::openBackupCursor(
         uassert(50912,
                 str::stream() << "No oplog records were found.",
                 Helpers::getSingleton(opCtx, NamespaceString::kRsOplogNamespace, firstEntry));
-        auto oplogEntry = fassertNoTrace(50918, repl::OplogEntry::parse(firstEntry));
-        oplogStart = oplogEntry.getOpTime();
+        const repl::OplogEntryParserNonStrict oplogEntryParser{firstEntry};
+        oplogStart = oplogEntryParser.getOpTime();
         uassert(50917,
                 str::stream() << "Oplog rolled over while establishing the backup cursor."
                               << " oplogStart: " << oplogStart.toString()


### PR DESCRIPTION
Replace OplogEntry::parse (strict, fatal on error) with OplogEntryParserNonStrict when extracting oplogStart from the first oplog entry. Only opTime is needed, so strict field validation is unnecessary and causes a server crash when the oplog entry was written by an older version with a different schema.