### PR TITLE
PSMDB-2141: automate the upstream-merge loop (periodic merge + merge gate + AI merge-pick)

### DIFF
--- a/.github/MERGAI.md
+++ b/.github/MERGAI.md
@@ -1,10 +1,19 @@
 # Mergai Workflow
 
-The `mergai.yml` workflow automates the process of merging upstream MongoDB commits into Percona Server for MongoDB, including AI-assisted conflict resolution and AI-assisted summary of merged commits.
+The `mergai.yml` workflow automates the process of merging upstream MongoDB commits into Percona
+Server for MongoDB, including AI-assisted conflict resolution and AI-assisted summary of merged
+commits.
+
+A companion `periodic-merge.yml` workflow runs the merge loop unattended: on a daily schedule (and,
+optionally, right after each merge lands) it decides _whether_ to merge and, if so, dispatches
+`mergai.yml` to do the work — replacing a human watching the Fork Status page and triggering merges
+by hand. Both workflows are tuned through GitHub Actions
+[repository variables](#repository-variables) and the merge-gate settings in `.mergai/config.yml`.
 
 ## Quick Start
 
-1. **Check available commits**: Visit the [Fork Status page](https://percona.github.io/percona-server-mongodb/)
+1. **Check available commits**: Visit the
+   [Fork Status page](https://percona.github.io/percona-server-mongodb/)
 2. **Trigger merge**: Go to Actions → "mergai bot" → "Run workflow", or use CLI:
 
    ```bash
@@ -13,16 +22,99 @@ The `mergai.yml` workflow automates the process of merging upstream MongoDB comm
 
 3. **Review the PR**: The workflow creates one of two PR types:
    - **Merge PR** - Clean merge without conflicts, ready for review
-   - **Conflict Solution PR** - Contains conflict markers with AI-resolved solutions visible in the diff for easy review
+   - **Conflict Solution PR** - Contains conflict markers with AI-resolved solutions visible in the
+     diff for easy review
 4. **Build and test**: Check out the branch locally, build, and run tests
 5. **Merge**: Post `/fast-forward` comment to merge without double commits
 
-## Workflow Jobs
+## Workflows
 
-| Job               | Trigger                          | Purpose                                              |
-| ----------------- | -------------------------------- | ---------------------------------------------------- |
-| `trigger-merge`   | Manual dispatch                  | Performs merge, handles conflicts with AI resolution |
-| `solution-merged` | PR merged to `mergai/*/conflict` | Finalizes after solution PR is merged                |
+### `mergai.yml` ("mergai bot")
+
+| Job               | Trigger                          | Purpose                                                                  |
+| ----------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| `trigger-merge`   | Manual dispatch                  | Picks a commit, performs the merge, handles conflicts with AI resolution |
+| `solution-merged` | PR merged to `mergai/*/conflict` | Finalizes after solution PR is merged                                    |
+
+`trigger-merge` no longer always merges the bare "next" commit. When dispatched **without** a
+`merge-pick` SHA it chooses the commit to merge according to the `MERGAI_MERGE_PICK_MODE` variable,
+and (in the `gate`/`ai` modes) only merges when the [merge gate](#merge-gate) is open — otherwise it
+logs "no merge pick" and exits without creating a PR. Passing an explicit `merge-pick` SHA bypasses
+both the mode and the gate (the manual "force this merge" path).
+
+It also early-fails if any mergai branch (`main`/`conflict`/`solution`/`semantic`) already exists
+for the chosen commit, so two runs can't race on the same merge.
+
+### `periodic-merge.yml` ("mergai periodic merge")
+
+Drives the merge loop without a human. It only _decides and triggers_ — all merge/conflict/PR
+behavior stays in `mergai.yml`'s `trigger-merge` job, which it dispatches unchanged.
+
+| Trigger                           | When it runs                                                                                                          |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `schedule` (cron)                 | Daily at 05:00 UTC, **only if** `MERGAI_PERIODIC_MERGE_ENABLED == 'true'`                                             |
+| `workflow_dispatch`               | Always (manual test); **not** gated by the enable toggles                                                             |
+| `pull_request` closed on `master` | Only if `MERGAI_FOLLOWUP_MERGE_ENABLED == 'true'` and a merged `mergai/*/main` PR — chains the next merge immediately |
+
+The pick happens in two phases so AI tokens are only ever spent in the privileged job:
+
+1. **Gate (here, token-free):** `mergai fork merge-pick --plan` decides _whether_ to merge (go/no-go
+   over fork status). If the gate is closed, the workflow stops. It also stops early if a mergai PR
+   is already open (a merge cycle is already underway).
+2. **Pick + merge (in `trigger-merge`):** the workflow dispatches `mergai.yml` with **no** SHA;
+   `trigger-merge` then picks the actual commit (deterministic or AI, per `MERGAI_MERGE_PICK_MODE`)
+   and merges it.
+
+> The cron _cadence_ is a literal in the workflow file — GitHub does not allow a variable there.
+> `MERGAI_PERIODIC_MERGE_ENABLED` only turns scheduled runs on/off; to change the frequency, edit
+> the `cron:` expression in `periodic-merge.yml`.
+
+## Repository Variables
+
+These are GitHub Actions **repository variables** (Settings → Secrets and variables → Actions →
+**Variables** tab), _not_ secrets. All are optional; unset variables fall back to the defaults
+below.
+
+| Variable                        | Used by          | Default     | Purpose                                                                                                               |
+| ------------------------------- | ---------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `MERGAI_REF`                    | both workflows   | `master`    | Git ref (branch/tag/commit) of the mergai CLI to install. A `mergai-ref` dispatch input to `mergai.yml` overrides it. |
+| `MERGAI_MERGE_PICK_MODE`        | `trigger-merge`  | `gate`      | How `trigger-merge` chooses which commit to merge when no SHA is given (see table below).                             |
+| `MERGAI_PERIODIC_MERGE_ENABLED` | `periodic-merge` | off (unset) | `true` enables the scheduled (cron) periodic merge. Manual dispatch ignores this toggle.                              |
+| `MERGAI_FOLLOWUP_MERGE_ENABLED` | `periodic-merge` | off (unset) | `true` chains the next merge automatically when a `mergai/*/main` PR is merged.                                       |
+
+### Merge pick mode (`MERGAI_MERGE_PICK_MODE`)
+
+Controls how `trigger-merge` selects the commit to merge **when dispatched without an explicit
+`merge-pick` SHA**. An explicit SHA always bypasses the mode and the gate.
+
+| Value                                                    | Honors gate? | Window cap? | How it picks the commit                                                                                                                               |
+| -------------------------------------------------------- | ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gate` _(default; also any unset or unrecognized value)_ | yes          | yes         | Deterministic: first prioritized strategy match within the candidate window, else the window tip (`merge-pick --gate`).                               |
+| `ai`                                                     | yes          | yes         | An AI agent chooses the best merge boundary within the candidate window (`merge-pick --ai`; spends AI tokens, hence runs only in the privileged job). |
+| `next`                                                   | **no**       | **no**      | Raw `merge-pick --next`: the first prioritized strategy match, with no gate and no window cap.                                                        |
+
+In `gate` and `ai` modes, a closed gate (or nothing to merge) yields an empty pick and the merge
+steps are skipped — no PR is created. `next` ignores the gate entirely.
+
+## Merge Gate
+
+The merge gate decides _when_ to merge (the pick decides _which_ commit). It is a pure go/no-go
+decision over already-computed fork status — no AI tokens — and is configured in
+`.mergai/config.yml` under `fork.merge_gate`:
+
+- `min_commits` — merge once at least this many unmerged commits have accumulated (default 50).
+- `max_age_days` — …or sooner if the oldest unmerged commit is older than this (default 2).
+- `max_commits` — batch ceiling and candidate-window size; a single merge never advances more than
+  this many commits (default 150).
+- `force_strategies` — strategy names that open the gate immediately regardless of count or age
+  (default `conflict`, `important_files`).
+
+The AI pick is configured alongside it under `fork.ai_pick` (`agent`, `rules_file`, `fallback`); the
+project rules it follows live in `.mergai/merge_pick_rules.md`.
+
+> **`MERGAI_MERGE_PICK_MODE` selects which pick `trigger-merge` runs** — `gate` (deterministic),
+> `ai`, or `next` — by calling `merge-pick --gate` / `--ai` / `--next` explicitly. The AI pick is
+> always opt-in via `--ai`; the `fork.ai_pick` settings only tune how it behaves when selected.
 
 ## Understanding PRs
 
@@ -43,7 +135,8 @@ If tests fail or changes are needed:
 
 ### Option 1 - Simple (commits not tracked by mergai)
 
-Add commits directly to the branch. This works but commits won't be marked as solutions for future reuse.
+Add commits directly to the branch. This works but commits won't be marked as solutions for future
+reuse.
 
 ### Option 2 - Tracked (recommended)
 
@@ -59,7 +152,8 @@ mergai pr update main    # Update PR description
 
 ## Merging the PR
 
-Ensure the PR branch is rebased onto (and fast-forwardable to) the base branch, then post a comment with `/fast-forward` to merge without creating extra merge commits.
+Ensure the PR branch is rebased onto (and fast-forwardable to) the base branch, then post a comment
+with `/fast-forward` to merge without creating extra merge commits.
 
 ## Canceling a Merge
 

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -8,10 +8,10 @@ on:
         required: false
         type: string
       mergai-ref:
-        description: "MergAI git ref to use (branch/tag/commit)"
+        description: "MergAI git ref (branch/tag/commit). Empty -> MERGAI_REF repo variable, else master."
         required: false
         type: string
-        default: "master"
+        default: ""
       mergai-agent:
         description: "AI agent to use for merge/describe/resolve (e.g., claude-cli:claude-opus-4-5)"
         required: false
@@ -68,7 +68,7 @@ jobs:
           claude-api-key: ${{ secrets.CLAUDE_API_KEY }}
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
-          mergai-ref: ${{ inputs['mergai-ref'] }}
+          mergai-ref: ${{ inputs['mergai-ref'] || vars.MERGAI_REF || 'master' }}
 
       # Get next prioritized commit to merge from upstream based on configured strategies
       - name: mergai merge-pick
@@ -163,7 +163,7 @@ jobs:
           setup-mergai: "true"
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
-          mergai-ref: master
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
 
       # Finalize after solution PR is merged into conflict branch
       - name: Finalize

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -87,6 +87,19 @@ jobs:
           echo "MERGE_PICK=$MERGE_PICK" >> $GITHUB_ENV
           mergai context init $MERGE_PICK
 
+      # Early-fail if a merge for this commit is already underway: any mergai
+      # branch (main/conflict/solution/semantic) for $MERGE_PICK means another
+      # trigger-merge run already started it. Abort rather than race it. This
+      # also covers the window the periodic-merge workflow can't see (a run
+      # dispatched but still awaiting privileged-ops approval, with no PR yet).
+      - name: Fail if a merge for this commit is already in progress
+        run: |
+          if [ -n "$(mergai branch list --sha "$MERGE_PICK" -q)" ]; then
+            echo "::error::mergai branches already exist for $MERGE_PICK - merge already in progress"
+            mergai branch list --sha "$MERGE_PICK"
+            exit 1
+          fi
+
       - name: merge
         env:
           MERGAI_AGENT: ${{ inputs['mergai-agent'] }}

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       merge-pick:
-        description: "Commit hash to merge (leave empty to use merge-pick --next)"
+        description: "Commit hash to merge (bypasses the gate). Empty -> pick per MERGAI_MERGE_PICK_MODE (gate/ai/next; default gate)."
         required: false
         type: string
       mergai-ref:
@@ -70,22 +70,80 @@ jobs:
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           mergai-ref: ${{ inputs['mergai-ref'] || vars.MERGAI_REF || 'master' }}
 
-      # Get next prioritized commit to merge from upstream based on configured strategies
-      - name: mergai merge-pick
-        if: ${{ !inputs['merge-pick'] }}
-        run: |
-          MERGE_PICK=$(mergai fork merge-pick --next)
-          echo "MERGE_PICK=$MERGE_PICK" >> $GITHUB_ENV
-          echo "Next merge pick is: $MERGE_PICK"
-          git show --stat $MERGE_PICK
-
-      # Initialize merge context with commit SHA and target branch info
-      - name: mergai context init
+      # Determine the commit to merge to. Precedence:
+      #   1. an explicit merge-pick input -> use it, bypassing the gate (the
+      #      manual "force this merge" path);
+      #   2. else the MERGAI_MERGE_PICK_MODE repository variable (not a secret),
+      #      one of three values:
+      #        * "ai"   -> the agent chooses the boundary within the gate's
+      #                    candidate window (uses AI tokens, hence in this
+      #                    privileged-ops job); honors the gate.
+      #        * "next" -> raw `merge-pick --next`: the first prioritized strategy
+      #                    match, with NO gate and NO window cap.
+      #        * "gate" -> gate-respecting deterministic pick (windowed). This is
+      #                    the default for an unset/any-other value.
+      # "ai" and "gate" honor the merge gate: when it is closed (or nothing to
+      # merge) they print nothing, so MERGE_PICK is empty and the merge steps
+      # below are skipped. "next" ignores the gate. To merge regardless of the
+      # gate, dispatch with an explicit merge-pick input.
+      - name: Determine merge pick
+        id: pick
         env:
-          MERGE_PICK: ${{ inputs['merge-pick'] || env.MERGE_PICK }}
+          MERGE_PICK_MODE: ${{ vars.MERGAI_MERGE_PICK_MODE }}
+          INPUT_PICK: ${{ inputs['merge-pick'] }}
         run: |
-          echo "MERGE_PICK=$MERGE_PICK" >> $GITHUB_ENV
-          mergai context init $MERGE_PICK
+          MERGE_PICK=""
+          if [ -n "$INPUT_PICK" ]; then
+            echo "Using explicit merge-pick input (gate bypassed): $INPUT_PICK"
+            MERGE_PICK="$INPUT_PICK"
+          else
+            case "$MERGE_PICK_MODE" in
+              ai)
+                echo "Merge-pick mode: ai (gate-respecting)"
+                # --json carries the agent's reasoning alongside the sha; --next
+                # would print only the bare sha and the reasoning would be lost.
+                PICK_JSON=$(mergai fork merge-pick --ai --json)
+                if [ -n "$PICK_JSON" ]; then
+                  MERGE_PICK=$(printf '%s' "$PICK_JSON" | jq -r '.sha // empty')
+                  AI_SOURCE=$(printf '%s' "$PICK_JSON" | jq -r '.source // empty')
+                  AI_REASONING=$(printf '%s' "$PICK_JSON" | jq -r '.reasoning // empty')
+                  echo "AI pick source: ${AI_SOURCE:-unknown}"
+                  if [ -n "$AI_REASONING" ]; then
+                    echo "AI pick reasoning: $AI_REASONING"
+                    {
+                      echo "### AI merge-pick"
+                      echo ""
+                      echo "- commit: \`${MERGE_PICK}\`"
+                      echo "- source: ${AI_SOURCE:-unknown}"
+                      echo ""
+                      echo "${AI_REASONING}"
+                    } >> "$GITHUB_STEP_SUMMARY"
+                  fi
+                fi
+                ;;
+              next)
+                echo "Merge-pick mode: next (raw strategy pick; ignores the gate)"
+                MERGE_PICK=$(mergai fork merge-pick --next)
+                ;;
+              *)
+                echo "Merge-pick mode: gate (gate-respecting deterministic)"
+                MERGE_PICK=$(mergai fork merge-pick --gate)
+                ;;
+            esac
+          fi
+          echo "MERGE_PICK=$MERGE_PICK" >> "$GITHUB_ENV"
+          echo "pick=$MERGE_PICK" >> "$GITHUB_OUTPUT"
+          if [ -z "$MERGE_PICK" ]; then
+            echo "No merge pick (merge gate closed or nothing to merge); skipping merge."
+          else
+            echo "Merge pick: $MERGE_PICK"
+            git show --stat "$MERGE_PICK"
+          fi
+
+      # Initialize merge context with commit SHA and target branch info.
+      - name: mergai context init
+        if: steps.pick.outputs.pick != ''
+        run: mergai context init "$MERGE_PICK"
 
       # Early-fail if a merge for this commit is already underway: any mergai
       # branch (main/conflict/solution/semantic) for $MERGE_PICK means another
