### PR TITLE
PSMDB-2125: harden ldapauthz_user_to_dn_cache against extra cache hits

### DIFF
--- a/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
+++ b/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
@@ -106,7 +106,29 @@ import {createAdminUser} from "jstests/ldapauthz/_setup.js";
         );
         var cache = stats.ldap.userToDNCache;
         for (var [key, val] of Object.entries(expected)) {
-            assert.eq(cache[key], val, msg + ": field " + key, {cache});
+            if (key === "hits") {
+                // The "hits" counter is a LOWER BOUND, not an exact value. A successful
+                // $external auth resolves the DN via mapUserToDN() at two call sites -- the
+                // SASL bind (external_sasl_authentication_session.cpp) and queryUserRoles()
+                // (ldap_manager_impl.cpp) -- which is the "miss + hit" the checkpoints below
+                // model. But the AuthorizationManager can also re-acquire an $external user's
+                // roles opportunistically (the short ldapUserCacheInvalidationInterval, session
+                // teardown around logout), and each extra acquisition runs queryUserRoles() ->
+                // mapUserToDN() again, adding another cache hit. That re-acquisition races the
+                // serverStatus read on the checkpoints taken right after an auth, so the exact
+                // hit count is timing-dependent and flakes under load (observed on the bb-psmdb
+                // farm: "expected NumberLong(2) to equal 1"). Assert hits >= expected so a
+                // legitimate extra hit does not fail the test.
+                //
+                // "misses" is intentionally NOT relaxed (asserted exactly below): a miss means
+                // an actual LDAP round-trip, so it is the metric that proves caching works and
+                // it is stable here -- on the post-auth checkpoints the DN is cached (a
+                // re-acquisition is a hit, not a miss), and the invalidation checkpoints settle
+                // via setParam()'s sleep before the read.
+                assert.gte(cache[key], val, msg + ": field " + key, {cache});
+            } else {
+                assert.eq(cache[key], val, msg + ": field " + key, {cache});
+            }
         }
     }
 


### PR DESCRIPTION
`assertCacheStats()` asserted the userToDN cache "hits" counter for exact equality, which is not stable. A successful `$external` auth resolves the DN via `mapUserToDN()` at two call sites (the SASL bind and `queryUserRoles()`), the "miss + hit" the checkpoints model. But the `AuthorizationManager` can also re-acquire an `$external` user's roles opportunistically (short `ldapUserCacheInvalidationInterval`, session teardown around logout), and each extra acquisition runs `queryUserRoles()` -> `mapUserToDN()` again, adding another hit. On the checkpoints read right after an auth (no settle time) that re-acquisition races the `serverStatus` read, so the count is timing-dependent and flakes under load -- seen on the bb-psmdb farm as "expected NumberLong(2) to equal 1" in `ldapauthz_user_to_dn_cache.js`.

Treat "hits" as a lower bound (`assert.gte`) while keeping every other field -- crucially "misses" -- exact. A miss means a real LDAP round-trip, so it is the metric that proves caching works and must not be relaxed; it is stable at every checkpoint (post-auth reads have the DN cached, so a re-acquisition is a hit not a miss, and the invalidation checkpoints settle via `setParam()`'s sleep).
