### PR TITLE
PSMDB-2038 Expose userToDN cache metrics via serverStatus

### DIFF
--- a/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
+++ b/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
@@ -8,167 +8,328 @@
  */
 import {createAdminUser} from "jstests/ldapauthz/_setup.js";
 
-(function() {
-"use strict";
+(function () {
+    "use strict";
 
-load("jstests/ldapauthz/_check.js");
+    load("jstests/ldapauthz/_check.js");
 
-const username = "exttestro";
-const userpwd = "exttestro9a5S";
-const nameToDn = function(name) {
-    return "cn=" + name + ",dc=percona,dc=com";
-};
-
-const ldapQueryMapping =
-    '[{match: "(.+)", ldapQuery: "dc=percona,dc=com??sub?(&(objectClass=organizationalPerson)(sn={0}))"}]';
-const substMapping = '[{match: "(.+)", substitution: "cn={0},dc=percona,dc=com"}]';
-const brokenMapping = '[{match: "(.+)", substitution: "cn={0},dc=WRONG,dc=com"}]';
-
-function baseMongodOpts(extraSetParams) {
-    // Use a short user cache invalidation interval so that each auth attempt after
-    // a setParameter change re-resolves the DN via mapUserToDN() instead of being
-    // served from the $external authorization user cache.
-    var setParameter = Object.assign({
-        authenticationMechanisms: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-1",
-        ldapUserCacheInvalidationInterval: 1,
-        ldapShouldRefreshUserCacheEntries: false,
-    },
-                                     extraSetParams || {});
-    return {
-        auth: "",
-        ldapServers: TestData.ldapServers,
-        ldapTransportSecurity: "none",
-        ldapBindMethod: "simple",
-        ldapQueryUser: TestData.ldapQueryUser,
-        ldapQueryPassword: TestData.ldapQueryPassword,
-        ldapAuthzQueryTemplate: TestData.ldapAuthzQueryTemplate,
-        ldapUserToDNMapping: ldapQueryMapping,
-        setParameter: setParameter,
+    const username = "exttestro";
+    const userpwd = "exttestro9a5S";
+    const nameToDn = function (name) {
+        return "cn=" + name + ",dc=percona,dc=com";
     };
-}
 
-function authLDAPUser(conn) {
-    var db = conn.getDB("$external");
-    var ok = db.auth({user: username, pwd: userpwd, mechanism: "PLAIN"});
-    if (ok) {
-        checkConnectionStatus(username, db.runCommand({connectionStatus: 1}), nameToDn);
-        db.logout();
+    const ldapQueryMapping =
+        '[{match: "(.+)", ldapQuery: "dc=percona,dc=com??sub?(&(objectClass=organizationalPerson)(sn={0}))"}]';
+    const substMapping = '[{match: "(.+)", substitution: "cn={0},dc=percona,dc=com"}]';
+    const brokenMapping = '[{match: "(.+)", substitution: "cn={0},dc=WRONG,dc=com"}]';
+
+    function baseMongodOpts(extraSetParams) {
+        // Use a short user cache invalidation interval so that each auth attempt after
+        // a setParameter change re-resolves the DN via mapUserToDN() instead of being
+        // served from the $external authorization user cache.
+        var setParameter = Object.assign(
+            {
+                authenticationMechanisms: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-1",
+                ldapUserCacheInvalidationInterval: 1,
+                ldapShouldRefreshUserCacheEntries: false,
+            },
+            extraSetParams || {},
+        );
+        return {
+            auth: "",
+            ldapServers: TestData.ldapServers,
+            ldapTransportSecurity: "none",
+            ldapBindMethod: "simple",
+            ldapQueryUser: TestData.ldapQueryUser,
+            ldapQueryPassword: TestData.ldapQueryPassword,
+            ldapAuthzQueryTemplate: TestData.ldapAuthzQueryTemplate,
+            ldapUserToDNMapping: ldapQueryMapping,
+            setParameter: setParameter,
+        };
     }
-    return ok;
-}
 
-function setParam(conn, paramObj) {
-    var adminDb = conn.getDB("admin");
-    assert(adminDb.auth({user: "admin", pwd: "password"}));
-    assert.commandWorked(adminDb.adminCommand(Object.assign({setParameter: 1}, paramObj)));
-    adminDb.logout();
-    // Wait for the $external user cache to be invalidated (interval is 1s)
-    // so the next auth attempt re-resolves the DN via mapUserToDN().
-    sleep(2000);
-}
+    function authLDAPUser(conn, check = true) {
+        var db = conn.getDB("$external");
+        var ok = db.auth({user: username, pwd: userpwd, mechanism: "PLAIN"});
+        if (ok) {
+            if (check) {
+                checkConnectionStatus(username, db.runCommand({connectionStatus: 1}), nameToDn);
+            }
+            db.logout();
+        }
+        return ok;
+    }
 
-function getParam(conn, paramName) {
-    var adminDb = conn.getDB("admin");
-    assert(adminDb.auth({user: "admin", pwd: "password"}));
-    var cmd = {getParameter: 1};
-    cmd[paramName] = 1;
-    var res = adminDb.adminCommand(cmd);
-    assert.commandWorked(res);
-    adminDb.logout();
-    return res[paramName];
-}
+    // The authLDAPUserNoCheck was introduced because authLDAPUser can generate unpredictable number
+    // of cache hits. We use authLDAPUserNoCheck in those places where we have asserts on the number
+    // of cache hits.
+    function authLDAPUserNoCheck(conn) {
+        return authLDAPUser(conn, false);
+    }
 
-// ------------------------------------------------------------------
-// Instance 1: Cache enabled with default params, ldapQuery mapping
-// ------------------------------------------------------------------
-{
-    jsTestLog("Starting instance with default cache params and ldapQuery mapping");
+    function setParam(conn, paramObj) {
+        var adminDb = conn.getDB("admin");
+        assert(adminDb.auth({user: "admin", pwd: "password"}));
+        assert.commandWorked(adminDb.adminCommand(Object.assign({setParameter: 1}, paramObj)));
+        adminDb.logout();
+        // Wait for the $external user cache to be invalidated (interval is 1s)
+        // so the next auth attempt re-resolves the DN via mapUserToDN().
+        sleep(2000);
+    }
 
-    var conn = MongoRunner.runMongod(baseMongodOpts());
-    assert(conn, "Cannot start mongod instance");
+    function getParam(conn, paramName) {
+        var adminDb = conn.getDB("admin");
+        assert(adminDb.auth({user: "admin", pwd: "password"}));
+        var cmd = {getParameter: 1};
+        cmd[paramName] = 1;
+        var res = adminDb.adminCommand(cmd);
+        assert.commandWorked(res);
+        adminDb.logout();
+        return res[paramName];
+    }
 
-    createAdminUser(conn);
+    function getServerStatus(conn) {
+        var adminDb = conn.getDB("admin");
+        assert(adminDb.auth({user: "admin", pwd: "password"}));
+        var res = assert.commandWorked(adminDb.adminCommand({serverStatus: 1}));
+        adminDb.logout();
+        return res;
+    }
 
-    jsTestLog("Test: Auth with cache enabled (first call)");
-    assert(authLDAPUser(conn), "First auth should succeed");
+    function assertCacheStats(stats, expected, msg) {
+        assert(stats.hasOwnProperty("ldap"), "serverStatus.ldap missing");
+        assert(stats.ldap.hasOwnProperty("userToDNCache"), "serverStatus.ldap.userToDNCache missing");
+        var cache = stats.ldap.userToDNCache;
+        for (var [key, val] of Object.entries(expected)) {
+            assert.eq(cache[key], val, msg + ": field " + key, {cache});
+        }
+    }
 
-    jsTestLog("Test: Auth with cache enabled (second call, cache hit)");
-    assert(authLDAPUser(conn), "Second auth should succeed (cache hit)");
+    // ------------------------------------------------------------------
+    // Instance 1: Cache enabled with default params, ldapQuery mapping
+    // ------------------------------------------------------------------
+    {
+        jsTestLog("Starting instance with default cache params and ldapQuery mapping");
 
-    jsTestLog("Test: getParameter returns default cache values");
-    assert.eq(getParam(conn, "ldapUserToDNCacheTTLSeconds"), 30);
-    assert.eq(getParam(conn, "ldapUserToDNCacheSize"), 10000);
+        var conn = MongoRunner.runMongod(baseMongodOpts());
+        assert(conn, "Cannot start mongod instance");
 
-    jsTestLog("Test: Invalidation on ldapUserToDNMapping change to substitution mode");
-    setParam(conn, {ldapUserToDNMapping: substMapping});
-    assert(authLDAPUser(conn), "Auth should succeed with substitution mapping");
+        createAdminUser(conn);
 
-    jsTestLog("Test: Invalidation on ldapUserToDNMapping change to broken mapping");
-    setParam(conn, {ldapUserToDNMapping: brokenMapping});
-    assert(!authLDAPUser(conn),
-           "Auth should fail with broken mapping (proves cache was invalidated)");
+        jsTestLog("Test: Auth with cache enabled (first call)");
+        assert(authLDAPUserNoCheck(conn), "First auth should succeed");
 
-    jsTestLog("Test: Restore original ldapQuery mapping");
-    setParam(conn, {ldapUserToDNMapping: ldapQueryMapping});
-    assert(authLDAPUser(conn), "Auth should succeed after restoring ldapQuery mapping");
+        // Each successful auth calls mapUserToDN twice: once for the LDAP bind (sasl session)
+        // and once inside queryUserRoles.
 
-    // To prove TTL/size changes actually invalidate the DN cache, we populate the
-    // cache with the correct mapping, then change the cache parameter AND switch to
-    // the broken mapping in the same batch. If the cache were NOT invalidated by the
-    // parameter change, the old cached DN would still be used and auth would succeed.
-    // Auth failing proves the parameter change cleared the cache.
+        // Ensure first auth = 1 miss + 1 hit
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: true,
+                maxSize: 10000,
+                ttlSeconds: 30,
+                currentSize: 1,
+                misses: 1,
+                hits: 1,
+                invalidations: 0,
+            },
+            "after first auth (miss+hit)",
+        );
 
-    jsTestLog("Test: ldapUserToDNCacheTTLSeconds change invalidates the DN cache");
-    setParam(conn, {ldapUserToDNMapping: ldapQueryMapping});
-    assert(authLDAPUser(conn), "Auth should succeed to populate cache");
-    setParam(conn, {ldapUserToDNCacheTTLSeconds: 60, ldapUserToDNMapping: brokenMapping});
-    assert(!authLDAPUser(conn), "Auth should fail — proves TTL change invalidated the DN cache");
+        // Wait for the $external user cache to expire so the second auth re-resolves
+        // the DN via mapUserToDN() and exercises the cache hit path.
+        sleep(2000);
 
-    jsTestLog("Test: ldapUserToDNCacheTTLSeconds=0 disables the DN cache");
-    setParam(conn, {ldapUserToDNCacheTTLSeconds: 0, ldapUserToDNMapping: ldapQueryMapping});
-    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (TTL=0)");
+        jsTestLog("Test: Auth with cache enabled (second call, cache hit)");
+        assert(authLDAPUserNoCheck(conn), "Second auth should succeed (cache hit)");
 
-    setParam(conn, {ldapUserToDNCacheTTLSeconds: 30});
+        jsTestLog(
+            "Test: serverStatus.ldap.userToDNCache fields are present and correct after first auth (miss+hit) and second auth (two hits)",
+        );
 
-    jsTestLog("Test: ldapUserToDNCacheSize change invalidates the DN cache");
-    assert(authLDAPUser(conn), "Auth should succeed to populate cache");
-    setParam(conn, {ldapUserToDNCacheSize: 1, ldapUserToDNMapping: brokenMapping});
-    assert(!authLDAPUser(conn), "Auth should fail — proves size change invalidated the DN cache");
+        // Second auth = 2 hits (no additional misses because the user is cached after the first
+        // auth)
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: true,
+                maxSize: 10000,
+                ttlSeconds: 30,
+                currentSize: 1,
+                misses: 1,
+                hits: 3,
+                invalidations: 0,
+            },
+            "after first auth (miss+hit) and second auth (two hits)",
+        );
 
-    jsTestLog("Test: ldapUserToDNCacheSize=0 disables the DN cache");
-    setParam(conn, {ldapUserToDNCacheSize: 0, ldapUserToDNMapping: ldapQueryMapping});
-    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (size=0)");
+        jsTestLog("Test: getParameter returns default cache values");
+        assert.eq(getParam(conn, "ldapUserToDNCacheTTLSeconds"), 30);
+        assert.eq(getParam(conn, "ldapUserToDNCacheSize"), 10000);
 
-    setParam(conn, {ldapUserToDNCacheSize: 10000});
+        jsTestLog("Test: Invalidation on ldapUserToDNMapping change to substitution mode");
+        setParam(conn, {ldapUserToDNMapping: substMapping});
 
-    MongoRunner.stopMongod(conn);
-}
+        jsTestLog("Test: hit/miss counters reset to zero immediately after invalidation (before any new auth)");
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: true,
+                invalidations: 1,
+                hits: 0,
+                misses: 0,
+            },
+            "counters reset right after invalidation",
+        );
 
-// ------------------------------------------------------------------
-// Instance 2: Cache disabled at startup via TTL=0
-// ------------------------------------------------------------------
-{
-    jsTestLog("Test: Auth works with cache disabled at startup (TTL=0)");
+        assert(authLDAPUser(conn), "Auth should succeed with substitution mapping");
 
-    var conn = MongoRunner.runMongod(baseMongodOpts({ldapUserToDNCacheTTLSeconds: 0}));
-    assert(conn, "Cannot start mongod instance");
+        jsTestLog("Test: invalidations counter incremented, one miss + one hit from single auth");
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: true,
+                invalidations: 1,
+                hits: 1,
+                misses: 1,
+            },
+            "after first auth post-invalidation (1 miss + 1 hit from two mapUserToDN calls)",
+        );
 