@@ -93,6 +151,7 @@ jobs:
       # also covers the window the periodic-merge workflow can't see (a run
       # dispatched but still awaiting privileged-ops approval, with no PR yet).
       - name: Fail if a merge for this commit is already in progress
+        if: steps.pick.outputs.pick != ''
         run: |
           if [ -n "$(mergai branch list --sha "$MERGE_PICK" -q)" ]; then
             echo "::error::mergai branches already exist for $MERGE_PICK - merge already in progress"
@@ -101,6 +160,7 @@ jobs:
           fi
 
       - name: merge
+        if: steps.pick.outputs.pick != ''
         env:
           MERGAI_AGENT: ${{ inputs['mergai-agent'] }}
         run: |

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -1,0 +1,177 @@
+name: mergai periodic merge
+
+# Drive the merge-from-upstream loop: pick the next upstream commit to merge and,
+# unless a merge is already in progress, dispatch the `mergai bot` `trigger-merge`
+# job for it. This replaces a human watching the Fork Status page and dispatching
+# mergai.yml by hand.
+#
+# This workflow only *decides and triggers* - all merge/conflict/PR behavior lives
+# in mergai.yml's trigger-merge job, which is reused unchanged.
+#
+# Toggles (GitHub Actions repository *variables*, not secrets; both off by default):
+#   * MERGAI_PERIODIC_MERGE_ENABLED == 'true'  -> scheduled (cron) runs do work.
+#   * MERGAI_FOLLOWUP_MERGE_ENABLED  == 'true'   -> chain the next merge when a
+#                                                 mergai main PR is merged.
+# Manual workflow_dispatch always runs (for testing) regardless of the toggles.
+#
+# NOTE: the cron *cadence* cannot come from a variable - GitHub requires a literal
+# schedule expression here. To change the cadence, edit the cron below. The toggle
+# only turns scheduled runs on/off; it does not change their frequency.
+on:
+  schedule:
+    # Daily at 05:00 UTC (morning), ahead of the 06:00 update-fork-status run.
+    # Gated by MERGAI_PERIODIC_MERGE_ENABLED (see the job `if` below).
+    - cron: "0 5 * * *"
+  # Manual entry point for testing. Runs the identical logic - no special-casing,
+  # and is NOT gated by the enable toggles. (To force a merge regardless of state,
+  # dispatch mergai.yml directly instead.)
+  workflow_dispatch: {}
+  # Chain the next merge: when a mergai main PR (mergai/*/main -> master) is merged,
+  # the cycle is complete, so kick off the next pick immediately instead of waiting
+  # for the next cron tick. Gated by MERGAI_FOLLOWUP_MERGE_ENABLED; the job's `if`
+  # also restricts this to merged main PRs; the in-progress guard still applies
+  # (it just finds no open mergai PR by then).
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+# Never let two ticks decide to dispatch at the same time.
+concurrency:
+  group: mergai-periodic-merge
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read # mergai pr list -> read PRs
+  actions: write # gh workflow run mergai.yml
+
+jobs:
+  periodic-merge:
+    runs-on: ubuntu-latest
+    # Gate per trigger:
+    #   * workflow_dispatch -> always (manual test).
+    #   * schedule          -> only when MERGAI_PERIODIC_MERGE_ENABLED == 'true'.
+    #   * pull_request      -> only when MERGAI_FOLLOWUP_MERGE_ENABLED == 'true' AND
+    #                          a mergai main PR (mergai/*/main -> master) was merged
+    #                          (other closed PRs to master fire but are skipped).
+    # Unset variables are empty strings, so both toggles default to disabled.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'schedule'
+          && vars.MERGAI_PERIODIC_MERGE_ENABLED == 'true')
+      || (github.event_name == 'pull_request'
+          && vars.MERGAI_FOLLOWUP_MERGE_ENABLED == 'true'
+          && github.event.pull_request.merged == true
+          && startsWith(github.event.pull_request.head.ref, 'mergai/')
+          && endsWith(github.event.pull_request.head.ref, '/main'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Scheduled and follow-up (pull_request) runs always operate on the
+          # target branch tip, not the triggering ref (e.g. a just-merged
+          # mergai/*/main head), so merge-pick sees the latest master including
+          # the merge that just landed. A manual workflow_dispatch instead uses
+          # the dispatched ref, so config / rules changes on a feature branch
+          # can be exercised before they reach master. (For schedule, github.ref
+          # is already the default branch.)
+          ref: ${{ github.event_name == 'pull_request' && 'master' || github.ref }}
+          fetch-depth: 0
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+
+      - name: Setup mergai
+        uses: ./.github/actions/setup-mergai
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ vars.MERGAI_REF || 'master' }}
+
+      # In-progress guard, run as early as possible: an open mergai PR means a
+      # merge cycle is already underway, so stop and let it finish before doing
+      # any expensive work (the upstream fetch in 'fork init', status, pick).
+      # This only needs the mergai CLI, the checked-out .mergai/config.yml, and a
+      # token - no upstream remote - so it precedes 'fork init'. The pre-PR window
+      # (a trigger-merge run dispatched but still awaiting privileged-ops approval)
+      # is covered by the early-fail guard in mergai.yml's trigger-merge job.
+      - name: Stop if a merge is already in progress
+        id: guard
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "$(mergai pr --repo "$GITHUB_REPOSITORY" list -q)" ]; then
+            echo "A merge is already in progress. Open mergai PR(s):"
+            mergai pr --repo "$GITHUB_REPOSITORY" list
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "No mergai PR open; clear to proceed."
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Initialize fork
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          mergai fork init
+
+      # Informational: show divergence from upstream, the unmerged commits, and
+      # the prioritized merge picks (same view as the Fork Status page).
+      - name: Show fork status
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          mergai fork status -lp
+
+      # Phase 1 (token-free): evaluate the merge gate. `--plan` decides *when* to
+      # merge (go/no-go over fork status) and needs no AI tokens, so it's safe in
+      # this unprivileged job. The *which-commit* pick (deterministic or AI) is
+      # phase 2, done in mergai.yml's privileged trigger-merge job - so we only
+      # read `.action` here and dispatch without a sha.
+      - name: Evaluate merge gate
+        id: gate
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          PLAN=$(mergai fork merge-pick --plan)
+          echo "Gate plan: $PLAN"
+          ACTION=$(echo "$PLAN" | jq -r '.action')
+          REASON=$(echo "$PLAN" | jq -r '.reason // ""')
+          if [ "$ACTION" != "merge" ]; then
+            echo "Merge gate closed ($ACTION): $REASON"
+            echo "merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Merge gate open: $REASON"
+          echo "merge=true" >> "$GITHUB_OUTPUT"
+
+      # Phase 2: dispatch trigger-merge to do the actual pick + merge. No sha is
+      # passed - trigger-merge picks the commit itself (deterministic or AI per
+      # the MERGAI_MERGE_PICK_MODE variable), keeping any AI-token use inside the
+      # privileged-ops job.
+      - name: Trigger merge
+        if: steps.guard.outputs.proceed == 'true' && steps.gate.outputs.merge == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # `gh workflow run` dispatches the workflow file from the default
+          # branch unless --ref is given. On a manual workflow_dispatch, target
+          # the dispatched branch so a feature-branch mergai.yml is what runs
+          # (matching the branch this job checked out and evaluated the gate on).
+          # schedule/follow-up runs leave it empty and dispatch from the default
+          # branch. github.ref_name is the branch on workflow_dispatch, but a
+          # non-branch ref (e.g. <N>/merge) on pull_request, so it is only used
+          # for the dispatch event.
+          DISPATCH_REF: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || '' }}
+        run: |
+          set -euo pipefail
+          echo "Merge gate open; dispatching mergai.yml trigger-merge."
+          if [ -n "$DISPATCH_REF" ]; then
+            echo "Dispatching mergai.yml on ref: $DISPATCH_REF"
+            gh workflow run mergai.yml --ref "$DISPATCH_REF"
+          else
+            gh workflow run mergai.yml
+          fi

