### PR TITLE
`InitialSyncerFCB`: remove dead code

### DIFF
--- a/src/mongo/db/repl/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_syncer_fcb.cpp
@@ -129,13 +129,6 @@ namespace repl {
 // Failpoint for initial sync
 extern FailPoint failInitialSyncWithBadHost;
 
-// Failpoint which causes the initial sync function to hang before creating shared data and
-// splitting control flow between the oplog fetcher and the cloners.
-extern FailPoint initialSyncHangBeforeSplittingControlFlow;
-
-// Failpoint which causes the initial sync function to hang before copying databases.
-extern FailPoint initialSyncHangBeforeCopyingDatabases;
-
 // Failpoint which causes the initial sync function to hang before finishing.
 extern FailPoint initialSyncHangBeforeFinish;
 
@@ -262,8 +255,7 @@ InitialSyncerFCB::InitialSyncerFCB(
     StorageInterface* storage,
     ReplicationProcess* replicationProcess,
     const OnCompletionFn& onCompletion)
-    : _fetchCount(0),
-      _opts(opts),
+    : _opts(opts),
       _dataReplicatorExternalState(std::move(dataReplicatorExternalState)),
       _exec(_dataReplicatorExternalState->getSharedTaskExecutor()),
       _clonerExec(_exec),
@@ -272,9 +264,7 @@ InitialSyncerFCB::InitialSyncerFCB(
       _replicationProcess(replicationProcess),
       _backupId(UUID::fromCDR(std::array<unsigned char, 16>{})),
       _cfgDBPath(storageGlobalParams.dbpath),
-      _onCompletion(onCompletion),
-      _createClientFn(
-          [] { return std::make_unique<DBClientConnection>(true /* autoReconnect */); }) {
+      _onCompletion(onCompletion) {
     uassert(ErrorCodes::BadValue, "task executor cannot be null", _exec);
     uassert(ErrorCodes::BadValue, "invalid storage interface", _storage);
     uassert(ErrorCodes::BadValue, "invalid replication process", _replicationProcess);
@@ -424,22 +414,13 @@ void InitialSyncerFCB::_cancelRemainingWork_inlock() {
     }
 
     if (_sharedData) {
-        // We actually hold the required lock, but the lock object itself is not passed through.
-        _clearRetriableError(WithLock::withoutLock());
         stdx::lock_guard<InitialSyncSharedData> lock(*_sharedData);
         _sharedData->setStatusIfOK(
             lock, Status{ErrorCodes::CallbackCanceled, "Initial sync attempt canceled"});
     }
-    if (_client) {
-        _client->shutdownAndDisallowReconnect();
-    }
-    _shutdownComponent_inlock(_applier);
     _shutdownComponent_inlock(_backupCursorFetcher);
-    _shutdownComponent_inlock(_fCVFetcher);
-    _shutdownComponent_inlock(_beginFetchingOpTimeFetcher);
     (*_attemptExec)->shutdown();
     (*_clonerAttemptExec)->shutdown();
-    _attemptCanceled = true;
 }
 
 void InitialSyncerFCB::join() {
@@ -893,8 +874,6 @@ void InitialSyncerFCB::_rollbackCheckerResetCallback(
         std::make_unique<InitialSyncSharedData>(_rollbackChecker->getBaseRBID(),
                                                 _allowedOutageDuration,
                                                 getGlobalServiceContext()->getFastClockSource());
-    _client = _createClientFn();
-
     // schedule $backupCursor on the sync source
     status = _scheduleWorkAndSaveHandle_inlock(
         [this, onCompletionGuard](const executor::TaskExecutor::CallbackArgs& args) {
@@ -914,132 +893,6 @@ void InitialSyncerFCB::_rollbackCheckerResetCallback(
         onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
         return;
     }
-}
-
-void InitialSyncerFCB::_fcvFetcherCallback(const StatusWith<Fetcher::QueryResponse>& result,
-                                           std::shared_ptr<OnCompletionGuard> onCompletionGuard,
-                                           const OpTime& lastOpTime,
-                                           OpTime& beginFetchingOpTime) {
-    stdx::unique_lock<Latch> lock(_mutex);
-    auto status = _checkForShutdownAndConvertStatus_inlock(
-        result.getStatus(), "error while getting the remote feature compatibility version");
-    if (!status.isOK()) {
-        onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
-        return;
-    }
-
-    const auto docs = result.getValue().documents;
-    if (docs.size() > 1) {
-        onCompletionGuard->setResultAndCancelRemainingWork_inlock(
-            lock,
-            Status(ErrorCodes::TooManyMatchingDocuments,
-                   str::stream() << "Expected to receive one feature compatibility version "
-                                    "document, but received: "
-                                 << docs.size() << ". First: " << redact(docs.front())
-                                 << ". Last: " << redact(docs.back())));
-        return;
-    }
-    const auto hasDoc = docs.begin() != docs.end();
-    if (!hasDoc) {
-        onCompletionGuard->setResultAndCancelRemainingWork_inlock(
-            lock,
-            Status(ErrorCodes::IncompatibleServerVersion,
-                   "Sync source had no feature compatibility version document"));
-        return;
-    }
-
-    auto fCVParseSW = FeatureCompatibilityVersionParser::parse(docs.front());
-    if (!fCVParseSW.isOK()) {
-        onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, fCVParseSW.getStatus());
-        return;
-    }
-
-    auto version = fCVParseSW.getValue();
-
-    // Changing the featureCompatibilityVersion during initial sync is unsafe.
-    // (Generic FCV reference): This FCV check should exist across LTS binary versions.
-    if (serverGlobalParams.featureCompatibility.acquireFCVSnapshot().isUpgradingOrDowngrading(
-            version)) {
-        onCompletionGuard->setResultAndCancelRemainingWork_inlock(
-            lock,
-            Status(ErrorCodes::IncompatibleServerVersion,
-                   str::stream() << "Sync source had unsafe feature compatibility version: "
-                                 << multiversion::toString(version)));
-        return;
-    } else {
-        // Since we don't guarantee that we always clone the "admin.system.version" collection first
-        // and collection/index creation can depend on FCV, we set the in-memory FCV value to match
-        // the version on the sync source. We won't persist the FCV on disk nor will we update our
-        // minWireVersion until we clone the actual document.
-        serverGlobalParams.mutableFCV.setVersion(version);
-    }
-
-    if (MONGO_unlikely(initialSyncHangBeforeSplittingControlFlow.shouldFail())) {
-        lock.unlock();
-        LOGV2(128436,
-              "initial sync - initialSyncHangBeforeSplittingControlFlow fail point "
-              "enabled. Blocking until fail point is disabled.");
-        while (MONGO_unlikely(initialSyncHangBeforeSplittingControlFlow.shouldFail()) &&
-               !_isShuttingDown()) {
-            mongo::sleepsecs(1);
-        }
-        lock.lock();
-    }
-
-    // This is where the flow of control starts to split into two parallel tracks:
-    // - oplog fetcher
-    // - data cloning and applier
-    _sharedData =
-        std::make_unique<InitialSyncSharedData>(_rollbackChecker->getBaseRBID(),
-                                                _allowedOutageDuration,
-                                                getGlobalServiceContext()->getFastClockSource());
-    _client = _createClientFn();
-    _initialSyncState = std::make_unique<InitialSyncState>(std::make_unique<AllDatabaseCloner>(
-        _sharedData.get(), _syncSource, _client.get(), _storage, _workerPool));
-
-    _initialSyncState->beginApplyingTimestamp = lastOpTime.getTimestamp();
-    _initialSyncState->beginFetchingTimestamp = beginFetchingOpTime.getTimestamp();
-
-    invariant(_initialSyncState->beginApplyingTimestamp >=
-                  _initialSyncState->beginFetchingTimestamp,
-              str::stream() << "beginApplyingTimestamp was less than beginFetchingTimestamp. "
-                               "beginApplyingTimestamp: "
-                            << _initialSyncState->beginApplyingTimestamp.toBSON()
-                            << " beginFetchingTimestamp: "
-                            << _initialSyncState->beginFetchingTimestamp.toBSON());
-
-    invariant(!result.getValue().documents.empty());
-    LOGV2_DEBUG(128437,
-                2,
-                "Setting begin applying timestamp and begin fetching timestamp",
-                "beginApplyingTimestamp"_attr = _initialSyncState->beginApplyingTimestamp,
-                logAttrs(NamespaceString::kRsOplogNamespace),
-                "beginFetchingTimestamp"_attr = _initialSyncState->beginFetchingTimestamp);
-
-    const auto configResult = _dataReplicatorExternalState->getCurrentConfig();
-    status = configResult.getStatus();
-    if (!status.isOK()) {
-        onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
-        _initialSyncState.reset();
-        return;
-    }
-
-    if (MONGO_unlikely(initialSyncHangBeforeCopyingDatabases.shouldFail())) {
-        lock.unlock();
-        // This could have been done with a scheduleWorkAt but this is used only by JS tests where
-        // we run with multiple threads so it's fine to spin on this thread.
-        // This log output is used in js tests so please leave it.
-        LOGV2(128438,
-              "initial sync - initialSyncHangBeforeCopyingDatabases fail point "
-              "enabled. Blocking until fail point is disabled.");
-        while (MONGO_unlikely(initialSyncHangBeforeCopyingDatabases.shouldFail()) &&
-               !_isShuttingDown()) {
-            mongo::sleepsecs(1);
-        }
-        lock.lock();
-    }
-
-    lock.unlock();
 }
 
 void InitialSyncerFCB::_finishInitialSyncAttempt(const StatusWith<OpTimeAndWallTime>& lastApplied) {
@@ -1148,7 +1001,6 @@ void InitialSyncerFCB::_finishInitialSyncAttempt(const StatusWith<OpTimeAndWallT
         _exec, Status(ErrorCodes::CallbackCanceled, "Initial Sync Attempt Canceled"));
     _clonerAttemptExec = std::make_unique<executor::ScopedTaskExecutor>(
         _clonerExec, Status(ErrorCodes::CallbackCanceled, "Initial Sync Attempt Canceled"));
-    _attemptCanceled = false;
     auto when = (*_attemptExec)->now() + _opts.initialSyncRetryWait;
     auto status = _scheduleWorkAtAndSaveHandle_inlock(
         when,
@@ -1196,10 +1048,6 @@ void InitialSyncerFCB::_finishCallback(StatusWith<OpTimeAndWallTime> lastApplied
         }
     }
 
-    // Any _retryingOperation is no longer active.  This must be done before signalling state
-    // Complete.
-    _retryingOperation = boost::none;
-
     // Completion callback must be invoked outside mutex.
     try {
         onCompletion(lastApplied);
@@ -1241,21 +1089,6 @@ void InitialSyncerFCB::_finishCallback(StatusWith<OpTimeAndWallTime> lastApplied
             mongo::sleepsecs(1);
         }
     }
-}
-
-bool InitialSyncerFCB::_shouldRetryError(WithLock lk, Status status) {
-    if (ErrorCodes::isRetriableError(status)) {
-        stdx::lock_guard<InitialSyncSharedData> sharedDataLock(*_sharedData);
-        return _sharedData->shouldRetryOperation(sharedDataLock, &_retryingOperation);
-    }
-    // The status was OK or some error other than a retriable error, so clear the retriable error
-    // state and indicate that we should not retry.
-    _clearRetriableError(lk);
-    return false;
-}
-
-void InitialSyncerFCB::_clearRetriableError(WithLock lk) {
-    _retryingOperation = boost::none;
 }
 
 Status InitialSyncerFCB::_checkForShutdownAndConvertStatus_inlock(
@@ -1316,28 +1149,6 @@ void InitialSyncerFCB::_cancelHandle_inlock(executor::TaskExecutor::CallbackHand
         return;
     }
     (*_attemptExec)->cancel(handle);
-}
-
-template <typename Component>
-Status InitialSyncerFCB::_startupComponent_inlock(Component& component) {
-    // It is necessary to check if shutdown or attempt cancelling happens before starting a
-    // component; otherwise the component may call a callback function in line which will
-    // cause a deadlock when the callback attempts to obtain the initial syncer mutex.
-    if (_isShuttingDown_inlock() || _attemptCanceled) {
-        component.reset();
-        if (_isShuttingDown_inlock()) {
-            return {ErrorCodes::CallbackCanceled,
-                    "initial syncer shutdown while trying to call startup() on component"};
-        } else {
-            return {ErrorCodes::CallbackCanceled,
-                    "initial sync attempt canceled while trying to call startup() on component"};
-        }
-    }
-    auto status = component->startup();
-    if (!status.isOK()) {
-        component.reset();
-    }
-    return status;
 }
 
 template <typename Component>
@@ -1634,12 +1445,6 @@ namespace {
 
 using namespace fmt::literals;
 constexpr int kBackupCursorFileFetcherRetryAttempts = 10;
-
-BSONObj makeBackupCursorCmd() {
-    BSONArrayBuilder pipelineBuilder;
-    pipelineBuilder << BSON("$backupCursor" << BSONObj());
-    return BSON("aggregate" << 1 << "pipeline" << pipelineBuilder.arr() << "cursor" << BSONObj());
-}
 
 AggregateCommandRequest makeBackupCursorRequest() {
     return {NamespaceString::makeCollectionlessAggregateNSS(DatabaseName::kAdmin),

--- a/src/mongo/db/repl/initial_syncer_fcb.h
+++ b/src/mongo/db/repl/initial_syncer_fcb.h
@@ -400,15 +400,6 @@ private:
                                        std::shared_ptr<OnCompletionGuard> onCompletionGuard);
 
     /**
-     * Callback for the '_fCVFetcher'. A successful response lets us check if the remote node
-     * is in a currently acceptable fCV and if it has a 'targetVersion' set.
-     */
-    void _fcvFetcherCallback(const StatusWith<Fetcher::QueryResponse>& result,
-                             std::shared_ptr<OnCompletionGuard> onCompletionGuard,
-                             const OpTime& lastOpTime,
-                             OpTime& beginFetchingOpTime);
-
-    /**
      * Reports result of current initial sync attempt. May schedule another initial sync attempt
      * depending on shutdown state and whether we've exhausted all initial sync retries.
      */
@@ -439,19 +430,6 @@ private:
     BSONObj _getInitialSyncProgress_inlock() const;
 
     /**
-     * Check if a status is one which means there's a retriable error and we should retry the
-     * current operation, and records whether an operation is currently being retried.  Note this
-     * can only handle one operation at a time (i.e. it should not be used in both parts of the
-     * "split" section of Initial Sync)
-     */
-    bool _shouldRetryError(WithLock lk, Status status);
-
-    /**
-     * Indicates we are no longer handling a retriable error.
-     */
-    void _clearRetriableError(WithLock lk);
-
-    /**
      * Checks the given status (or embedded status inside the callback args) and current data
      * replicator shutdown state. If the given status is not OK or if we are shutting down, returns
      * a new error status that should be passed to _finishCallback. The reason in the new error
@@ -480,14 +458,6 @@ private:
      * Cancels task executor callback handle if not null.
      */
     void _cancelHandle_inlock(executor::TaskExecutor::CallbackHandle handle);
-
-    /**
-     * Starts up component and checks initial syncer's shutdown state at the same time.
-     * If component's startup() fails, resets 'component' (which is assumed to be a unique_ptr
-     * to the component type).
-     */
-    template <typename Component>
-    Status _startupComponent_inlock(Component& component);
 
     /**
      * Shuts down component if not null.
@@ -525,9 +495,6 @@ private:
     void _restoreStorageLocation(stdx::unique_lock<Latch>& lock, OperationContext* opCtx);
 
     Status _killBackupCursor_inlock();
-
-    // Counts how many documents have been refetched from the source in the current batch.
-    AtomicWord<unsigned> _fetchCount;
 
     //
     // All member variables are labeled with one of the following codes indicating the
@@ -598,17 +565,10 @@ private:
     // Handle returned from RollbackChecker::reset().
     RollbackChecker::CallbackHandle _getBaseRollbackIdHandle;  // (M)
 
-    // The operation, if any, currently being retried because of a network error.
-    InitialSyncSharedData::RetryableOperation _retryingOperation;  // (M)
-
-    std::unique_ptr<InitialSyncState> _initialSyncState;   // (M)
-    std::unique_ptr<Fetcher> _beginFetchingOpTimeFetcher;  // (S)
-    std::unique_ptr<Fetcher> _fCVFetcher;                  // (S)
-    std::unique_ptr<Fetcher> _backupCursorFetcher;         // (S)
-    std::unique_ptr<MultiApplier> _applier;                // (M)
-    HostAndPort _syncSource;                               // (M)
-    std::unique_ptr<DBClientConnection> _client;           // (M)
-    OpTime _lastFetched;                                   // (MX)
+    std::unique_ptr<InitialSyncState> _initialSyncState;  // (M)
+    std::unique_ptr<Fetcher> _backupCursorFetcher;        // (S)
+    HostAndPort _syncSource;                              // (M)
+    OpTime _lastFetched;                                  // (MX)
 
     // The last applied optime and wall clock time.
     // Updated with the value from the _oplogEnd when we finish cloning batch of files returned by
@@ -623,9 +583,6 @@ private:
     // Current initial syncer state. See comments for State enum class for details.
     State _state = State::kPreStart;  // (M)
 
-    // Used to create the DBClientConnection for the cloners
-    CreateClientFn _createClientFn;
-
     // Contains stats on the current initial sync request (includes all attempts).
     // To access these stats in a user-readable format, use getInitialSyncProgress().
     Stats _stats;  // (M)
@@ -636,9 +593,6 @@ private:
     // Amount of time an outage is allowed to continue before the initial sync attempt is marked
     // as failed.
     Milliseconds _allowedOutageDuration;  // (M)
-
-    // The initial sync attempt has been canceled
-    bool _attemptCanceled = false;  // (X)
 
     // Conditional variable to wait for end of storage change
     stdx::condition_variable _inStorageChangeCondition;  // (M)


### PR DESCRIPTION
The patch removes:
- unused methods
- unused data fields as the code that assigns values to them
- unused failpoints