-    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (TTL=0)");
+        jsTestLog("Test: Invalidation on ldapUserToDNMapping change to broken mapping");
+        setParam(conn, {ldapUserToDNMapping: brokenMapping});
+        assert(!authLDAPUser(conn), "Auth should fail with broken mapping (proves cache was invalidated)");
+        assertCacheStats(
+            getServerStatus(conn),
+            {enabled: true, invalidations: 2, hits: 0, misses: 1},
+            "invalidation should happen on ldapUserToDNMapping change",
+        );
 
-    MongoRunner.stopMongod(conn);
-}
+        jsTestLog("Test: Restore original ldapQuery mapping");
+        setParam(conn, {ldapUserToDNMapping: ldapQueryMapping});
+        assert(authLDAPUser(conn), "Auth should succeed");
 
-// ------------------------------------------------------------------
-// Instance 3: Cache disabled at startup via size=0
-// ------------------------------------------------------------------
-{
-    jsTestLog("Test: Auth works with cache disabled at startup (size=0)");
+        jsTestLog("Test: ldapUserToDNCacheTTLSeconds change invalidates the DN cache");
+        setParam(conn, {ldapUserToDNCacheTTLSeconds: 60});
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: true,
+                invalidations: 4,
+                hits: 0,
+                misses: 0,
+            },
+            "invalidation should happen on ldapUserToDNCacheTTLSeconds change",
+        );
 