--- a/.github/workflows/update-fork-status.yml
+++ b/.github/workflows/update-fork-status.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/setup-mergai
         with:
           token: ${{ steps.app-token.outputs.token }}
-          ref: master
+          ref: ${{ vars.MERGAI_REF || 'master' }}
 
       - name: Initialize fork
         run: |

--- a/.mergai/config.yml
+++ b/.mergai/config.yml
@@ -159,6 +159,67 @@ fork:
           - src/mongo/db/repl/initial_sync/initial_syncer.h #since SERVER-103460
           - src/mongo/db/repl/initial_sync/initial_syncer.cpp # since SERVER-103460
 
+  # ---------------------------------------------------------------------------
+  # MERGE GATE CONFIGURATION
+  # ---------------------------------------------------------------------------
+  # Deterministic gate that decides *when* to merge (the pick decides *which*
+  # commit to merge to). It is a pure go/no-go decision over already-computed
+  # fork status and needs no AI tokens (`mergai fork merge-pick --plan`).
+  #
+  # The gate opens when ANY of these hold (evaluated in this order):
+  #   - a prioritized commit matches a strategy in `force_strategies`
+  #     (reason: force:<name>), or
+  #   - `commits_behind >= min_commits`, or
+  #   - the oldest unmerged commit is at least `max_age_days` old.
+  #
+  merge_gate:
+    # Merge once at least this many unmerged commits have accumulated.
+    # Default: 50
+    min_commits: 50
+
+    # ...or sooner if the oldest unmerged commit is older than this many days.
+    # Default: 2
+    max_age_days: 2
+
+    # Batch ceiling: a single merge never advances more than this many upstream
+    # commits. This also defines the candidate window (the oldest `max_commits`
+    # unmerged commits) - which bounds both the merge batch size and the AI
+    # prompt size. Commits newer than the window are omitted and drained by
+    # later merges.
+    # Default: 150
+    max_commits: 150
+
+    # Strategy names that open the gate immediately when any prioritized commit
+    # matches one, regardless of count or age. These are signals that a merge
+    # should not be deferred. Must be strategy names configured under
+    # merge_picks.strategies above. Default: [conflict, important_files]
+    force_strategies:
+      - conflict
+      - important_files
+
+  # ---------------------------------------------------------------------------
+  # AI PICK CONFIGURATION
+  # ---------------------------------------------------------------------------
+  # Settings for the AI-assisted merge pick (`mergai fork merge-pick --ai`),
+  # where an agent chooses the best merge boundary within the gate's candidate
+  # window, guided by the built-in system prompt plus the project rules file
+  # below. The AI pick is always selected explicitly via `--ai`; these settings
+  # only tune how it behaves.
+  ai_pick:
+    # Agent descriptor (same format as resolve.agent). Empty falls back to
+    # resolve.agent. Default: "" (-> resolve.agent)
+    agent: claude-cli:claude-opus-4-5
+
+    # Project-specific merge-pick rules (markdown), appended to the built-in
+    # system prompt. Holds PSMDB batch-size targets and boundary heuristics.
+    # Default: "" (no project rules)
+    rules_file: .mergai/merge_pick_rules.md
+
+    # What to do on agent error / invalid sha: "deterministic" (resilient -
+    # fall back to the deterministic pick) or "error" (fail).
+    # Default: deterministic
+    fallback: deterministic
+
 # -----------------------------------------------------------------------------
 # RESOLVE CONFIGURATION
 # -----------------------------------------------------------------------------

