### PR TITLE
PSMDB-1990 Avoid `mongod` crash in tests

### DIFF
--- a/jstests/product_limits/libs/long_pipelines.js
+++ b/jstests/product_limits/libs/long_pipelines.js
@@ -42,6 +42,9 @@ export class WorkloadManyCollectionsInLookupBushy extends LongPipelineWorkload {
         // Too many $lookups result in "errmsg" : "BSONObj size: 53097740 (0x32A350C) is invalid.
         // Size must be between 0 and 16793600(16MB) First element: slots: \"$$RESULT=s7202 env: {
         // }\"",
+        //
+        // TODO: revert the value back to 500 after the stack overflow has been
+        // fixed. For more details, please see the commit message.
         return Math.min(250, super.scale());
     }
 

--- a/jstests/product_limits/libs/long_pipelines.js
+++ b/jstests/product_limits/libs/long_pipelines.js
@@ -42,7 +42,7 @@ export class WorkloadManyCollectionsInLookupBushy extends LongPipelineWorkload {
         // Too many $lookups result in "errmsg" : "BSONObj size: 53097740 (0x32A350C) is invalid.
         // Size must be between 0 and 16793600(16MB) First element: slots: \"$$RESULT=s7202 env: {
         // }\"",
-        return Math.min(500, super.scale());
+        return Math.min(250, super.scale());
     }
 
     pipeline() {


### PR DESCRIPTION
Running the `DatasetManyCollections.WorkloadManyCollectionsLookupBushy` test from the `product_limits` suite resulted in a `mongod` crash due to a stack overflow while processing a long aggregation pipeline.

Since the issue does not reproduce in the `master` branch at the time of writing (commit `3d02afa7e1c`), we expect upstream to backport the fix into branch `v8.3`. We don't want to interfere with upstream by devising our own fix or doing the backport ourselves, in order to minimize the potential for future merge conflicts. Instead, we temporarily halve the pipeline length so that the stack overflow does not happen.

After upstream has fixed branch `v8.3`, this commit can be reverted.