### PR TITLE
PSMDB-2141: exclude template files from clang-tidy file filter

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -65,6 +65,8 @@ jobs:
             **/*.c
           files_ignore: |
             src/third_party/**
+            **/*.tpl.cpp
+            **/*.tpl.c
       - name: List changed files
         run: |
           echo "Changed files: ${{ steps.changed.outputs.all_changed_files }}"


### PR DESCRIPTION
The clang-tidy workflow matched **/*.cpp / **/*.c changed files but only ignored src/third_party/**. Template sources such as src/mongo/util/version_impl.tpl.cpp contain unsubstituted placeholders (e.g. @mongo_version_major@) that are not valid C++, so clang-tidy produced compiler errors and the job failed with exit code 1.

Ignore **/*.tpl.cpp and **/*.tpl.c so these non-compilable templates are never passed to clang-tidy.