--- a/.mergai/merge_pick_rules.md
+++ b/.mergai/merge_pick_rules.md
@@ -1,0 +1,31 @@
+# PSMDB merge-pick rules
+
+## Target batch size
+
+- Aim for **~50 commits per merge** (comfortable band ~30–65).
+- Go smaller when there is a good reason to cut early; go larger only to reach a clean boundary, and
+  never beyond the candidate window.
+- Do not merge to the very newest candidate unless it is itself a clean boundary - leave the
+  freshest few commits for the next batch (see "Stop short of unsettled commits" below).
+
+## Where to cut
+
+- **End on a self-contained commit, not a mid-stream one.** Large vendored third-party imports and
+  auto-generated / regenerated artifact commits are ideal boundaries: they touch a well-isolated set
+  of files, rarely depend on the commits right after them, and are easy to validate post-merge. When
+  one sits near the target size, cut on it even if it is large - a big _atomic_ commit is a better
+  boundary than a smaller commit in the middle of active churn.
+- **Never split a coherent unit of work.** When consecutive commits clearly belong together - the
+  same work item, a stacked series, or a change plus its follow-up/fixup - end the batch after the
+  whole group or before it starts. Cutting between them lands the fork in a half-applied state that
+  is hard to build, test, and conflict-resolve.
+- **Keep a revert with what it reverts.** When upstream reverts a commit that is also in range,
+  include the original and its revert in the **same batch** so they cancel out instead of importing
+  a feature now and removing it next merge. If only the original is in range and its revert is just
+  beyond the window edge, prefer stopping **before** the original so the next batch takes the pair
+  together - importing a change upstream has already decided to undo is wasted conflict-resolution
+  effort.
+- **Stop short of unsettled commits.** This is why the batch should not end on the very newest
+  candidate: the freshest commits are the ones most likely to be reverted or fixed up within a day
+  or two. Leaving them for the next batch lets that churn resolve upstream first, so the fork
+  imports the settled result rather than the back-and-forth.


