### PR TITLE
PSMDB-2125: wire Percona jstests suites into bazel

### DIFF
--- a/jstests/audit/BUILD.bazel
+++ b/jstests/audit/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,35 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+# audit tests start their own fixtures via _audit_helpers.js: standalone mongod,
+# ReplSetTest, and ShardingTest (so the suite needs mongos). Audit log sinks are file and
+# console (no syslog daemon), so the suite is hermetic. audit_config.js loads these config
+# files by relative path at runtime; keyfiles for the auth tests are already in the
+# resmoke_suite_test default data.
+#
+# The 4 ShardingTest tests (auditTestShard) are self-clustering and want resources:cpu:2,
+# but a suite-level cpu:2 tag would route the WHOLE suite to a 2-core pool and make it
+# unschedulable on a 1-CPU-only farm. So the suite is left untagged to run on the default
+# pool.
+resmoke_suite_test(
+    name = "audit",
+    config = "//buildscripts/resmokeconfig:suites/audit.yml",
+    data = [
+        "//jstests/libs/config_files:audit_config.yaml",
+        "//jstests/libs/config_files:audit_config_basic.yaml",
+        "//jstests/libs/config_files:audit_config_deprecated.yaml",
+        "//jstests/libs/config_files:audit_config_destination_empty.yaml",
+        "//jstests/libs/config_files:audit_config_empty.yaml",
+    ],
+    shard_count = 10,
+    tags = [
+        "audit",
+        "percona",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/backup/BUILD.bazel
+++ b/jstests/backup/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,54 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+# Shared helper load()ed by the TDE wrongkey tests in jstests/percona/tde; exported so
+# those suites can depend on just this file rather than the whole backup library.
+exports_files([
+    "_backup_helpers.js",
+])
+
+# backup tests start their own mongod's; no external fixture beyond mongod + shell.
+resmoke_suite_test(
+    name = "backup",
+    config = "//buildscripts/resmokeconfig:suites/backup.yml",
+    tags = [
+        "backup",
+        "percona",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+# Encrypted variants: same fixture plus the TDE encryption key.
+resmoke_suite_test(
+    name = "backup_tde_cbc",
+    config = "//buildscripts/resmokeconfig:suites/backup_tde_cbc.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    tags = [
+        "backup_tde_cbc",
+        "percona",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+resmoke_suite_test(
+    name = "backup_tde_gcm",
+    config = "//buildscripts/resmokeconfig:suites/backup_tde_gcm.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    tags = [
+        "backup_tde_gcm",
+        "percona",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/knobs/BUILD.bazel
+++ b/jstests/knobs/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,16 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+resmoke_suite_test(
+    name = "knobs",
+    config = "//buildscripts/resmokeconfig:suites/knobs.yml",
+    tags = [
+        "knobs",
+        "percona",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/libs/config_files/BUILD.bazel
+++ b/jstests/libs/config_files/BUILD.bazel
@@ -15,6 +15,7 @@ exports_files(
     glob([
         "*.json",
         "*.ini",
+        "*.yaml",
     ]),
 )
 

--- a/jstests/oidc/BUILD.bazel
+++ b/jstests/oidc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,31 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+# OIDC tests run against a mock identity provider (jstests/oidc/lib/oidc_idp_mock.py, a
+# Python HTTP/HTTPS server launched by oidc_fixture.js), so the suite is self-contained
+# rather than needing a real external IdP -- but the worker's python3 must have the
+# `cryptography` and `PyJWT[crypto]` packages (both are in the repo poetry.lock; the mock
+# fails to start without them). Most tests parametrize over StandaloneMongod and
+# ShardedCluster, hence mongos. The suite roots are jstests/oidc/*.js (top level), so the
+# lib/ fixture + mock + certs must be shipped explicitly as data.
+resmoke_suite_test(
+    name = "oidc",
+    config = "//buildscripts/resmokeconfig:suites/oidc.yml",
+    data = [
+        "//jstests/oidc/lib:all_javascript_files",
+        "//jstests/oidc/lib:ca_oidc_idp.crt",
+        "//jstests/oidc/lib:ca_oidc_idp.pem",
+        "//jstests/oidc/lib:oidc_idp_mock.py",
+    ],
+    shard_count = 10,
+    tags = [
+        "oidc",
+        "percona",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/oidc/lib/BUILD.bazel
+++ b/jstests/oidc/lib/BUILD.bazel
@@ -10,3 +10,12 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+# The mock OIDC identity provider (a Python HTTP/HTTPS server) and its TLS material,
+# launched by oidc_idp_mock.js. Exported so the oidc suite can ship them as data; they are
+# referenced by relative path at runtime (jstests/oidc/lib/...).
+exports_files([
+    "oidc_idp_mock.py",
+    "ca_oidc_idp.pem",
+    "ca_oidc_idp.crt",
+])

--- a/jstests/percona/noPassthroughWithMongod/BUILD.bazel
+++ b/jstests/percona/noPassthroughWithMongod/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,16 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+resmoke_suite_test(
+    name = "percona_no_passthrough_with_mongod",
+    config = "//buildscripts/resmokeconfig:suites/percona_no_passthrough_with_mongod.yml",
+    tags = [
+        "percona",
+        "percona_no_passthrough_with_mongod",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/percona/tde/BUILD.bazel
+++ b/jstests/percona/tde/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,203 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+# Encryption key files referenced by the TDE suites via encryptionKeyFile /
+# config_variables. `ekf` is a valid key; `ekfw` is a deliberately wrong key used by the
+# tde_cbc/tde_gcm negative tests.
+exports_files([
+    "ekf",
+    "ekfw",
+])
+
+# TDE matrix. These run upstream test directories under an encrypted mongod, so the
+# targets live in this Percona-owned package rather than in the upstream dirs (avoids
+# upstream-merge conflicts); srcs auto-derive from the suite YAML's selector regardless.
+# core/replica_sets/sharding suites contain tests that stand up their own ShardingTest, so
+# they also need mongos.
+
+resmoke_suite_test(
+    name = "core_tde_cbc",
+    config = "//buildscripts/resmokeconfig:suites/core_tde_cbc.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 48,  # split much finer than upstream `core` (24); encrypted run is slower
+    tags = [
+        "core_tde_cbc",
+        "percona",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+resmoke_suite_test(
+    name = "core_tde_gcm",
+    config = "//buildscripts/resmokeconfig:suites/core_tde_gcm.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 48,  # split much finer than upstream `core` (24); encrypted run is slower
+    tags = [
+        "core_tde_gcm",
+        "percona",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+resmoke_suite_test(
+    name = "aggregation_tde_cbc",
+    config = "//buildscripts/resmokeconfig:suites/aggregation_tde_cbc.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 4,  # mirrors upstream `aggregation`
+    tags = [
+        "aggregation_tde_cbc",
+        "percona",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+resmoke_suite_test(
+    name = "aggregation_tde_gcm",
+    config = "//buildscripts/resmokeconfig:suites/aggregation_tde_gcm.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 4,  # mirrors upstream `aggregation`
+    tags = [
+        "aggregation_tde_gcm",
+        "percona",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+resmoke_suite_test(
+    name = "replica_sets_tde_cbc",
+    config = "//buildscripts/resmokeconfig:suites/replica_sets_tde_cbc.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 40,  # mirrors upstream `replica_sets`
+    # Each test stands up its own ReplSetTest; route to the multi-CPU pool (ticket §2).
+    tags = [
+        "percona",
+        "replica_sets_tde_cbc",
+        "resources:cpu:2",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+        "//src/mongo/tools/mongobridge_tool:mongobridge",  # replsets use ReplSetTest({useBridge: true})
+    ],
+)
+
+resmoke_suite_test(
+    name = "replica_sets_tde_gcm",
+    config = "//buildscripts/resmokeconfig:suites/replica_sets_tde_gcm.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 40,  # mirrors upstream `replica_sets`
+    # Each test stands up its own ReplSetTest; route to the multi-CPU pool (ticket §2).
+    tags = [
+        "percona",
+        "replica_sets_tde_gcm",
+        "resources:cpu:2",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+        "//src/mongo/tools/mongobridge_tool:mongobridge",  # replsets use ReplSetTest({useBridge: true})
+    ],
+)
+
+resmoke_suite_test(
+    name = "sharding_tde_cbc",
+    config = "//buildscripts/resmokeconfig:suites/sharding_tde_cbc.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 50,  # mirrors upstream `sharding`
+    # Each test stands up its own ShardingTest; route to the multi-CPU pool (ticket §2).
+    tags = [
+        "percona",
+        "resources:cpu:2",
+        "sharding_tde_cbc",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+        "//src/mongo/tools/mongobridge_tool:mongobridge",  # some ShardingTest variants use useBridge
+    ],
+)
+
+resmoke_suite_test(
+    name = "sharding_tde_gcm",
+    config = "//buildscripts/resmokeconfig:suites/sharding_tde_gcm.yml",
+    data = ["//jstests/percona/tde:ekf"],
+    shard_count = 50,  # mirrors upstream `sharding`
+    # Each test stands up its own ShardingTest; route to the multi-CPU pool (ticket §2).
+    tags = [
+        "percona",
+        "resources:cpu:2",
+        "sharding_tde_gcm",
+        "tde",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+        "//src/mongo/tools/mongobridge_tool:mongobridge",  # some ShardingTest variants use useBridge
+    ],
+)
+
+resmoke_suite_test(
+    name = "tde_cbc",
+    config = "//buildscripts/resmokeconfig:suites/tde_cbc.yml",
+    # tde_cbc/tde_gcm use both a valid (ekf) and a deliberately wrong (ekfw) key, and the
+    # wrongkey tests load()/share the backup helper.
+    data = [
+        "//jstests/backup:_backup_helpers.js",
+        "//jstests/percona/tde:ekf",
+        "//jstests/percona/tde:ekfw",
+    ],
+    tags = [
+        "percona",
+        "tde",
+        "tde_cbc",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
+resmoke_suite_test(
+    name = "tde_gcm",
+    config = "//buildscripts/resmokeconfig:suites/tde_gcm.yml",
+    data = [
+        "//jstests/backup:_backup_helpers.js",
+        "//jstests/percona/tde:ekf",
+        "//jstests/percona/tde:ekfw",
+    ],
+    tags = [
+        "percona",
+        "tde",
+        "tde_gcm",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/ratelimit/BUILD.bazel
+++ b/jstests/ratelimit/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,16 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+resmoke_suite_test(
+    name = "ratelimit",
+    config = "//buildscripts/resmokeconfig:suites/ratelimit.yml",
+    tags = [
+        "percona",
+        "ratelimit",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/redaction/BUILD.bazel
+++ b/jstests/redaction/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,20 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+resmoke_suite_test(
+    name = "redaction",
+    config = "//buildscripts/resmokeconfig:suites/redaction.yml",
+    # redaction_config.js / redaction_mongos_config.js load this config file via a relative path at runtime.
+    data = ["//jstests/libs/config_files:redaction_config.yaml"],
+    tags = [
+        "percona",
+        "redaction",
+    ],
+    # redaction_mongos_*.js stand up a ShardingTest.
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/telemetry/BUILD.bazel
+++ b/jstests/telemetry/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +11,18 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+resmoke_suite_test(
+    name = "telemetry",
+    config = "//buildscripts/resmokeconfig:suites/telemetry.yml",
+    tags = [
+        "percona",
+        "telemetry",
+    ],
+    # telemetry_sharded.js / telemetry_auth.js stand up a ShardingTest.
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)


### PR DESCRIPTION
Adds `resmoke_suite_test` targets so Percona-specific jstests suites build and
run under Bazel (RBE). No test logic changes - only `BUILD.bazel` wiring.

### Suites wired
- **audit** - sharded across 10 workers; mongod + mongos + shell
- **backup** + encrypted variants `backup_tde_cbc` / `backup_tde_gcm`
- **knobs**, **ratelimit**, **redaction**, **telemetry**
- **oidc** - mock IdP (python3 needs `cryptography` + `PyJWT[crypto]`)
- **percona_no_passthrough_with_mongod**
- **TDE matrix** - `core`, `aggregation`, `replica_sets`, `sharding` × CBC/GCM,
  plus `tde_cbc` / `tde_gcm`

### Notes
- TDE matrix targets live in the Percona-owned `jstests/percona/tde` package
  (not upstream dirs) to avoid merge conflicts; srcs derive from the suite YAML.
- Encryption key files (`ekf`, `ekfw`) and the backup helper are exported and
  shipped as `data` where suites reference them by relative path at runtime.
- replica_sets/sharding TDE suites tagged `resources:cpu:2` to route to the
  multi-CPU pool; audit left untagged to stay schedulable on a 1-CPU farm
  (sharded split deferred - see PSMDB-2125-audit-sharded-split.md).
- `jstests/libs/config_files` now exports `*.yaml` for the audit/redaction
  config fixtures.