-    var conn = MongoRunner.runMongod(baseMongodOpts({ldapUserToDNCacheSize: 0}));
-    assert(conn, "Cannot start mongod instance");
+        jsTestLog("Test: ldapUserToDNCacheTTLSeconds=0 disables the DN cache");
+        setParam(conn, {ldapUserToDNCacheTTLSeconds: 0});
+        assert(authLDAPUser(conn), "Auth should succeed with cache disabled (TTL=0)");
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: false,
+                invalidations: 5,
+                ttlSeconds: 0,
+                hits: 0,
+                misses: 0,
+            },
+            "ldapUserToDNCacheTTLSeconds=0 disables the DN cache",
+        );
 
-    assert(authLDAPUser(conn), "Auth should succeed with cache disabled (size=0)");
+        // Restore original value
+        setParam(conn, {ldapUserToDNCacheTTLSeconds: 30});
 
-    MongoRunner.stopMongod(conn);
-}
+        jsTestLog("Test: ldapUserToDNCacheSize change invalidates the DN cache");
+        assert(authLDAPUser(conn), "Auth should succeed to populate cache");
+        setParam(conn, {ldapUserToDNCacheSize: 1});
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: true,
+                invalidations: 7,
+                hits: 0,
+                misses: 0,
+            },
+            "invalidation should happen on ldapUserToDNCacheTTLSeconds change",
+        );
+
+        jsTestLog("Test: ldapUserToDNCacheSize=0 disables the DN cache");
+        setParam(conn, {ldapUserToDNCacheSize: 0});
+        assert(authLDAPUser(conn), "Auth should succeed with cache disabled (size=0)");
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: false,
+                invalidations: 8,
+                maxSize: 0,
+                hits: 0,
+                misses: 0,
+            },
+            "ldapUserToDNCacheSize=0 disables the DN cache",
+        );
+
+        // Restore original value
+        setParam(conn, {ldapUserToDNCacheSize: 10000});
+
+        MongoRunner.stopMongod(conn);
+    }
+
+    // ------------------------------------------------------------------
+    // Instance 2: Cache disabled at startup via TTL=0
+    // ------------------------------------------------------------------
+    {
+        jsTestLog("Test: Auth works with cache disabled at startup (TTL=0)");
+
+        var conn = MongoRunner.runMongod(baseMongodOpts({ldapUserToDNCacheTTLSeconds: 0}));
+        assert(conn, "Cannot start mongod instance");
+
+        createAdminUser(conn);
+        assert(authLDAPUser(conn), "Auth should succeed with cache disabled (TTL=0)");
+
+        jsTestLog("Test: serverStatus.ldap.userToDNCache reports enabled=false and zero counters when TTL=0");
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: false,
+                ttlSeconds: 0,
+                hits: 0,
+                misses: 0,
+                invalidations: 0,
+            },
+            "cache disabled via TTL=0",
+        );
+
+        MongoRunner.stopMongod(conn);
+    }
+
+    // ------------------------------------------------------------------
+    // Instance 3: Cache disabled at startup via size=0
+    // ------------------------------------------------------------------
+    {
+        jsTestLog("Test: Auth works with cache disabled at startup (size=0)");
+
+        var conn = MongoRunner.runMongod(baseMongodOpts({ldapUserToDNCacheSize: 0}));
+        assert(conn, "Cannot start mongod instance");
+
+        createAdminUser(conn);
+        assert(authLDAPUser(conn), "Auth should succeed with cache disabled (size=0)");
+
+        jsTestLog("Test: serverStatus.ldap.userToDNCache reports enabled=false and zero counters when size=0");
+        assertCacheStats(
+            getServerStatus(conn),
+            {
+                enabled: false,
+                maxSize: 0,
+                hits: 0,
+                misses: 0,
+                invalidations: 0,
+            },
+            "cache disabled via size=0",
+        );
+
+        MongoRunner.stopMongod(conn);
+    }
 })();

