### PR TITLE
PSMDB-2066 Refactor _chooseSyncSource into per-check helpers

### DIFF
--- a/src/mongo/db/repl/initial_sync/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_sync/initial_syncer_fcb.cpp
@@ -1337,17 +1337,9 @@ void InitialSyncerFCB::_shutdownComponent(WithLock lk, Component& component) {
     component->shutdown();
 }
 
-StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
-    auto syncSource = _opts.syncSourceSelector->chooseNewSyncSource(_lastFetched);
-    if (syncSource.empty()) {
-        return Status{ErrorCodes::InvalidSyncSource,
-                      str::stream() << "No valid sync source available. Our last fetched optime: "
-                                    << _lastFetched.toString()};
-    }
+Status InitialSyncerFCB::_checkSyncSourceBuildInfo(WithLock lk, const HostAndPort& syncSource) {
+    Status result = Status::OK();
 
-    StatusWith<HostAndPort> result = syncSource;
-
-    // Check if sync source supports FCBIS.
     executor::RemoteCommandRequest buildInfoRequest(
         syncSource, DatabaseName::kAdmin, BSON("buildInfo" << 1), nullptr);
     auto scheduleResult =
@@ -1410,17 +1402,16 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
             str::stream() << "Failed to schedule buildInfo command to sync source: "
                           << syncSource.toString());
     }
-    // Block until the command is executed.
     (*_attemptExec)->wait(scheduleResult.getValue());
+    return result;
+}
 
-    if (!result.isOK()) {
-        return result;
-    }
+Status InitialSyncerFCB::_checkSyncSourceStorageEngine(WithLock lk, const HostAndPort& syncSource) {
+    Status result = Status::OK();
 
-    // Check if storage engine on the sync source is wiredTiger.
     executor::RemoteCommandRequest serverStatusRequest(
         syncSource, DatabaseName::kAdmin, BSON("serverStatus" << 1), nullptr);
-    scheduleResult =
+    auto scheduleResult =
         (*_attemptExec)
             ->scheduleRemoteCommand(
                 serverStatusRequest,
@@ -1436,7 +1427,6 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
                                             << args.response.status.toString());
                         return;
                     }
-                    // validate storage engine
                     auto storageEngineName =
                         args.response.data["storageEngine"].Obj().getStringField("name");
                     if (storageEngineName != "wiredTiger") {
@@ -1453,17 +1443,17 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
             str::stream() << "Failed to schedule serverStatus command to sync source: "
                           << syncSource.toString());
     }
-    // Block until the command is executed.
     (*_attemptExec)->wait(scheduleResult.getValue());
+    return result;
+}
 
-    if (!result.isOK()) {
-        return result;
-    }
+Status InitialSyncerFCB::_checkSyncSourceStorageParameters(WithLock lk,
+                                                           const HostAndPort& syncSource) {
+    Status result = Status::OK();
 
-    // Check directoryperdb and wiredTigerDirectoryForIndexes via getParameter command.
     executor::RemoteCommandRequest getParameterRequest(
         syncSource, DatabaseName::kAdmin, BSON("getParameter" << "*"), nullptr);
-    scheduleResult =
+    auto scheduleResult =
         (*_attemptExec)
             ->scheduleRemoteCommand(
                 getParameterRequest,
@@ -1479,7 +1469,6 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
                                             << args.response.status.toString());
                         return;
                     }
-                    // validate critical parameters
                     bool dirPerDB =
                         args.response.data.getBoolField("storageGlobalParams.directoryperdb");
                     if (dirPerDB != storageGlobalParams.directoryperdb) {
@@ -1502,8 +1491,7 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
                                                     "wiredTigerDirectoryForIndexes mismatch");
                         return;
                     }
-                    // And BTW, get cursorTimeoutMillis, to fine tune the backup cursor's keep alive
-                    // code
+                    // Get cursorTimeoutMillis to fine-tune the backup cursor keep-alive.
                     _keepAliveInterval =
                         Milliseconds{args.response.data.getIntField("cursorTimeoutMillis") / 2};
                 });
@@ -1512,14 +1500,13 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
             str::stream() << "Failed to schedule getParameter command to sync source: "
                           << syncSource.toString());
     }
-    // Block until the command is executed.
     (*_attemptExec)->wait(scheduleResult.getValue());
+    return result;
+}
 
-    if (!result.isOK()) {
-        return result;
-    }
+Status InitialSyncerFCB::_checkSyncSourceFCV(WithLock lk, const HostAndPort& syncSource) {
+    Status result = Status::OK();
 
-    // Check FCV on the sync source.
     BSONObjBuilder queryBob;
     queryBob.append("find", NamespaceString::kServerConfigurationNamespace.coll());
     auto filterBob = BSONObjBuilder(queryBob.subobjStart("filter"));
@@ -1600,8 +1587,27 @@ StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
             str::stream() << "Failed to join feature compatibility version fetcher to sync source: "
                           << syncSource.toString());
     }
-
     return result;
+}
+
+StatusWith<HostAndPort> InitialSyncerFCB::_chooseSyncSource(WithLock lk) {
+    auto syncSource = _opts.syncSourceSelector->chooseNewSyncSource(_lastFetched);
+    if (syncSource.empty()) {
+        return Status{ErrorCodes::InvalidSyncSource,
+                      str::stream() << "No valid sync source available. Our last fetched optime: "
+                                    << _lastFetched.toString()};
+    }
+
+    if (auto s = _checkSyncSourceBuildInfo(lk, syncSource); !s.isOK())
+        return s;
+    if (auto s = _checkSyncSourceStorageEngine(lk, syncSource); !s.isOK())
+        return s;
+    if (auto s = _checkSyncSourceStorageParameters(lk, syncSource); !s.isOK())
+        return s;
+    if (auto s = _checkSyncSourceFCV(lk, syncSource); !s.isOK())
+        return s;
+
+    return syncSource;
 }
 
 Status InitialSyncerFCB::_invalidSyncSource(WithLock lk,

--- a/src/mongo/db/repl/initial_sync/initial_syncer_fcb.h
+++ b/src/mongo/db/repl/initial_sync/initial_syncer_fcb.h
@@ -421,6 +421,13 @@ private:
                               Seconds denylistDuration,
                               const std::string& context);
 
+    // Sync-source validation helpers called by _chooseSyncSource.
+    // Each returns OK if the source passes the check, or an error status otherwise.
+    Status _checkSyncSourceBuildInfo(WithLock lk, const HostAndPort& syncSource);
+    Status _checkSyncSourceStorageEngine(WithLock lk, const HostAndPort& syncSource);
+    Status _checkSyncSourceStorageParameters(WithLock lk, const HostAndPort& syncSource);
+    Status _checkSyncSourceFCV(WithLock lk, const HostAndPort& syncSource);
+
     void _appendInitialSyncProgressMinimal(WithLock lk, BSONObjBuilder* bob) const;
     BSONObj _getInitialSyncProgress(WithLock lk) const;
 


### PR DESCRIPTION
Extract four validation phases of InitialSyncerFCB::_chooseSyncSource into private methods: _checkSyncSourceBuildInfo, _checkSyncSourceStorageEngine, _checkSyncSourceStorageParameters, and _checkSyncSourceFCV. No behavior change.