### PR DESCRIPTION
## What

Makes the mergai upstream-merge loop self-driving instead of hand-triggered. Adds a
scheduled `periodic-merge` workflow that decides *when* to merge, and extends
`trigger-merge` to decide *which* commit to merge (deterministic gate or AI) - all
driven by opt-in repository variables that are inert by default.

## Changes

- **New `periodic-merge.yml`** - evaluates the merge gate token-free and dispatches
  `mergai.yml` when it's open and no merge is in progress.
- **`trigger-merge` pick is mode-driven** (`MERGAI_MERGE_PICK_MODE`: `gate`/`ai`/`next`),
  honors the gate, and early-fails if a merge for the picked commit already exists.
- **`MERGAI_REF`** selects the mergai CLI ref for both workflows.
- **Merge gate + AI pick** config in `.mergai/config.yml` and `.mergai/merge_pick_rules.md`.

## Rollout

Defaults are safe: scheduled/follow-up merges stay off until their toggles are set, and
the pick mode defaults to deterministic (`gate`). Enable `MERGAI_PERIODIC_MERGE_ENABLED`
with `MERGAI_MERGE_PICK_MODE=gate` first, then switch to `ai` once validated.

## Details

See [`.github/MERGAI.md`](.github/MERGAI.md) for the full workflow description, the
repository variables, and the merge-pick-mode table.

**mergai** PR:  https://github.com/Percona-Lab/mergai/pull/27