--- a/src/mongo/db/ldap/BUILD.bazel
+++ b/src/mongo/db/ldap/BUILD.bazel
@@ -44,6 +44,7 @@ mongo_cc_library(
         "//src/mongo:base",
         "//src/mongo/db:ldap_options",
         "//src/mongo/db:service_context",
+        "//src/mongo/db/commands:server_status_core",
         "//src/mongo/db/ldap:ldap_manager_base",
         "//src/mongo/util:background_job",
     ],

--- a/src/mongo/db/ldap/ldap_manager.h
+++ b/src/mongo/db/ldap/ldap_manager.h
@@ -34,6 +34,7 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include <memory>
 
 #include "mongo/base/status.h"
+#include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/db/auth/role_name.h"
 #include "mongo/db/auth/user_name.h"
 #include "mongo/db/service_context.h"
@@ -64,6 +65,9 @@ public:
 
     // Invalidate all cached userToDN mapping results.
     virtual void invalidateUserToDNCache() = 0;
+
+    // Append userToDN cache metrics to a BSONObjBuilder under the "userToDNCache" key.
+    virtual void appendUserToDNCacheStats(BSONObjBuilder& bob) const = 0;
 };
 
 }  // namespace mongo

--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -45,8 +45,10 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include <fmt/format.h>
 #include <sasl/sasl.h>
 
