### PR TITLE
PSMDB-2108 `InitialSyncerFCB`: fix GlobalLock intent for featureFlagIntentRegistration=true

### DIFF
--- a/src/mongo/db/repl/initial_sync/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_sync/initial_syncer_fcb.cpp
@@ -2156,7 +2156,10 @@ void InitialSyncerFCB::_switchToDownloadedCallback(
         128406, 2, "Retrieved names of local files", "number"_attr = bfiles.getValue().size());
     _localFiles = bfiles.getValue();
 
-    Lock::GlobalLock lk(opCtx.get(), MODE_X);
+    Lock::GlobalLock lk(opCtx.get(),
+                        MODE_X,
+                        Lock::GlobalLockOptions{
+                            .explicitIntent = rss::consensus::IntentRegistry::Intent::LocalWrite});
     // retrieve the current on-disk replica set configuration
     auto* rs = repl::ReplicationCoordinator::get(opCtx->getServiceContext());
     invariant(rs);
@@ -2261,7 +2264,11 @@ void InitialSyncerFCB::_executeRecovery(
 
     auto opCtx = makeOpCtx();
     ScopeGuard storageGuard([this, &lock, opCtx = opCtx.get()] {
-        Lock::GlobalLock lk(opCtx, MODE_X);
+        Lock::GlobalLock lk(
+            opCtx,
+            MODE_X,
+            Lock::GlobalLockOptions{.explicitIntent =
+                                        rss::consensus::IntentRegistry::Intent::LocalWrite});
         // Restore storage location back to original dbpath in case of any failure
         _restoreStorageLocation(lock, opCtx);
     });
@@ -2323,7 +2330,11 @@ void InitialSyncerFCB::_switchToDummyToDBPathCallback(
 
     {
         auto opCtx = makeOpCtx();
-        Lock::GlobalLock lk(opCtx.get(), MODE_X);
+        Lock::GlobalLock lk(
+            opCtx.get(),
+            MODE_X,
+            Lock::GlobalLockOptions{.explicitIntent =
+                                        rss::consensus::IntentRegistry::Intent::LocalWrite});
         ScopeGuard storageGuard([this, &lock, opCtx = opCtx.get()] {
             // Restore storage location back to original dbpath in case of any failure
             _restoreStorageLocation(lock, opCtx);

--- a/src/mongo/db/repl/initial_sync/initial_syncer_fcb.h
+++ b/src/mongo/db/repl/initial_sync/initial_syncer_fcb.h
@@ -478,7 +478,7 @@ private:
     /**
      * Switches the storage location to 'newLocation'.
      * - Callers must ensure that _mutex is NOT held.
-     * - Caller must hold a GlobalLock (MODE_X) while calling this method.
+     * - Caller must hold a GlobalLock (MODE_X) with LocalWrite intent while calling this method.
      */
     Status _switchStorageLocation(OperationContext* opCtx,
                                   const std::string& newLocation,
@@ -487,7 +487,7 @@ private:
     /**
      * Restores the original storage location. Must be called with _mutex held.
      * - Temporarily unlocks and relocks the provided lock.
-     * - Caller must hold a GlobalLock (MODE_X) while calling this method.
+     * - Caller must hold a GlobalLock (MODE_X) with LocalWrite intent while calling this method.
      * - Logs fatal on failure.
      */
     void _restoreStorageLocation(std::unique_lock<std::mutex>& lock, OperationContext* opCtx);


### PR DESCRIPTION
With `featureFlagIntentRegistration` enabled by default, `Lock::GlobalLock` acquisitions in non-shared mode register `Intent::Write` with the IntentRegistry. `Intent::Write` checks `canAcceptWritesFor_UNSAFE` against primary enforcement, which is active from server startup. During FCBIS initial sync the node is in STARTUP2 state (not primary), so those lock acquisitions threw `NotWritablePrimary`, causing FCBIS to fail before the node could become a secondary.

The fix is to pass `explicitIntent = LocalWrite` to the three `GlobalLock(MODE_X)` calls in the FCBIS storage-switch callbacks (`_switchToDownloadedCallback`, `_executeRecovery` ScopeGuard, `_switchToDummyToDBPathCallback`). `LocalWrite` is the correct intent for internal storage-engine operations that must proceed regardless of primary status, matching the behaviour `DBLock` already provides automatically when `!opCtx->writesAreReplicated()`.

`DBLock` cannot replace `GlobalLock(MODE_X)` here because it only acquires the global resource in MODE_IX, which would fail the `isW()` invariant inside `_switchStorageLocation`.