### PR TITLE
PSMDB-2125: make telemetry tests hermetic and timing-robust

### DIFF
--- a/jstests/telemetry/_telemetry_helpers.js
+++ b/jstests/telemetry/_telemetry_helpers.js
@@ -1,4 +1,9 @@
-export const telmPath = "/tmp/psmdb";
+// Telemetry is written to a per-run directory under the test's data path so that
+// suites or jobs running concurrently on the same machine never collide on a single
+// global location. Falls back to /tmp when not run under resmoke.
+const _telmBase =
+    typeof MongoRunner !== "undefined" && MongoRunner.dataPath ? MongoRunner.dataPath : "/tmp/";
+export const telmPath = _telmBase + "psmdb_telemetry";
 export const setParameterOpts = {
     perconaTelemetryPath: telmPath,
     perconaTelemetryGracePeriod: 2,
@@ -15,6 +20,25 @@ export var cleanupDir = function (dir) {
 
 export var cleanupTelmDir = function () {
     cleanupDir(telmPath);
+};
+
+// Telemetry polls at this interval. The scrape interval is on the order of seconds, so the
+// 200ms assert.soon default just spins; 1s keeps the tests responsive without the churn.
+const kTelmPollIntervalMs = 1000;
+
+// Metric files are named "<epoch-seconds>-<instanceId>.json" (see TelemetryThreadBase): the
+// writer creates a ".tmp" first and atomically renames it to ".json" once fully written.
+// Restricting to ".json" files therefore skips entries caught mid-write, so callers do not
+// need to swallow parse errors from partially-written files.
+export var listTelmJsonFiles = function (dir = telmPath) {
+    return listFiles(dir).filter((file) => file.name.endsWith(".json"));
+};
+
+// The instance id is the file-name suffix, so it can be read without parsing the contents.
+var telmInstanceIdFromFile = function (file) {
+    var base = file.name.replace(/^.*\//, "").replace(/\.json$/, "");
+    var dash = base.indexOf("-");
+    return dash >= 0 ? base.substring(dash + 1) : base;
 };
 
 export var getTelmRawData = function () {
@@ -35,10 +59,9 @@ var getTelmInstanceId = function (conn) {
 
 export var getTelmDataByConn = function (conn) {
     var id = getTelmInstanceId(conn);
-    var files = listFiles(telmPath);
     var data = [];
-    files.forEach((file) => {
-        if (file.name.includes(id)) {
+    listTelmJsonFiles().forEach((file) => {
+        if (telmInstanceIdFromFile(file) === id) {
             data.push(JSON.parse(cat(file.name)));
         }
     });
@@ -46,13 +69,70 @@ export var getTelmDataByConn = function (conn) {
 };
 
 export var getTelmDataForMongos = function () {
-    var files = listFiles(telmPath);
     var data = [];
-    files.forEach((file) => {
+    listTelmJsonFiles().forEach((file) => {
         const obj = JSON.parse(cat(file.name));
         if (obj.source === "mongos") {
             data.push(obj);
         }
     });
     return data;
+};
+
+// Number of distinct telemetry-producing instances represented under `dir` (defaults to
+// telmPath). The scraper writes a fresh file on every scrape, so the raw file count grows
+// with elapsed time/load; counting distinct instances by the instance id encoded in the
+// file name (emitted by both mongod and mongos) is timing-independent and is the robust way
+// to assert "N nodes reported". Reading the id from the name also avoids parsing files that
+// may be caught mid-write.
+export var countTelmInstances = function (dir = telmPath) {
+    var ids = new Set();
+    listTelmJsonFiles(dir).forEach((file) => {
+        ids.add(telmInstanceIdFromFile(file));
+    });
+    return ids.size;
+};
+
+// Poll until `predicate` returns truthy, swallowing exceptions thrown while telemetry is
+// still being produced (e.g. a node's psmdb_telemetry.data not written yet). Replaces
+// fixed sleeps so the tests tolerate slow or variable startup/scrape timing.
+export var waitForTelm = function (predicate, msg) {
+    assert.soon(
+        () => {
+            try {
+                return predicate();
+            } catch (e) {
+                return false;
+            }
+        },
+        msg,
+        undefined,
+        kTelmPollIntervalMs,
+    );
+};
+
+// Poll until `getter()` returns a non-empty array, swallowing the transient parse errors
+// thrown while telemetry files are still being written (.tmp then renamed), and return
+// that captured array. Callers reuse the returned data rather than reading again
+// afterward, which would re-race an in-progress write.
+export var waitForTelmData = function (getter, msg) {
+    var captured;
+    assert.soon(
+        () => {
+            try {
+                var data = getter();
+                if (data.length > 0) {
+                    captured = data;
+                    return true;
+                }
+            } catch (e) {
+                // telemetry file still being written; retry on the next poll
+            }
+            return false;
+        },
+        msg,
+        undefined,
+        kTelmPollIntervalMs,
+    );
+    return captured;
 };

--- a/jstests/telemetry/telemetry_auth.js
+++ b/jstests/telemetry/telemetry_auth.js
@@ -5,6 +5,7 @@ import {
     cleanupTelmDir,
     getTelmDataByConn,
     getTelmDataForMongos,
+    waitForTelmData,
 } from "jstests/telemetry/_telemetry_helpers.js";
 
 // check for LDAP test configuration
@@ -21,7 +22,9 @@ const ldapOptions = {
 };
 
 // options for enabling LDAP with authorization
-const ldapAuthzOptions = Object.merge(ldapOptions, {ldapAuthzQueryTemplate: "{USER}?memberOf?base"});
+const ldapAuthzOptions = Object.merge(ldapOptions, {
+    ldapAuthzQueryTemplate: "{USER}?memberOf?base",
+});
 
 // options for enabling OIDC authentication
 const oidcOptions = {
@@ -72,10 +75,13 @@ function getMongodTelemetry(options) {
     var conn = MongoRunner.runMongod(options);
 
     assert(setParameterOpts.perconaTelemetryGracePeriod, "perconaTelemetryGracePeriod is not set");
-    sleep(setParameterOpts.perconaTelemetryGracePeriod * 1000);
-
-    const data = getTelmDataByConn(conn);
-    assert(data.length > 0, "No telemetry data found");
+    // Poll until the telemetry is present instead of sleeping exactly the grace period,
+    // which raced with slow startup. Capture it from the poll so we don't re-read and race
+    // a .tmp -> .json rename.
+    const data = waitForTelmData(
+        () => getTelmDataByConn(conn),
+        "No telemetry data found for mongod",
+    );
     print("Telemetry data collected: " + tojson(data));
 
     MongoRunner.stopMongod(conn);
@@ -97,11 +103,13 @@ function getMongosTelemetry(options) {
     });
 
     assert(setParameterOpts.perconaTelemetryGracePeriod, "perconaTelemetryGracePeriod is not set");
-    sleep(setParameterOpts.perconaTelemetryGracePeriod * 1000);
-
-    getTelmDataByConn(st.shard0);
-    const data = getTelmDataForMongos();
-    assert(data.length > 0, "No telemetry data found");
+    // Poll until the mongos telemetry is present instead of sleeping exactly the grace
+    // period, which raced with slow startup. Capture it from the poll so we don't re-read
+    // and race a .tmp -> .json rename.
+    const data = waitForTelmData(
+        () => getTelmDataForMongos(),
+        "No telemetry data found for mongos",
+    );
     print("Telemetry data collected: " + tojson(data));
 
     st.stop();
@@ -166,7 +174,11 @@ for (const getTelemetryFunc of [getMongodTelemetry, getMongosTelemetry]) {
 
         // LDAP authorization is not supported by mongos
         if (getTelemetryFunc !== getMongosTelemetry) {
-            testFields(getTelemetryFunc, ["ldap_enabled", "ldap_authorization_enabled"], ldapAuthzOptions);
+            testFields(
+                getTelemetryFunc,
+                ["ldap_enabled", "ldap_authorization_enabled"],
+                ldapAuthzOptions,
+            );
         }
     } else {
         print(

--- a/jstests/telemetry/telemetry_replicaset.js
+++ b/jstests/telemetry/telemetry_replicaset.js
@@ -5,6 +5,7 @@ import {
     cleanupTelmDir,
     getTelmRawData,
     getTelmDataByConn,
+    waitForTelm,
 } from "jstests/telemetry/_telemetry_helpers.js";
 
 (function () {
@@ -27,18 +28,39 @@ import {
         replTest.startSet();
         replTest.initiate();
 
-        sleep(3000);
-
-        var telmFileList = listFiles(telmPath);
-        assert.eq(3, telmFileList.length, telmFileList);
+        // Let every member reach its steady replication state before sampling telemetry,
+        // then drop any telemetry captured during STARTUP so the files we read reflect the
+        // settled PRIMARY/SECONDARY/ARBITER states. The first scrape can otherwise capture
+        // a transient STARTUP state (more likely when startup is slow), which made the
+        // replication_state asserts flaky. Counting distinct instances afterwards tolerates
+        // extra files from repeated scrapes.
+        replTest.awaitSecondaryNodes();
+        cleanupTelmDir();
+        // Wait until all three members have reported, capturing each node's telemetry from
+        // the poll so we don't re-read and race a .tmp -> .json rename.
+        var primaryTelmData, secondaryTelmData, arbiterTelmData;
+        waitForTelm(
+            () => {
+                const primary = getTelmDataByConn(replTest.nodes[0]);
+                const secondary = getTelmDataByConn(replTest.nodes[1]);
+                const arbiter = getTelmDataByConn(replTest.nodes[2]);
+                if (primary.length > 0 && secondary.length > 0 && arbiter.length > 0) {
+                    primaryTelmData = primary[0];
+                    secondaryTelmData = secondary[0];
+                    arbiterTelmData = arbiter[0];
+                    return true;
+                }
+                return false;
+            },
+            () =>
+                "telemetry from 3 replica set members did not appear; files: " +
+                tojson(listFiles(telmPath)),
+        );
 
         //test replication_state
         var telmData = getTelmRawData();
         jsTest.log("Get RS tetemetry");
         jsTest.log(telmData);
-        var primaryTelmData = getTelmDataByConn(replTest.nodes[0])[0];
-        var secondaryTelmData = getTelmDataByConn(replTest.nodes[1])[0];
-        var arbiterTelmData = getTelmDataByConn(replTest.nodes[2])[0];
         var dbReplicationId = primaryTelmData["db_replication_id"];
         assert.eq(primaryTelmData["replication_state"], "PRIMARY");
         assert.eq(secondaryTelmData["replication_state"], "SECONDARY");

--- a/jstests/telemetry/telemetry_sharded.js
+++ b/jstests/telemetry/telemetry_sharded.js
@@ -5,6 +5,9 @@ import {
     cleanupTelmDir,
     getTelmRawData,
     getTelmDataByConn,
+    getTelmDataForMongos,
+    countTelmInstances,
+    waitForTelm,
     cleanupDir,
 } from "jstests/telemetry/_telemetry_helpers.js";
 
@@ -24,21 +27,36 @@ import {
             configOptions: {setParameter: setParameterOpts},
         });
 
-        sleep(3000);
-
-        //test mongos + config_svr + shard_svr
-        var telmFileList = listFiles(telmPath);
-        assert.eq(3, telmFileList.length, telmFileList);
+        // Wait until all three roles (mongos + config server + shard) have written
+        // telemetry. Counting distinct instances tolerates extra files from repeated
+        // scrapes, which made the old "exactly 3 files after a 3s sleep" check flaky
+        // (e.g. 5 files observed when startup was slow).
+        waitForTelm(
+            () => countTelmInstances() >= 3,
+            () =>
+                "telemetry from 3 instances did not appear; files: " + tojson(listFiles(telmPath)),
+        );
 
         cleanupTelmDir();
-        //wait for sh init
-        sleep(5000);
+        // Wait until every role has reported again after the cleanup, capturing the config
+        // and shard telemetry from the poll so we don't re-read and race a .tmp -> .json
+        // rename.
+        var configTelmData, shardTelmData;
+        waitForTelm(() => {
+            const mongos = getTelmDataForMongos();
+            const config = getTelmDataByConn(st.config0);
+            const shard = getTelmDataByConn(st.shard0);
+            if (mongos.length > 0 && config.length > 0 && shard.length > 0) {
+                configTelmData = config[0];
+                shardTelmData = shard[0];
+                return true;
+            }
+            return false;
+        }, "telemetry from mongos, config server and shard did not all reappear after cleanup");
         var telmData = getTelmRawData();
         jsTest.log("Get sharded cluster telemetry");
         jsTest.log(telmData);
         assert.includes(telmData, "mongos");
-        var configTelmData = getTelmDataByConn(st.config0)[0];
-        var shardTelmData = getTelmDataByConn(st.shard0)[0];
         assert(configTelmData["db_cluster_id"]);
         assert(shardTelmData["db_cluster_id"]);
         assert.eq(configTelmData["db_cluster_id"], shardTelmData["db_cluster_id"]);
@@ -70,11 +88,21 @@ import {
             configOptions: {setParameter: setParameterOpt},
         });
 
-        sleep(3000);
-        var mongodTelmFileList = listFiles(mongodTelmPath);
-        assert.eq(2, mongodTelmFileList.length, mongodTelmFileList);
-        var mongosTelmFileList = listFiles(mongosTelmPath);
-        assert.eq(1, mongosTelmFileList.length, mongosTelmFileList);
+        // Two mongods (config server + shard) and one mongos should report at their
+        // respective default telemetry paths; poll on distinct instances rather than an
+        // exact file count so repeated scrapes do not break the check.
+        waitForTelm(
+            () => countTelmInstances(mongodTelmPath) >= 2,
+            () =>
+                "expected telemetry from 2 mongods at default path; files: " +
+                tojson(listFiles(mongodTelmPath)),
+        );
+        waitForTelm(
+            () => countTelmInstances(mongosTelmPath) >= 1,
+            () =>
+                "expected telemetry from mongos at default path; files: " +
+                tojson(listFiles(mongosTelmPath)),
+        );
         st.stop();
     };
 

--- a/jstests/telemetry/telemetry_single_node.js
+++ b/jstests/telemetry/telemetry_single_node.js
@@ -1,4 +1,12 @@
-import {telmPath, setParameterOpts, cleanupTelmDir, getTelmDataByConn} from "jstests/telemetry/_telemetry_helpers.js";
+import {
+    telmPath,
+    setParameterOpts,
+    cleanupTelmDir,
+    getTelmDataByConn,
+    listTelmJsonFiles,
+    waitForTelm,
+    waitForTelmData,
+} from "jstests/telemetry/_telemetry_helpers.js";
 
 (function () {
     "use strict";
@@ -11,18 +19,19 @@ import {telmPath, setParameterOpts, cleanupTelmDir, getTelmDataByConn} from "jst
             setParameter: setParameterOpts,
             storageEngine: storage,
         });
+        var graceSec = setParameterOpts.perconaTelemetryGracePeriod;
+        var scrapeSec = setParameterOpts.perconaTelemetryScrapeInterval;
 
-        //test perconaTelemetryGracePeriod
-        sleep(1000);
-        var telmFileList = listFiles(telmPath);
-        assert.eq(0, telmFileList.length, telmFileList);
-
-        sleep(2000);
-        telmFileList = listFiles(telmPath);
-        assert.eq(1, telmFileList.length, telmFileList);
-
-        //test telemetry data
-        var jsonTelmData = getTelmDataByConn(singleTest)[0];
+        // Grace period: the first scrape runs one grace period after start, so the first
+        // record's self-reported `uptime` (seconds since start, stamped server-side at
+        // scrape time) must be at least the grace period. Checking the value the server
+        // stamped is robust on slow machines -- unlike the old fixed shell-side sleep, which
+        // raced a startup that had already consumed the grace. Capture the data from the
+        // poll so we don't re-read and race a .tmp -> .json rename.
+        var jsonTelmData = waitForTelmData(
+            () => getTelmDataByConn(singleTest),
+            "first telemetry file did not appear after grace period",
+        )[0];
         jsTest.log("Get single-node telemetry");
         jsTest.log(jsonTelmData);
 
@@ -33,29 +42,63 @@ import {telmPath, setParameterOpts, cleanupTelmDir, getTelmDataByConn} from "jst
         assert(jsonTelmData["db_instance_id"], "db_instance_id doesn't exist");
         assert(jsonTelmData["db_internal_id"], "db_internal_id doesn't exist");
         assert(jsonTelmData["uptime"], "uptime doesn't exist");
+        var firstUptime = Number(jsonTelmData["uptime"]);
+        assert.gte(
+            firstUptime,
+            graceSec,
+            "first telemetry was written before the grace period elapsed",
+        );
 
-        //test perconaTelemetryScrapeInterval
-        sleep(5000);
-        telmFileList = listFiles(telmPath);
-        assert.eq(2, telmFileList.length, telmFileList);
+        // Scrape interval: a second scrape runs one scrape interval after the first, so a
+        // record with a later uptime appears and the gap between the two equals the scrape
+        // interval. Capture the later record from the poll and check the delta -- again
+        // using the server-stamped uptime rather than shell-side timing.
+        var secondUptime;
+        waitForTelm(() => {
+            const later = getTelmDataByConn(singleTest)
+                .map((r) => Number(r["uptime"]))
+                .filter((u) => u > firstUptime);
+            if (later.length === 0) {
+                return false;
+            }
+            secondUptime = Math.min(...later);
+            return true;
+        }, "second telemetry scrape did not appear after the scrape interval");
+        assert.gte(
+            secondUptime - firstUptime,
+            scrapeSec,
+            "second telemetry scrape ran before the scrape interval elapsed",
+        );
 
-        //test perconaTelemetryHistoryKeepInterval
-        sleep(5000);
-        telmFileList = listFiles(telmPath);
-        assert.eq(2, telmFileList.length, telmFileList);
+        // test perconaTelemetryHistoryKeepInterval: old files are pruned, so the file
+        // count stays bounded rather than growing with every scrape. Wait long enough
+        // for files to age past the keep interval and for the next scrape to run cleanup.
+        var historyKeepSec = setParameterOpts.perconaTelemetryHistoryKeepInterval;
+        sleep((historyKeepSec + scrapeSec + 1) * 1000);
+        assert.lte(listTelmJsonFiles().length, 2, listFiles(telmPath));
 
-        //test disable perconaTelemetry
-        assert.commandWorked(singleTest.getDB("admin").runCommand({setParameter: 1, "perconaTelemetry": false}));
+        //test disable perconaTelemetry: no new files are written after disabling
+        assert.commandWorked(
+            singleTest.getDB("admin").runCommand({setParameter: 1, "perconaTelemetry": false}),
+        );
         cleanupTelmDir();
-        sleep(6000);
-        telmFileList = listFiles(telmPath);
-        assert.eq(0, telmFileList.length, telmFileList);
+        // Wait longer than a scrape would take, then confirm nothing was written.
+        sleep(
+            (setParameterOpts.perconaTelemetryScrapeInterval +
+                setParameterOpts.perconaTelemetryGracePeriod +
+                1) *
+                1000,
+        );
+        assert.eq(0, listTelmJsonFiles().length, listFiles(telmPath));
 
         //test enable perconaTelemetry
-        assert.commandWorked(singleTest.getDB("admin").runCommand({setParameter: 1, "perconaTelemetry": true}));
-        sleep(3000);
-        telmFileList = listFiles(telmPath);
-        assert.eq(1, telmFileList.length, telmFileList);
+        assert.commandWorked(
+            singleTest.getDB("admin").runCommand({setParameter: 1, "perconaTelemetry": true}),
+        );
+        waitForTelm(
+            () => listTelmJsonFiles().length >= 1,
+            "telemetry did not resume after re-enabling",
+        );
 
         MongoRunner.stopMongod(singleTest);
     };


### PR DESCRIPTION
The telemetry scraper writes a file per scrape interval, so "exactly N files after a fixed sleep" assertions flaked under slow startup (`telemetry_sharded.js` saw 5 files, expected 3). Tests also shared the global `/tmp/psmdb` output dir, unsafe for jobs running concurrently on the same machine.

- `_telemetry_helpers.js`: write to a per-run dir under `MongoRunner.dataPath`; add `countTelmInstances()` (distinct reporting instances, robust to extra scrape files) and `waitForTelm()` (polls, swallowing transient mid-write errors) to replace fixed sleeps.
- `telemetry_sharded.js` / `telemetry_replicaset.js`: poll `countTelmInstances() >= 3` instead of `sleep` + exact file count.
- `telemetry_auth.js`: poll until the instance's telemetry is present.
- `telemetry_single_node.js`: poll for files; drop the racy pre-grace check and assert the count stays bounded, not an exact transient value.

Anything in this description will be included in the commit message. Replace or delete this text
before merging. Add links to testing in the comments of the PR.