+#include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/bson/json.h"
 #include "mongo/db/client.h"
+#include "mongo/db/commands/server_status.h"
 #include "mongo/db/ldap_options.h"
 #include "mongo/logv2/log.h"
 #include "mongo/util/background.h"
@@ -657,8 +659,8 @@ Status LDAPManagerImpl::initialize() {
         ber_set_option(nullptr, LBER_OPT_LOG_PRINT_FN, reinterpret_cast<const void*>(cb_log));
     }
 
-    // Initialize _userToDNCache and friends on startup
-    invalidateUserToDNCache();
+    // Initialize _userToDNCache and friends on startup.
+    _userToDNCacheHolder = std::make_shared<UserToDNCacheHolder>();
 
     return Status::OK();
 }
@@ -905,17 +907,19 @@ std::string substituteFromMatch(const std::string& stempl,
 
 }  // namespace
 
-LDAPManagerImpl::UserToDNCacheHolder::UserToDNCacheHolder()
+LDAPManagerImpl::UserToDNCacheHolder::UserToDNCacheHolder(long long invalidations)
     : size(ldapGlobalParams.ldapUserToDNCacheSize.load()),
       ttl(ldapGlobalParams.ldapUserToDNCacheTTLSeconds.load()),
       enabled(ttl > 0 && size > 0),
       mapping(fromjson(ldapGlobalParams.ldapUserToDNMapping.get())),
