### PR TITLE
Resolve conflicts for merge 'c9fa3ccc6dc' into 'master'

### DIFF
--- a/src/mongo/client/sasl_oidc_client_conversation.cpp
+++ b/src/mongo/client/sasl_oidc_client_conversation.cpp
@@ -78,7 +78,6 @@ constexpr auto kDeviceCodeParameterName = "device_code"sv;
 constexpr auto kCodeParameterName = "code"sv;
 constexpr auto kRefreshTokenParameterName = kGrantTypeParameterRefreshTokenValue;
 
-<<<<<<< HEAD
 std::unique_ptr<HttpClient> createHttpClient(bool withConnectionPool = false) {
     std::unique_ptr<HttpClient> httpClient =
         withConnectionPool ? HttpClient::create() : HttpClient::createWithoutConnectionPool();
@@ -88,12 +87,7 @@ std::unique_ptr<HttpClient> createHttpClient(bool withConnectionPool = false) {
     return httpClient;
 }
 
-inline void appendPostBodyRequiredParams(StringBuilder* sb, StringData clientId) {
-||||||| 2eff3754f8e
-inline void appendPostBodyRequiredParams(StringBuilder* sb, StringData clientId) {
-=======
 inline void appendPostBodyRequiredParams(StringBuilder* sb, std::string_view clientId) {
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
     *sb << kClientIdParameterName << "=" << uriEncode(clientId);
 }
 
@@ -136,33 +130,15 @@ BSONObj doPostRequest(HttpClient* httpClient,
 std::pair<std::string, std::string> doDeviceAuthorizationGrantFlow(
     const OAuthAuthorizationServerMetadata& discoveryReply,
     const auth::OIDCMechanismServerStep1& serverReply,
-<<<<<<< HEAD
-    StringData principalName) {
+    std::string_view principalName) {
     boost::optional<StringData> deviceAuthorizationEndpoint =
         discoveryReply.getDeviceAuthorizationEndpoint().get();
     // If exists, the device authorization endpoint has been already validated during parsing of
     // `OAuthAuthorizationServerMetadata` class.
     // (@see `src/mongo/db/auth/oauth_authorization_server_metadata.idl`).
-||||||| 2eff3754f8e
-    StringData principalName) {
-    auto deviceAuthorizationEndpoint = discoveryReply.getDeviceAuthorizationEndpoint().get();
-=======
-    std::string_view principalName) {
-    auto deviceAuthorizationEndpoint = discoveryReply.getDeviceAuthorizationEndpoint().get();
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
     uassert(ErrorCodes::BadValue,
-<<<<<<< HEAD
             "Missing or invalid device authorization endpoint in server reply",
             deviceAuthorizationEndpoint && !deviceAuthorizationEndpoint->empty());
-||||||| 2eff3754f8e
-            "Device authorization endpoint in server reply must be an https endpoint or localhost",
-            deviceAuthorizationEndpoint.starts_with("https://"_sd) ||
-                deviceAuthorizationEndpoint.starts_with("http://localhost"_sd));
-=======
-            "Device authorization endpoint in server reply must be an https endpoint or localhost",
-            deviceAuthorizationEndpoint.starts_with("https://"sv) ||
-                deviceAuthorizationEndpoint.starts_with("http://localhost"sv));
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
 
     auto clientId = serverReply.getClientId();
     uassert(ErrorCodes::BadValue,
@@ -358,17 +334,7 @@ StatusWith<bool> SaslOIDCClientConversation::_secondStep(std::string_view input,
         boost::optional<StringData> tokenEndpoint = discoveryReply.getTokenEndpoint();
         uassert(ErrorCodes::BadValue,
                 "Missing or invalid token endpoint in server reply",
-<<<<<<< HEAD
                 tokenEndpoint && !tokenEndpoint->empty());
-||||||| 2eff3754f8e
-                tokenEndpoint && !tokenEndpoint->empty() &&
-                    (tokenEndpoint->starts_with("https://"_sd) ||
-                     tokenEndpoint->starts_with("http://localhost"_sd)));
-=======
-                tokenEndpoint && !tokenEndpoint->empty() &&
-                    (tokenEndpoint->starts_with("https://"sv) ||
-                     tokenEndpoint->starts_with("http://localhost"sv)));
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
 
         // Cache the token endpoint for potential reuse during the refresh flow.
         oidcClientGlobalParams.oidcTokenEndpoint = std::string{*tokenEndpoint};

--- a/src/mongo/crypto/jwks_fetcher_factory.h
+++ b/src/mongo/crypto/jwks_fetcher_factory.h
@@ -42,14 +42,8 @@ namespace mongo {
 class MONGO_MOD_OPEN JWKSFetcherFactory {
 public:
     virtual ~JWKSFetcherFactory() = default;
-<<<<<<< HEAD
-    virtual std::unique_ptr<crypto::JWKSFetcher> makeJWKSFetcher(StringData issuer,
-                                                                 StringData caFilePath) const = 0;
-||||||| 2eff3754f8e
-    virtual std::unique_ptr<crypto::JWKSFetcher> makeJWKSFetcher(StringData issuer) const = 0;
-=======
-    virtual std::unique_ptr<crypto::JWKSFetcher> makeJWKSFetcher(std::string_view issuer) const = 0;
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
+    virtual std::unique_ptr<crypto::JWKSFetcher> makeJWKSFetcher(std::string_view issuer,
+                                                                 std::string_view caFilePath) const = 0;
 };
 
 

--- a/src/mongo/crypto/jwks_fetcher_impl.cpp
+++ b/src/mongo/crypto/jwks_fetcher_impl.cpp
@@ -52,19 +52,11 @@
 
 namespace mongo::crypto {
 
-<<<<<<< HEAD
-JWKSFetcherImpl::JWKSFetcherImpl(ClockSource* clock, StringData issuer, StringData caFilePath)
+JWKSFetcherImpl::JWKSFetcherImpl(ClockSource* clock, std::string_view issuer, std::string_view caFilePath)
     : _issuer(issuer),
       _clock(clock),
       _lastAttemptedFetchTime(Date_t::min()),
       _caFilePath(caFilePath) {}
-||||||| 2eff3754f8e
-JWKSFetcherImpl::JWKSFetcherImpl(ClockSource* clock, StringData issuer)
-    : _issuer(issuer), _clock(clock), _lastAttemptedFetchTime(Date_t::min()) {}
-=======
-JWKSFetcherImpl::JWKSFetcherImpl(ClockSource* clock, std::string_view issuer)
-    : _issuer(issuer), _clock(clock), _lastAttemptedFetchTime(Date_t::min()) {}
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
 
 JWKSet JWKSFetcherImpl::fetch() {
     try {

--- a/src/mongo/crypto/jwks_fetcher_impl.h
+++ b/src/mongo/crypto/jwks_fetcher_impl.h
@@ -45,13 +45,7 @@ namespace crypto {
  */
 class MONGO_MOD_PUBLIC JWKSFetcherImpl : public JWKSFetcher {
 public:
-<<<<<<< HEAD
-    JWKSFetcherImpl(ClockSource* clock, StringData issuer, StringData caFilePath = {});
-||||||| 2eff3754f8e
-    JWKSFetcherImpl(ClockSource* clock, StringData issuer);
-=======
-    JWKSFetcherImpl(ClockSource* clock, std::string_view issuer);
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
+    JWKSFetcherImpl(ClockSource* clock, std::string_view issuer, std::string_view caFilePath = {});
 
     JWKSet fetch() override;
 

--- a/src/mongo/db/commands/profile_common.cpp
+++ b/src/mongo/db/commands/profile_common.cpp
@@ -174,23 +174,11 @@ bool ProfileCmdBase::run(OperationContext* opCtx,
         BSONObjBuilder oldState;
         BSONObjBuilder newState;
 
-<<<<<<< HEAD
-        oldState.append("level"_sd, oldSettings.level);
-        oldState.append("slowms"_sd, oldSlowMS);
-        oldState.append("slowinprogms"_sd, oldSettings.slowOpInProgressThreshold.count());
-        oldState.append("ratelimit"_sd, oldRateLimit);
-        oldState.append("sampleRate"_sd, oldSampleRate);
-||||||| 2eff3754f8e
-        oldState.append("level"_sd, oldSettings.level);
-        oldState.append("slowms"_sd, oldSlowMS);
-        oldState.append("slowinprogms"_sd, oldSettings.slowOpInProgressThreshold.count());
-        oldState.append("sampleRate"_sd, oldSampleRate);
-=======
         oldState.append("level"sv, oldSettings.level);
         oldState.append("slowms"sv, oldSlowMS);
         oldState.append("slowinprogms"sv, oldSettings.slowOpInProgressThreshold.count());
+        oldState.append("ratelimit"sv, oldRateLimit);
         oldState.append("sampleRate"sv, oldSampleRate);
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
         if (oldSettings.filter) {
             oldState.append("filter"sv, oldSettings.filter->serialize());
         }
@@ -201,23 +189,11 @@ bool ProfileCmdBase::run(OperationContext* opCtx,
         // (0, 1, or 2).
         auto& dbProfileSettings = DatabaseProfileSettings::get(opCtx->getServiceContext());
         auto newSettings = dbProfileSettings.getDatabaseProfileSettings(dbName);
-<<<<<<< HEAD
-        newState.append("level"_sd, newSettings.level);
-        newState.append("slowms"_sd, serverGlobalParams.slowMS.load());
-        newState.append("slowinprogms"_sd, newSettings.slowOpInProgressThreshold.count());
-        newState.append("ratelimit"_sd, serverGlobalParams.rateLimit.load());
-        newState.append("sampleRate"_sd, serverGlobalParams.sampleRate.load());
-||||||| 2eff3754f8e
-        newState.append("level"_sd, newSettings.level);
-        newState.append("slowms"_sd, serverGlobalParams.slowMS.load());
-        newState.append("slowinprogms"_sd, newSettings.slowOpInProgressThreshold.count());
-        newState.append("sampleRate"_sd, serverGlobalParams.sampleRate.load());
-=======
         newState.append("level"sv, newSettings.level);
         newState.append("slowms"sv, serverGlobalParams.slowMS.load());
         newState.append("slowinprogms"sv, newSettings.slowOpInProgressThreshold.count());
+        newState.append("ratelimit"sv, serverGlobalParams.rateLimit.load());
         newState.append("sampleRate"sv, serverGlobalParams.sampleRate.load());
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
         if (newSettings.filter) {
             newState.append("filter"sv, newSettings.filter->serialize());
         }

--- a/src/mongo/db/ftdc/ftdc_system_stats_linux.cpp
+++ b/src/mongo/db/ftdc/ftdc_system_stats_linux.cpp
@@ -376,32 +376,16 @@ public:
 
         // Skip the disks section if we could not find any disks.
         // This can happen when we do not have permission to /sys/block for instance.
-<<<<<<< HEAD
         if (gDiagnosticDataCollectionEnableSystemMetricsDisks.load() && !_disksStringData.empty()) {
-            BSONObjBuilder subObjBuilder(builder.subobjStart("disks"_sd));
-||||||| 2eff3754f8e
-        if (!_disksStringData.empty()) {
-            BSONObjBuilder subObjBuilder(builder.subobjStart("disks"_sd));
-=======
-        if (!_disksStringData.empty()) {
             BSONObjBuilder subObjBuilder(builder.subobjStart("disks"sv));
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
             processStatusErrors(procparser::parseProcDiskStatsFile(
                                     "/proc/diskstats"sv, _disksStringData, &subObjBuilder),
                                 &subObjBuilder);
             subObjBuilder.doneFast();
         }
 
-<<<<<<< HEAD
         if (gDiagnosticDataCollectionEnableSystemMetricsMounts.load()) {
-            BSONObjBuilder subObjBuilder(builder.subobjStart("mounts"_sd));
-||||||| 2eff3754f8e
-        {
-            BSONObjBuilder subObjBuilder(builder.subobjStart("mounts"_sd));
-=======
-        {
             BSONObjBuilder subObjBuilder(builder.subobjStart("mounts"sv));
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
             processStatusErrors(
                 procparser::parseProcSelfMountStatsFile("/proc/self/mountinfo"sv, &subObjBuilder),
                 &subObjBuilder);

--- a/src/mongo/db/fts/fts_language.cpp
+++ b/src/mongo/db/fts/fts_language.cpp
@@ -76,43 +76,8 @@ struct {
     std::string_view name;   // - lower case string name
     std::string_view alias;  // - language alias (if nonempty)
 } static constexpr kLanguagesV2V3[] = {
-<<<<<<< HEAD
-    {"none"_sd, {}},
-    {"ngram"_sd, {}},
-    {"danish"_sd, "da"_sd},
-    {"dutch"_sd, "nl"_sd},
-    {"english"_sd, "en"_sd},
-    {"finnish"_sd, "fi"_sd},
-    {"french"_sd, "fr"_sd},
-    {"german"_sd, "de"_sd},
-    {"hungarian"_sd, "hu"_sd},
-    {"italian"_sd, "it"_sd},
-    {"norwegian"_sd, "nb"_sd},
-    {"portuguese"_sd, "pt"_sd},
-    {"romanian"_sd, "ro"_sd},
-    {"russian"_sd, "ru"_sd},
-    {"spanish"_sd, "es"_sd},
-    {"swedish"_sd, "sv"_sd},
-    {"turkish"_sd, "tr"_sd},
-||||||| 2eff3754f8e
-    {"none"_sd, {}},
-    {"danish"_sd, "da"_sd},
-    {"dutch"_sd, "nl"_sd},
-    {"english"_sd, "en"_sd},
-    {"finnish"_sd, "fi"_sd},
-    {"french"_sd, "fr"_sd},
-    {"german"_sd, "de"_sd},
-    {"hungarian"_sd, "hu"_sd},
-    {"italian"_sd, "it"_sd},
-    {"norwegian"_sd, "nb"_sd},
-    {"portuguese"_sd, "pt"_sd},
-    {"romanian"_sd, "ro"_sd},
-    {"russian"_sd, "ru"_sd},
-    {"spanish"_sd, "es"_sd},
-    {"swedish"_sd, "sv"_sd},
-    {"turkish"_sd, "tr"_sd},
-=======
     {"none"sv, {}},
+    {"ngram"sv, {}},
     {"danish"sv, "da"sv},
     {"dutch"sv, "nl"sv},
     {"english"sv, "en"sv},
@@ -128,7 +93,6 @@ struct {
     {"spanish"sv, "es"sv},
     {"swedish"sv, "sv"sv},
     {"turkish"sv, "tr"sv},
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
 };
 
 //

--- a/src/mongo/db/fts/fts_query_parser.cpp
+++ b/src/mongo/db/fts/fts_query_parser.cpp
@@ -102,7 +102,7 @@ QueryToken FTSQueryParser::nextForNgram() {
         }
     }
 
-    StringData ret = _raw.substr(start, _pos - start);
+    std::string_view ret = _raw.substr(start, _pos - start);
     bool old = _previousWhiteSpace;
     _previousWhiteSpace = skipWhitespace();
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp
@@ -30,15 +30,10 @@
 #include "mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.h"
 
 #include "mongo/base/init.h"  // IWYU pragma: keep
-<<<<<<< HEAD
 #include "mongo/base/string_data.h"
 #include "mongo/db/database_name_util.h"
 #include "mongo/db/encryption/encryption_options.h"
 #include "mongo/db/namespace_string_util.h"
-||||||| 2eff3754f8e
-#include "mongo/base/string_data.h"
-=======
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
 #include "mongo/db/service_context.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/decorable.h"

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -588,17 +588,11 @@ public:
 
     StatusWith<std::deque<std::string>> extendBackupCursor() override;
 
-<<<<<<< HEAD
     Status hotBackup(OperationContext* opCtx, const std::string& path) override;
     Status hotBackupTar(OperationContext* opCtx, const std::string& path) override;
     Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
 
-    int64_t getIdentSize(RecoveryUnit&, StringData ident) override;
-||||||| 2eff3754f8e
-    int64_t getIdentSize(RecoveryUnit&, StringData ident) override;
-=======
     int64_t getIdentSize(RecoveryUnit&, std::string_view ident) override;
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
 
     Status repairIdent(RecoveryUnit& ru, std::string_view ident) override;
 

--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -89,7 +89,7 @@ public:
         return {"unknown"};
     }
 
-    std::vector<StringData> perconaFeatures() const final {
+    std::vector<std::string_view> perconaFeatures() const final {
         return {"unknown"};
     }
 

--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -89,17 +89,11 @@ public:
         return {"unknown"};
     }
 
-<<<<<<< HEAD
     std::vector<StringData> perconaFeatures() const final {
         return {"unknown"};
     }
 
-    StringData allocator() const noexcept final {
-||||||| 2eff3754f8e
-    StringData allocator() const noexcept final {
-=======
     std::string_view allocator() const noexcept final {
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
         return "unknown";
     }
 

--- a/src/mongo/util/version.h
+++ b/src/mongo/util/version.h
@@ -123,7 +123,7 @@ public:
      * Returns a list of the features Percona implemented on top of the
      * MongoDB Community Edition.
      */
-    virtual std::vector<StringData> perconaFeatures() const = 0;
+    virtual std::vector<std::string_view> perconaFeatures() const = 0;
 
     /**
      * Returns a string describing the configured memory allocator.

--- a/src/mongo/util/version_impl.tpl.cpp
+++ b/src/mongo/util/version_impl.tpl.cpp
@@ -74,7 +74,7 @@ public:
         return modulesList;
     }
 
-    std::vector<StringData> perconaFeatures() const final {
+    std::vector<std::string_view> perconaFeatures() const final {
         return perconaFeatureList;
     }
 
@@ -115,7 +115,7 @@ private:
     std::string_view kJsEngine = "@buildinfo_js_engine@"sv;
     std::vector<std::string_view> modulesList{@buildinfo_modules@};
     std::vector<VersionInfoInterface::BuildInfoField> buildEnvironment{@buildinfo_environment_data@};
-    std::vector<StringData> perconaFeatureList{
+    std::vector<std::string_view> perconaFeatureList{
         "MemoryEngine",
         "HotBackup",
         "BackupCursorAggregationStage",

--- a/src/mongo/util/version_impl.tpl.cpp
+++ b/src/mongo/util/version_impl.tpl.cpp
@@ -74,17 +74,11 @@ public:
         return modulesList;
     }
 
-<<<<<<< HEAD
     std::vector<StringData> perconaFeatures() const final {
         return perconaFeatureList;
     }
 
-    StringData allocator() const final {
-||||||| 2eff3754f8e
-    StringData allocator() const final {
-=======
     std::string_view allocator() const final {
->>>>>>> c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36
         return kAllocator;
     }
 


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `master`
- **Target Branch SHA:** [`97940e765a37c28ff910c12afbb287a6ac32d7bf`](https://github.com/plebioda/percona-server-mongodb/commit/97940e765a37c28ff910c12afbb287a6ac32d7bf)
- **Merge Commit:** [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36)


# Merge Context

- **Number of merged commits:** 42
- **Auto-merged files:** 86


## Important Files Modified

- `src/mongo/db/audit.cpp`

- `src/mongo/db/audit.h`

- `src/mongo/db/auth/sasl_plain_server_conversation.cpp`

- `src/mongo/db/auth/sasl_scram_server_conversation.cpp`

- `src/mongo/db/repl/initial_sync/initial_syncer.cpp`

- `src/mongo/db/repl/initial_sync/initial_syncer.h`

- `src/mongo/db/storage/storage_engine.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_init_test.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine_test.cpp`




## Auto-Merged Files


- `.bazelrc`

- `.gitignore`

- `bazel/config/BUILD.bazel`

- `jstests/auth/lib/commands_lib.js`

- `jstests/core/catalog/views/views_all_commands.js`

- `jstests/libs/write_concern_all_commands.js`

- `jstests/replsets/all_commands_downgrading_to_upgraded.js`

- `jstests/replsets/db_reads_while_recovering_all_commands.js`

- `jstests/sharding/all_commands_direct_shard_connection_auth.js`

- `jstests/sharding/database_versioning_all_commands.js`

- `jstests/sharding/read_write_concern_defaults_application.js`

- `src/mongo/client/sasl_oidc_client_conversation.cpp`

- `src/mongo/crypto/jwks_fetcher_factory.h`

- `src/mongo/crypto/jwks_fetcher_impl.cpp`

- `src/mongo/crypto/jwks_fetcher_impl.h`

- `src/mongo/db/BUILD.bazel`

- `src/mongo/db/audit.cpp`

- `src/mongo/db/auth/authorization_backend_local.cpp`

- `src/mongo/db/auth/authorization_manager_global.cpp`

- `src/mongo/db/auth/authorization_manager_impl.cpp`

- `src/mongo/db/auth/authorization_manager_impl.h`

- `src/mongo/db/auth/authorization_manager_test.cpp`

- `src/mongo/db/auth/sasl_mechanism_policies.h`

- `src/mongo/db/commands/BUILD.bazel`

- `src/mongo/db/commands/profile_common.cpp`

- `src/mongo/db/curop.cpp`

- `src/mongo/db/curop.h`

- `src/mongo/db/exec/document_value/value.cpp`

- `src/mongo/db/exec/mutable_bson/algorithm.h`

- `src/mongo/db/ftdc/ftdc_system_stats_linux.cpp`

- `src/mongo/db/fts/fts_language.cpp`

- `src/mongo/db/fts/fts_matcher.cpp`

- `src/mongo/db/fts/fts_query_impl.cpp`

- `src/mongo/db/fts/fts_query_parser.cpp`

- `src/mongo/db/fts/fts_query_parser.h`

- `src/mongo/db/fts/fts_tokenizer.h`

- `src/mongo/db/initialize_server_global_state.cpp`

- `src/mongo/db/mongod_main.cpp`

- `src/mongo/db/mongod_options.cpp`

- `src/mongo/db/namespace_string_reserved.h`

- `src/mongo/db/namespace_string_util_test.cpp`

- `src/mongo/db/op_debug.cpp`

- `src/mongo/db/pipeline/BUILD.bazel`

- `src/mongo/db/pipeline/process_interface/common_mongod_process_interface.cpp`

- `src/mongo/db/query/query_tester/mock_version_info.h`

- `src/mongo/db/repl/replication_coordinator_impl.cpp`

- `src/mongo/db/server_options.h`

- `src/mongo/db/server_options_server_helpers.cpp`

- `src/mongo/db/shard_role/shard_catalog/collection_catalog_helper.cpp`

- `src/mongo/db/startup_recovery.cpp`

- `src/mongo/db/storage/kv/kv_engine.h`

- `src/mongo/db/storage/kv/kv_engine_test_harness.cpp`

- `src/mongo/db/storage/storage_engine.h`

- `src/mongo/db/storage/storage_engine_impl.cpp`

- `src/mongo/db/storage/storage_engine_impl.h`

- `src/mongo/db/storage/storage_engine_init.cpp`

- `src/mongo/db/storage/storage_engine_metadata.cpp`

- `src/mongo/db/storage/storage_engine_metadata.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_global_options.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_util.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_util_test.cpp`

- `src/mongo/db/topology/cluster_add_shard_cmd.cpp`

- `src/mongo/s/BUILD.bazel`

- `src/mongo/s/mongos_main.cpp`

- `src/mongo/s/write_ops/write_op.cpp`

- `src/mongo/s/write_ops/write_op.h`

- `src/mongo/shell/mongo_main.cpp`

- `src/mongo/shell/shell_options.cpp`

- `src/mongo/shell/shell_options.h`

- `src/mongo/shell/shell_utils_extended.cpp`

- `src/mongo/util/buildinfo.cpp`

- `src/mongo/util/net/http_client.cpp`

- `src/mongo/util/net/http_client.h`

- `src/mongo/util/net/http_client_curl.cpp`

- `src/mongo/util/net/ssl_options.cpp`

- `src/mongo/util/net/ssl_types.h`

- `src/mongo/util/processinfo_linux.cpp`

- `src/mongo/util/stacktrace_test.cpp`

- `src/mongo/util/version.cpp`

- `src/mongo/util/version.h`

- `src/mongo/util/version_impl.tpl.cpp`



**Merged with strategy:** ort




<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| [`8706f7d2c50b7f25091a407ffc9cf546b3dd51c8`](https://github.com/plebioda/percona-server-mongodb/commit/8706f7d2c50b7f25091a407ffc9cf546b3dd51c8) | SERVER-128285 Make hybrid search stages desugar and resolve views during lite-parse-time (#56216) |
| [`e0339bc1ca2ccf7939b6849df85497f8322de7dd`](https://github.com/plebioda/percona-server-mongodb/commit/e0339bc1ca2ccf7939b6849df85497f8322de7dd) | SERVER-128447 Initialize fast count metadata when performing modal validate if persistence provider uses replicated fast count (#56301) |
| [`c5613c8c973eac1e310f836265786682f13c2d8f`](https://github.com/plebioda/percona-server-mongodb/commit/c5613c8c973eac1e310f836265786682f13c2d8f) | SERVER-122067 Include queryShapeHash in the explain output for delete (#56223) |
| [`23281a7739a0cbaed41f25a9dc0d93df2d4d7fe0`](https://github.com/plebioda/percona-server-mongodb/commit/23281a7739a0cbaed41f25a9dc0d93df2d4d7fe0) | SERVER-129382 The MigrationSourceManager object should be released before the ActiveMigrationsRegistry is released (#56329) |
| [`df8948f261484ee80311e55cf9f394dcde2fc690`](https://github.com/plebioda/percona-server-mongodb/commit/df8948f261484ee80311e55cf9f394dcde2fc690) | SERVER-123429 Update query stats and query shape README for deletes and inserts (#56308) |
| [`94654530d0876d90aff5f74d1913ad6f334b9e65`](https://github.com/plebioda/percona-server-mongodb/commit/94654530d0876d90aff5f74d1913ad6f334b9e65) | SERVER-129247 Enable bolt everywhere (#56210) |
| [`ffc08bda98f039419319c8a8822f77ad0cbded9d`](https://github.com/plebioda/percona-server-mongodb/commit/ffc08bda98f039419319c8a8822f77ad0cbded9d) | SERVER-129188 Add MFP variants for older versions (#56075) |
| [`dc28d6389ae966bddb28e94f15435314458ff2b9`](https://github.com/plebioda/percona-server-mongodb/commit/dc28d6389ae966bddb28e94f15435314458ff2b9) | SERVER-129394 make rules_poetry HOME and CARGO_HOME work in bazel sandbox (#56330) |
| [`06608380fcc064e0da24c1c9ec16a86f89a17039`](https://github.com/plebioda/percona-server-mongodb/commit/06608380fcc064e0da24c1c9ec16a86f89a17039) | SERVER-87919 Take stable checkpoints during startup recovery for restore (#55197) |
| [`59cac8884ec60ddd5f2be58503ac3eb9062d5101`](https://github.com/plebioda/percona-server-mongodb/commit/59cac8884ec60ddd5f2be58503ac3eb9062d5101) | SERVER-129178 Clarify replicated size and count metadata checkpoint exception handling (#56159) |
| [`f2da74b03ae94675f2cc2826cabdf0e6f9c389ae`](https://github.com/plebioda/percona-server-mongodb/commit/f2da74b03ae94675f2cc2826cabdf0e6f9c389ae) | SERVER-128354 Explained why falling back to firstTimeInBatch is safe for null earliestTimestamp for new multikey paths (#56290) |
| [`a6823e95802aafd66cb54b03f5bdf6ba542d1ae7`](https://github.com/plebioda/percona-server-mongodb/commit/a6823e95802aafd66cb54b03f5bdf6ba542d1ae7) | SERVER-129195: Address interleaved schema index overflow (#56169) |
| [`430421bdc0b96d102f19c3cbbe99a3fe392b41d2`](https://github.com/plebioda/percona-server-mongodb/commit/430421bdc0b96d102f19c3cbbe99a3fe392b41d2) | SERVER-114364 Support internal-only extension stages (#55650) |
| [`e63b21e1a12a1a3cf315cc4a19cf017fb65a0777`](https://github.com/plebioda/percona-server-mongodb/commit/e63b21e1a12a1a3cf315cc4a19cf017fb65a0777) | SERVER-116458 Make stopServerReplication() work in disagg storage suites (#52275) |
| [`2801a6899df58dc3601707c7d8b7c927bfd66426`](https://github.com/plebioda/percona-server-mongodb/commit/2801a6899df58dc3601707c7d8b7c927bfd66426) | SERVER-128939 Create featureFlagLogicalSizeTracking (#56111) |
| [`e29f2871f1252681f9584a350eba0176cd310428`](https://github.com/plebioda/percona-server-mongodb/commit/e29f2871f1252681f9584a350eba0176cd310428) | SERVER-128462: Add default sampling configuration (#55994) |
| [`3ac9681d18cf44254701bb8b13720c98c12350ef`](https://github.com/plebioda/percona-server-mongodb/commit/3ac9681d18cf44254701bb8b13720c98c12350ef) | SERVER-129342 MoveRangeCoordinator cannot update _doc when it has not been created yet (#56283) |
| [`bbe7e72ed937c99ac1c91ffb5ac8d44b26670229`](https://github.com/plebioda/percona-server-mongodb/commit/bbe7e72ed937c99ac1c91ffb5ac8d44b26670229) | SERVER-127697 simplify match expression logic in propagateSingleTablePredicate (#56221) |
| [`f00cd1a8c1c7b3da3fa6ea7427c3ea3ca643d43d`](https://github.com/plebioda/percona-server-mongodb/commit/f00cd1a8c1c7b3da3fa6ea7427c3ea3ca643d43d) | SERVER-122081 Test that queryShapeHash for deletes on mongos matches queryShapeHash in slow query logs on mongod (#56239) |
| [`f425bc38d6f5f9767bb2a2e59365cff4f032c256`](https://github.com/plebioda/percona-server-mongodb/commit/f425bc38d6f5f9767bb2a2e59365cff4f032c256) | SERVER-128987 Pipe opCtx through chunk manager callers (#55950) |
| [`ef6361c487d6f136cc095e5c8442852b5c45e760`](https://github.com/plebioda/percona-server-mongodb/commit/ef6361c487d6f136cc095e5c8442852b5c45e760) | SERVER-122059 Implement custom sha256Hash for InsertCmdShape (#55888) |
| [`f6e87ca237c519fc134fca7c6c539ac5f8645a5a`](https://github.com/plebioda/percona-server-mongodb/commit/f6e87ca237c519fc134fca7c6c539ac5f8645a5a) | SERVER-126317 Mark fuzztests that crash as failing (#55977) |
| [`0c231743c0c7d05f26fe5d3ae2187f48a13a3858`](https://github.com/plebioda/percona-server-mongodb/commit/0c231743c0c7d05f26fe5d3ae2187f48a13a3858) | SERVER-129089 Update owner for document_source_sequential_document_cache (#56296) |
| [`04bd171799dc7b4082f2c550feb69f4026ff417a`](https://github.com/plebioda/percona-server-mongodb/commit/04bd171799dc7b4082f2c550feb69f4026ff417a) | SERVER-125083: Introduce a new jstest suite for testing the dependency graph (#55757) |
| [`ef9e6f71f0775ed11d63927da3ee3704cc72ac60`](https://github.com/plebioda/percona-server-mongodb/commit/ef9e6f71f0775ed11d63927da3ee3704cc72ac60) | SERVER-128661 Avoid testing legacy paths for depriorization if crud is authoritative (#55734) |
| [`0e37ef13236b21ef606310cdbcb560add3db00a0`](https://github.com/plebioda/percona-server-mongodb/commit/0e37ef13236b21ef606310cdbcb560add3db00a0) | SERVER-128887 Observability for non-wildcard multikey path changes (#55823) |
| [`fde9d2312b973bfec22d2432a7f5bb99ebfc027b`](https://github.com/plebioda/percona-server-mongodb/commit/fde9d2312b973bfec22d2432a7f5bb99ebfc027b) | SERVER-129255 Fix topology-dependent and non-deterministic sharded metric assertions in extension IFR-flag-retry $unionWith jstests (#56225) |
| [`f75b3d150c3163198a656ee82cc1098ca964fb38`](https://github.com/plebioda/percona-server-mongodb/commit/f75b3d150c3163198a656ee82cc1098ca964fb38) | SERVER-129314 Ban migrations_with_mixed_fcv.js during 8.x/9.0 FCV transitions (#56269) |
| [`7da5308045cf5d7d6d8de0153cf4f05059537703`](https://github.com/plebioda/percona-server-mongodb/commit/7da5308045cf5d7d6d8de0153cf4f05059537703) | SERVER-127228 Add internalQueryMaxMemoryUsageBytesPerOperation knob (#55106) |
| [`0bf82e94c5c4d7954dd42b54b94bafd3162e76b7`](https://github.com/plebioda/percona-server-mongodb/commit/0bf82e94c5c4d7954dd42b54b94bafd3162e76b7) | SERVER-129328 Clear stale collection CSS when recreating a database on the primary shard (#56276) |
| [`821fe103e6122d33a6672fd4391fb9d30f856cb5`](https://github.com/plebioda/percona-server-mongodb/commit/821fe103e6122d33a6672fd4391fb9d30f856cb5) | SERVER-123182 Add query knobs to the explain output (#56113) |
| [`8853b97053fc1b57b7b5624e043aef06e6162c77`](https://github.com/plebioda/percona-server-mongodb/commit/8853b97053fc1b57b7b5624e043aef06e6162c77) | SERVER-126826 Enable `featureFlagFixedBucketingCatalog` by default (#56187) |
| [`9ffc7b7f03a6daf9950b1d093e3b5429e15b0932`](https://github.com/plebioda/percona-server-mongodb/commit/9ffc7b7f03a6daf9950b1d093e3b5429e15b0932) | SERVER-129256 MergeAllChunks may retry forever (#56228) |
| [`77abf323035e97e22fc96cbb9b9d92992301091b`](https://github.com/plebioda/percona-server-mongodb/commit/77abf323035e97e22fc96cbb9b9d92992301091b) | SERVER-129190 Fix chunk_operations_honor_allow_chunk_operations.js (#56196) |
| [`66d67ec58e704e4440de20c5b54c45e3864dcd07`](https://github.com/plebioda/percona-server-mongodb/commit/66d67ec58e704e4440de20c5b54c45e3864dcd07) | SERVER-129084 Allow manually creating persistent samples for HJ/INLJ suite (#56051) |
| [`86c8c9f87a7295c515548225b47891f1ee61ded4`](https://github.com/plebioda/percona-server-mongodb/commit/86c8c9f87a7295c515548225b47891f1ee61ded4) | SERVER-128070 Add CheckMultikeyConsistencyInBackground hook (#54645) |
| [`bf8477f1a3bec557408a977ba431f93875bdcbc1`](https://github.com/plebioda/percona-server-mongodb/commit/bf8477f1a3bec557408a977ba431f93875bdcbc1) | SERVER-126825 Remove `timeseriesBucketingParametersHaveChanged` from shard catalog (#55963) |
| [`26dac4665f2fb081b0cb5c8def3fa3df2aa63622`](https://github.com/plebioda/percona-server-mongodb/commit/26dac4665f2fb081b0cb5c8def3fa3df2aa63622) | SERVER-129107 Centralize resmoke multiversion binary-name logic in MultiversionService (#56173) |
| [`29485a708a30c831272ecb11e778464ff9c923aa`](https://github.com/plebioda/percona-server-mongodb/commit/29485a708a30c831272ecb11e778464ff9c923aa) | SERVER-110427 Update profiling data (#56267) |
| [`f32b4944d233fc52b1ac87a8c9c118ac56c66b5b`](https://github.com/plebioda/percona-server-mongodb/commit/f32b4944d233fc52b1ac87a8c9c118ac56c66b5b) | SERVER-123662 Per-knob merge semantics for queryKnobs in mergeQuerySettings (#56048) |
| [`c6f1114b0cd67141b9b60e4b5a74ea0efb6961f4`](https://github.com/plebioda/percona-server-mongodb/commit/c6f1114b0cd67141b9b60e4b5a74ea0efb6961f4) | SERVER-119485 Add a persisted phase to setFCV after enabling target FCV features (#54422) |

</details>



# Merge Description

## Summary

This merge brings in SERVER-32422 (bulk StringData -> std::string_view rewrites, part 2) along with approximately 40 other commits. The primary change is a systematic replacement of MongoDB's StringData type with the C++ standard library's std::string_view across many files. Additional commits include: SERVER-128285 (hybrid search stages view resolution), SERVER-87919 (stable checkpoints during startup recovery for restore), SERVER-128070 (CheckMultikeyConsistencyInBackground hook), SERVER-126826 (enable featureFlagFixedBucketingCatalog by default), SERVER-129247 (enable bolt everywhere), SERVER-123182 (query knobs in explain output), and various other bug fixes and improvements.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `src/mongo/client/sasl_oidc_client_conversation.cpp` | Changes StringData to std::string_view throughout the file. Affected: parameter types (appendPostBodyRequiredParams, appendPostBodyTokenRequestParams, appendPostBodyRefreshFlowParams, doPostRequest, doDeviceAuthorizationGrantFlow, SaslOIDCClientConversation::step, _secondStep), string literal suffixes (_sd to sv), string constants (kClientIdParameterName, kRequestScopesParameterName, etc.), HTTP response parsing (responseCdr.readInto<std::string_view>), and URL validation checks (starts_with with sv suffix). |
| `src/mongo/crypto/jwks_fetcher_factory.h` | Changes makeJWKSFetcher parameter from StringData to std::string_view. Removes #include "mongo/base/string_data.h" and adds #include <string_view>. |
| `src/mongo/crypto/jwks_fetcher_impl.cpp` | Changes JWKSFetcherImpl constructor parameter from StringData to std::string_view. Changes HTTP response parsing to use std::string_view instead of StringData for the readInto call. |
| `src/mongo/crypto/jwks_fetcher_impl.h` | Changes JWKSFetcherImpl constructor parameter from StringData to std::string_view. Removes #include "mongo/base/string_data.h" and adds #include <string_view>. |
| `src/mongo/db/commands/profile_common.cpp` | Changes string literals from _sd suffix to sv suffix for BSONObjBuilder::append calls (level, slowms, slowinprogms, sampleRate, filter, unset). Changes serializeObjectOrUnset parameter from StringData to std::string_view. |
| `src/mongo/db/ftdc/ftdc_system_stats_linux.cpp` | Extensive StringData to std::string_view conversion. Affects: kCpuKeys, kMemKeys, kNetstatKeys, kVMKeys, kSockstatKeys vectors/maps; EthTool class (create, get_strings, name methods, _ioctlNoThrow); LinuxSystemMetricsCollector class (_disksStringData member, collect method); SimpleFunctionCollector constructor; collectUlimit and collectUlimits functions. All string literals changed from _sd to sv suffix. |
| `src/mongo/db/fts/fts_language.cpp` | Changes LanguageStringCompare to compare std::string_view instead of StringData. Changes kLanguagesV2V3 and kLanguagesV1 arrays to use std::string_view for name and alias fields with sv suffix. Changes LanguageRegistry::add and make methods to use std::string_view. Changes FTSLanguage::make parameter from StringData to std::string_view. |
| `src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp` | Changes WiredTigerCustomizationHooksRegistry::getTableCreateConfig and WiredTigerCustomizationHooks::getTableCreateConfig parameter from StringData to std::string_view. Removes #include "mongo/base/string_data.h". |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h` | Extensive StringData to std::string_view conversion across the WiredTigerKVEngine class. Affected methods include: insertIntoIdent, updateInIdent, getFromIdent, deleteFromIdent, alterMetadata, publishIdent, _getTableIdForIdent, createRecordStore, getRecordStore, getInternalRecordStore, makeInternalRecordStore, createSortedDataInterface, getSortedDataInterface, importRecordStore, importSortedDataInterface, dropSortedDataInterface, dropIdent, dropIdentForImport, alterIdentMetadata, getIdentSize, repairIdent, recoverOrphanedIdent, hasIdent, setRecoveryCheckpointMetadata, getDataFilePathForIdent, getStorageMetadata, getKeyFormat, setFlagToStorageOptions, getFlagFromStorageOptions, _createRecordStore, _ensureIdentPath, _removeIdentDirectoryIfEmpty. Also affects generateWTOpenConfigString function. |
| `src/mongo/util/version.cpp` | Changes VersionInfoInterface methods to return std::string_view instead of StringData: version, gitVersion, modules (returns vector<string_view>), allocator, jsEngine, targetMinOS. Changes makeVersionString and openSSLVersion parameters from StringData to std::string_view. Changes formatVersionString parameter from StringData to std::string_view. |
| `src/mongo/util/version_impl.tpl.cpp` | Changes InterpolatedVersionInfo methods to return std::string_view instead of StringData. Changes internal constants (kVersion, kVersionExtraStr, kGitVersion, kAllocator, kJsEngine) from StringData to std::string_view with sv suffix. Changes modulesList to vector<std::string_view>. |


## Review Notes

The core change is a bulk migration from MongoDB's StringData to C++ standard std::string_view. This is part of a larger modernization effort (SERVER-32422, part 2). Reviewers should verify that Percona-specific features using StringData in the conflicting files (such as caFilePath parameter in JWKS fetcher, ratelimit in profile command, diagnosticDataCollection flags in FTDC, ngram language in FTS, hotBackup methods and encryption hooks in WiredTiger, and perconaFeatures in version info) are correctly preserved while adopting the std::string_view type changes. The conflict resolution should maintain Percona's StringData-based caFilePath for JWKS fetcher while changing the issuer parameter to std::string_view, keep Percona's ratelimit field in profile output with sv suffix, preserve Percona's conditional collection of disk/mount metrics with sv suffix, keep Percona's ngram language entry with sv suffix, preserve Percona's hotBackup methods and encryption customization hooks, and keep Percona's perconaFeatures method returning vector<StringData> (unchanged) while the other methods use std::string_view.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.186 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 587 | 14 |  |  |  |  |
| claude-opus-4-5 | 1342 | 4518 |  |  |  |  |


</details>



# Conflict Context

- **Base Commit:** [`2eff3754f8e28b55b58b93ea2dbd601598e677d8`](https://github.com/plebioda/percona-server-mongodb/commit/2eff3754f8e28b55b58b93ea2dbd601598e677d8)
- **Ours Commit:** [`97940e765a37c28ff910c12afbb287a6ac32d7bf`](https://github.com/plebioda/percona-server-mongodb/commit/97940e765a37c28ff910c12afbb287a6ac32d7bf)
- **Theirs Commit:** [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `src/mongo/client/sasl_oidc_client_conversation.cpp` | both modified |
| `src/mongo/crypto/jwks_fetcher_factory.h` | both modified |
| `src/mongo/crypto/jwks_fetcher_impl.cpp` | both modified |
| `src/mongo/crypto/jwks_fetcher_impl.h` | both modified |
| `src/mongo/db/commands/profile_common.cpp` | both modified |
| `src/mongo/db/ftdc/ftdc_system_stats_linux.cpp` | both modified |
| `src/mongo/db/fts/fts_language.cpp` | both modified |
| `src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp` | both modified |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h` | both modified |
| `src/mongo/util/version.cpp` | both modified |
| `src/mongo/util/version_impl.tpl.cpp` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `src/mongo/client/sasl_oidc_client_conversation.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/crypto/jwks_fetcher_factory.h` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/crypto/jwks_fetcher_impl.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/crypto/jwks_fetcher_impl.h` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/db/commands/profile_common.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/db/ftdc/ftdc_system_stats_linux.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/db/fts/fts_language.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/util/version.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |
| `src/mongo/util/version_impl.tpl.cpp` | [`c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36`](https://github.com/plebioda/percona-server-mongodb/commit/c9fa3ccc6dc4e6c15ca26d58bc03951df288eb36) | SERVER-32422 bulk StringData -> std::string_view rewrites (part 2) (#55887) |

</details>



# Solutions

## Solution 1
### Summary

Resolved StringData to std::string_view migration conflicts while preserving Percona-specific features (caFilePath parameter in JWKS fetcher, ratelimit in profiler, ngram language support, diagnostics collection flags, hotBackup methods, and perconaFeatures)

**By:** Agent (claude_cli v2.1.186 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `src/mongo/client/sasl_oidc_client_conversation.cpp` | Changed StringData to std::string_view for appendPostBodyRequiredParams and doDeviceAuthorizationGrantFlow parameters. Preserved Percona's createHttpClient helper and the enhanced validation logic for device authorization and token endpoints. |
| `src/mongo/crypto/jwks_fetcher_factory.h` | Changed StringData parameters to std::string_view while keeping Percona's caFilePath parameter in makeJWKSFetcher method. |
| `src/mongo/crypto/jwks_fetcher_impl.cpp` | Changed StringData parameters to std::string_view in constructor while preserving Percona's caFilePath initialization. |
| `src/mongo/crypto/jwks_fetcher_impl.h` | Changed StringData parameters to std::string_view while preserving Percona's caFilePath parameter with default value. |
| `src/mongo/db/commands/profile_common.cpp` | Changed _sd suffix to sv suffix for string literals while preserving Percona's ratelimit field in profiler settings logging. |
| `src/mongo/db/ftdc/ftdc_system_stats_linux.cpp` | Changed _sd suffix to sv suffix for string literals while preserving Percona's gDiagnosticDataCollectionEnableSystemMetricsDisks and gDiagnosticDataCollectionEnableSystemMetricsMounts feature flags. |
| `src/mongo/db/fts/fts_language.cpp` | Changed _sd suffix to sv suffix for language definitions while preserving Percona's ngram language support. |
| `src/mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.cpp` | Kept Percona's includes for encryption_options.h, database_name_util.h, and namespace_string_util.h that were removed by MongoDB. |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h` | Changed StringData to std::string_view in getIdentSize method while preserving Percona's hotBackup method declarations. |
| `src/mongo/util/version.cpp` | Changed StringData to std::string_view for allocator() method while preserving Percona's perconaFeatures() method. |
| `src/mongo/util/version_impl.tpl.cpp` | Changed StringData to std::string_view for allocator() method while preserving Percona's perconaFeatures() method. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

All conflicts were caused by MongoDB's SERVER-32422 bulk StringData to std::string_view rewrites. Resolution strategy: adopt std::string_view changes from MongoDB while preserving all Percona-specific enhancements. Key Percona features preserved: (1) caFilePath parameter for JWKS fetcher, (2) ratelimit field in profiler, (3) ngram language in FTS, (4) system metrics collection flags, (5) hotBackup methods in WiredTiger KV engine, (6) perconaFeatures() method in version info, (7) encryption-related includes in WiredTiger customization hooks.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.186 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 587 | 14 |  |  |  |  |
| claude-opus-4-5 | 23 | 10498 |  |  |  |  |


</details>


## Solution 2
### Summary

Changed perconaFeatures() return type from std::vector<StringData> to std::vector<std::string_view> in version.h, version.cpp, and version_impl.tpl.cpp to align with the StringData to std::string_view migration.

**By:** Agent (claude_cli v2.1.168 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `src/mongo/util/version.cpp` | Changed perconaFeatures() return type to std::vector<std::string_view> |
| `src/mongo/util/version_impl.tpl.cpp` | Changed perconaFeatures() return type and perconaFeatureList variable type to std::vector<std::string_view> |


### Unresolved Files

All conflicts have been resolved.


### Modified Files


| File Path | Explanation |
|-----------|-------------|
| `src/mongo/util/version.h` | Updated the base class pure virtual declaration of perconaFeatures() to return std::vector<std::string_view> - required for the implementation changes to compile correctly |


### Review Notes

The base class declaration in version.h had to be updated as well since perconaFeatures() is a virtual method. The perconaFeatureList variable in version_impl.tpl.cpp was also updated to match the new return type.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.168 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 507 | 15 |  |  |  |  |
| claude-opus-4-5 | 18 | 2423 |  |  |  |  |


</details>


## Solution 3
### Summary

PSMDB-2110: use string_view instead of StringData

**By:** Pawel Lebioda <pawel.lebioda@percona.com>

### Resolved Files

No files were resolved.


### Unresolved Files

All conflicts have been resolved.


### Modified Files


- `src/mongo/db/fts/fts_query_parser.cpp`



### Review Notes

No review notes provided.



---

*note created with mergai 0.1.dev1+g96d7692d2*