+      invalidations(invalidations),
       cache(static_cast<std::size_t>(std::max(size, 0))) {}
 
 void LDAPManagerImpl::invalidateUserToDNCache() {
-    // Atomically replace instance of UserToDNCacheHolder
-    // the new instance is current snapshot of the ldapGlobalParams
-    _userToDNCacheHolder = std::make_shared<UserToDNCacheHolder>();
+    // Atomically replace the holder and bump invalidations under one lock so
+    // serverStatus readers observe a coherent cache-generation snapshot.
+    auto guard = _userToDNCacheHolder.synchronize();
+    *guard = std::make_shared<UserToDNCacheHolder>((*guard)->invalidations + 1);
 }
 
 Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
@@ -933,9 +937,11 @@ Status LDAPManagerImpl::mapUserToDN(const std::string& user, std::string& out) {
             if (Date_t::now() - it->second.insertedAt < Seconds(cache->ttl)) {
                 cache->cache.promote(it);
                 out = it->second.dn;
+                cache->hits.fetchAndAdd(1);
                 return Status::OK();
             }
         }
+        cache->misses.fetchAndAdd(1);
     }
 
     // Perform the actual mapping (inner mutex NOT held during potential LDAP queries
@@ -1106,7 +1112,46 @@ Status LDAPbind(LDAP* ld, const std::string& usr, const std::string& psw) {
     return LDAPbind(ld, usr.c_str(), psw.c_str());
 }
 
+void LDAPManagerImpl::appendUserToDNCacheStats(BSONObjBuilder& bob) const {
+    std::shared_ptr<UserToDNCacheHolder> holder = *_userToDNCacheHolder;
+
+    BSONObjBuilder sub(bob.subobjStart("userToDNCache"));
+    sub.append("enabled", holder->enabled);
+    sub.append("maxSize", holder->size);
+    {
+        std::lock_guard lock(holder->mutex);
+        sub.append("currentSize", static_cast<long long>(holder->cache.size()));
+    }
+    sub.append("ttlSeconds", holder->ttl);
+    sub.append("hits", holder->hits.load());
+    sub.append("misses", holder->misses.load());
+    sub.append("invalidations", holder->invalidations);
+}
+
 namespace {
+
+class LDAPServerStatusSection : public ServerStatusSection {
+public:
+    using ServerStatusSection::ServerStatusSection;
+
+    bool includeByDefault() const override {
+        return true;
+    }
+
+    BSONObj generateSection(OperationContext* opCtx,
+                            const BSONElement& configElement) const override {
+        auto* manager = LDAPManager::get(opCtx->getServiceContext());
+        if (!manager) {
+            return BSONObj{};
+        }
+        BSONObjBuilder bob;
+        manager->appendUserToDNCacheStats(bob);
+        return bob.obj();
+    }
+};
+
+auto& ldapServerStatusSection =
+    *ServerStatusSectionBuilder<LDAPServerStatusSection>("ldap").forShard().forRouter();
 
 ServiceContext::ConstructorActionRegisterer createLDAPManager(
     "CreateLDAPManager", {"EndStartupOptionStorage"}, [](ServiceContext* service) {

--- a/src/mongo/db/ldap/ldap_manager_impl.h
+++ b/src/mongo/db/ldap/ldap_manager_impl.h
@@ -37,6 +37,7 @@ Copyright (C) 2019-present Percona and/or its affiliates. All rights reserved.
 #include "mongo/bson/bsonobj.h"
 #include "mongo/db/ldap/ldap_manager.h"
 #include "mongo/logv2/log_severity.h"
+#include "mongo/platform/atomic_word.h"
 #include "mongo/platform/mutex.h"
 #include "mongo/util/lru_cache.h"
 #include "mongo/util/time_support.h"
@@ -63,6 +64,8 @@ public:
 
     void invalidateUserToDNCache() override;
 
+    void appendUserToDNCacheStats(BSONObjBuilder& bob) const override;
+
 private:
     struct UserToDNCacheEntry {
         std::string dn;
@@ -70,7 +73,7 @@ private:
     };
 
     struct UserToDNCacheHolder {
-        UserToDNCacheHolder();
+        explicit UserToDNCacheHolder(long long invalidations = 0);
 
         using UserToDNCache = LRUCache<std::string, UserToDNCacheEntry>;
 
@@ -78,8 +81,11 @@ private:
         const int ttl;
         const bool enabled;
         const BSONArray mapping;
+        const long long invalidations;
         Mutex mutex = MONGO_MAKE_LATCH("UserToDNCacheHolder::mutex");
         UserToDNCache cache;
+        AtomicWord<long long> hits{0};
+        AtomicWord<long long> misses{0};
     };
 
     // UserToDNCacheHolder will be atomically replaced on any configuration changes


### PR DESCRIPTION
Add db.serverStatus().ldap.userToDNCache with enabled, maxSize, currentSize, ttlSeconds, hits, misses, and invalidations fields. Hits/misses reset on cache invalidation (stored in the atomically-replaced holder); invalidations is monotonic (stored on LDAPManagerImpl). Startup initialization does not count as an invalidation.
