### PR TITLE
PSMDB-2125: add hermetic ldapauthz_mock suite and mock LDAP server

### DIFF
--- a/buildscripts/resmokeconfig/suites/ldapauthz_mock.yml
+++ b/buildscripts/resmokeconfig/suites/ldapauthz_mock.yml
@@ -1,0 +1,22 @@
+test_kind: js_test
+
+# Same tests as the ldapauthz suite, but run against the Python mock LDAP server
+# (jstests/ldapauthz/lib/ldap_mock.py) instead of a real slapd deployment.
+# Each test starts its own mock on a freshly allocated port via the `eval` import below.
+selector:
+  roots:
+    - jstests/ldapauthz/*.js
+  exclude_files:
+    - jstests/ldapauthz/_*.js
+
+# ldapauthz tests start their own mongod's.
+executor:
+  config:
+    shell_options:
+      eval: await import("jstests/ldapauthz/lib/use_mock_ldap.js");
+      global_vars:
+        TestData:
+          ldapQueryUser: "cn=admin,dc=percona,dc=com"
+          ldapQueryPassword: "password"
+          ldapAuthzQueryTemplate: "dc=percona,dc=com??sub?(&(objectClass=groupOfNames)(member={USER}))"
+      nodb: ""

--- a/buildscripts/resmokeconfig/suites/ldapauthz_mock.yml
+++ b/buildscripts/resmokeconfig/suites/ldapauthz_mock.yml
@@ -16,7 +16,7 @@ executor:
       eval: await import("jstests/ldapauthz/lib/use_mock_ldap.js");
       global_vars:
         TestData:
-          ldapQueryUser: "cn=admin,dc=percona,dc=com"
-          ldapQueryPassword: "password"
+          # ldapQueryUser / ldapQueryPassword are set by use_mock_ldap.js (imported via the
+          # eval above) from ldap_directory.js, so they stay in sync with the mock directory.
           ldapAuthzQueryTemplate: "dc=percona,dc=com??sub?(&(objectClass=groupOfNames)(member={USER}))"
       nodb: ""

--- a/jstests/ldapauthz/BUILD.bazel
+++ b/jstests/ldapauthz/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@poetry//:dependencies.bzl", "dependency")
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,3 +12,34 @@ mongo_js_library(
 )
 
 all_subpackage_javascript_files()
+
+# ldapauthz tests run against a mock LDAP server (jstests/ldapauthz/lib/ldap_mock.py, a
+# Python server built on ldaptor and launched by use_mock_ldap.js), so this suite is
+# self-contained rather than needing a real slapd deployment.
+# The non-mock ldapauthz suite (buildscripts/resmokeconfig/suites/ldapauthz.yml)
+# is intentionally NOT wired into Bazel because it needs an external LDAP server.
+# The tests start their own standalone mongod's (nodb), so the lib/ override + mock
+# must be shipped explicitly as data.
+resmoke_suite_test(
+    name = "ldapauthz_mock",
+    config = "//buildscripts/resmokeconfig:suites/ldapauthz_mock.yml",
+    data = [
+        "//jstests/ldapauthz/lib:all_javascript_files",
+        "//jstests/ldapauthz/lib:ldap_mock.py",
+        # ldap_mock.py is launched (via use_mock_ldap.js) by the test's RESMOKE_PYTHON,
+        # which imports modules from the resmoke runtime's PYTHONPATH. ldaptor is not a
+        # resmoke dependency, so ship it.
+        dependency(
+            "ldaptor",
+            group = "external-auth",
+        ),
+    ],
+    tags = [
+        "ldap",
+        "percona",
+    ],
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/shell:mongo",
+    ],
+)

--- a/jstests/ldapauthz/_check.js
+++ b/jstests/ldapauthz/_check.js
@@ -1,50 +1,12 @@
-// Check authorization result
+// Check authorization result.
+//
+// The expected (user DN -> role DNs) mapping is derived from the shared directory
+// source of truth (jstests/ldapauthz/lib/ldap_directory.js), the same data fed to the
+// mock LDAP server, so the two cannot drift.
 
-const shortusernames = [
-    "exttestro",
-    "exttestrw",
-    "extotherro",
-    "extotherrw",
-    "extbothro",
-    "extbothrw",
-    "exttestrwotherro",
-    "exttestrootherrw",
-    "Surname\\, Name",
-    'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\',
-];
+import {rolesmap, shortusernames} from "jstests/ldapauthz/lib/ldap_directory.js";
 
-const rolesmap = {
-    "cn=exttestro,dc=percona,dc=com": ["cn=testreaders,dc=percona,dc=com", "cn=testusers,dc=percona,dc=com"],
-    "cn=exttestrw,dc=percona,dc=com": ["cn=testwriters,dc=percona,dc=com", "cn=testusers,dc=percona,dc=com"],
-    "cn=extotherro,dc=percona,dc=com": ["cn=otherreaders,dc=percona,dc=com", "cn=otherusers,dc=percona,dc=com"],
-    "cn=extotherrw,dc=percona,dc=com": ["cn=otherwriters,dc=percona,dc=com", "cn=otherusers,dc=percona,dc=com"],
-    "cn=extbothro,dc=percona,dc=com": [
-        "cn=testreaders,dc=percona,dc=com",
-        "cn=otherreaders,dc=percona,dc=com",
-        "cn=testusers,dc=percona,dc=com",
-        "cn=otherusers,dc=percona,dc=com",
-    ],
-    "cn=extbothrw,dc=percona,dc=com": [
-        "cn=testwriters,dc=percona,dc=com",
-        "cn=otherwriters,dc=percona,dc=com",
-        "cn=testusers,dc=percona,dc=com",
-        "cn=otherusers,dc=percona,dc=com",
-    ],
-    "cn=exttestrwotherro,dc=percona,dc=com": [
-        "cn=testwriters,dc=percona,dc=com",
-        "cn=otherreaders,dc=percona,dc=com",
-        "cn=testusers,dc=percona,dc=com",
-        "cn=otherusers,dc=percona,dc=com",
-    ],
-    "cn=exttestrootherrw,dc=percona,dc=com": [
-        "cn=testreaders,dc=percona,dc=com",
-        "cn=otherwriters,dc=percona,dc=com",
-        "cn=testusers,dc=percona,dc=com",
-        "cn=otherusers,dc=percona,dc=com",
-    ],
-    "cn=Surname\\, Name,dc=percona,dc=com": ["cn=specchar\\2C\\2B\\3D\\5C,dc=percona,dc=com"],
-    'cn=Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\,dc=percona,dc=com': ["cn=specchar\\2C\\2B\\3D\\5C,dc=percona,dc=com"],
-};
+export {rolesmap, shortusernames};
 
 //{
 //	"authInfo" : {
@@ -67,7 +29,7 @@ const rolesmap = {
 //	},
 //	"ok" : 1
 //}
-function checkConnectionStatus(username, cs, name_to_dn) {
+export function checkConnectionStatus(username, cs, name_to_dn) {
     "use strict";
 
     assert.eq(cs.authInfo.authenticatedUsers[0].db, "$external");
@@ -83,11 +45,17 @@ function checkConnectionStatus(username, cs, name_to_dn) {
     let authorizedroles = [];
     // all authorized roles must be in our rolesmap
     cs.authInfo.authenticatedUserRoles.forEach(function (entry) {
-        assert(userroles.includes(entry.role), `User '${user}' was authorized to unexpected role '${entry.role}'`);
+        assert(
+            userroles.includes(entry.role),
+            `User '${user}' was authorized to unexpected role '${entry.role}'`,
+        );
         authorizedroles.push(entry.role);
     });
     // all roles from our rolesmap must be authorized
     userroles.forEach(function (entry) {
-        assert(authorizedroles.includes(entry), `User '${user}' was not authorized '${entry}' role`);
+        assert(
+            authorizedroles.includes(entry),
+            `User '${user}' was not authorized '${entry}' role`,
+        );
     });
 }

--- a/jstests/ldapauthz/ldapauthz_mapping_query.js
+++ b/jstests/ldapauthz/ldapauthz_mapping_query.js
@@ -1,3 +1,5 @@
+import {checkConnectionStatus, shortusernames} from "jstests/ldapauthz/_check.js";
+
 (function () {
     "use strict";
 
@@ -16,9 +18,6 @@
     });
 
     assert(conn, "Cannot start mongod instance");
-
-    // load check roles routine
-    load("jstests/ldapauthz/_check.js");
 
     var db = conn.getDB("$external");
 

--- a/jstests/ldapauthz/ldapauthz_mapping_subst.js
+++ b/jstests/ldapauthz/ldapauthz_mapping_subst.js
@@ -1,3 +1,5 @@
+import {checkConnectionStatus, shortusernames} from "jstests/ldapauthz/_check.js";
+
 (function () {
     "use strict";
 
@@ -15,9 +17,6 @@
     });
 
     assert(conn, "Cannot start mongod instance");
-
-    // load check roles routine
-    load("jstests/ldapauthz/_check.js");
 
     var db = conn.getDB("$external");
 

--- a/jstests/ldapauthz/ldapauthz_memberof.js
+++ b/jstests/ldapauthz/ldapauthz_memberof.js
@@ -1,3 +1,5 @@
+import {checkConnectionStatus, shortusernames} from "jstests/ldapauthz/_check.js";
+
 (function () {
     "use strict";
 
@@ -16,9 +18,6 @@
     });
 
     assert(conn, "Cannot start mongod instance");
-
-    // load check roles routine
-    load("jstests/ldapauthz/_check.js");
 
     var db = conn.getDB("$external");
 

--- a/jstests/ldapauthz/ldapauthz_pool_invalidation.js
+++ b/jstests/ldapauthz/ldapauthz_pool_invalidation.js
@@ -2,12 +2,11 @@
  * Tests that LDAP connection pool is invalidated when bind credentials
  * are changed at runtime via setParameter.
  */
+import {checkConnectionStatus} from "jstests/ldapauthz/_check.js";
 import {createAdminUser} from "jstests/ldapauthz/_setup.js";
 
 (function () {
     "use strict";
-
-    load("jstests/ldapauthz/_check.js");
 
     const username = "cn=exttestro,dc=percona,dc=com";
     const userpwd = "exttestro9a5S";
@@ -55,7 +54,9 @@ import {createAdminUser} from "jstests/ldapauthz/_setup.js";
     // Change ldapQueryPassword to an invalid value — pool should be invalidated
     var adminDb = conn.getDB("admin");
     assert(adminDb.auth({user: "admin", pwd: "password"}));
-    assert.commandWorked(adminDb.adminCommand({setParameter: 1, ldapQueryPassword: "wrong_password"}));
+    assert.commandWorked(
+        adminDb.adminCommand({setParameter: 1, ldapQueryPassword: "wrong_password"}),
+    );
     adminDb.logout();
 
     // Wait for user cache to be invalidated
@@ -71,7 +72,9 @@ import {createAdminUser} from "jstests/ldapauthz/_setup.js";
 
     // Restore correct ldapQueryPassword — pool invalidated again
     assert(adminDb.auth({user: "admin", pwd: "password"}));
-    assert.commandWorked(adminDb.adminCommand({setParameter: 1, ldapQueryPassword: TestData.ldapQueryPassword}));
+    assert.commandWorked(
+        adminDb.adminCommand({setParameter: 1, ldapQueryPassword: TestData.ldapQueryPassword}),
+    );
     adminDb.logout();
 
     // Auth should succeed again with restored credentials

--- a/jstests/ldapauthz/ldapauthz_simple.js
+++ b/jstests/ldapauthz/ldapauthz_simple.js
@@ -1,3 +1,5 @@
+import {checkConnectionStatus, shortusernames} from "jstests/ldapauthz/_check.js";
+
 (function () {
     "use strict";
 
@@ -14,9 +16,6 @@
     });
 
     assert(conn, "Cannot start mongod instance");
-
-    // load check roles routine
-    load("jstests/ldapauthz/_check.js");
 
     var db = conn.getDB("$external");
 

--- a/jstests/ldapauthz/ldapauthz_userRoles_with_dn.js
+++ b/jstests/ldapauthz/ldapauthz_userRoles_with_dn.js
@@ -4,12 +4,13 @@
     // test command line parameters related to LDAP authorization
     var conn = MongoRunner.runMongod({
         auth: "",
-        ldapServers: "localhost:389",
+        ldapServers: TestData.ldapServers,
         ldapTransportSecurity: "none",
         ldapBindMethod: "simple",
-        ldapQueryUser: "cn=admin,dc=percona,dc=com",
-        ldapQueryPassword: "password",
-        ldapAuthzQueryTemplate: "dc=percona,dc=com?dn?sub?(&(objectClass=groupOfNames)(member={USER}))",
+        ldapQueryUser: TestData.ldapQueryUser,
+        ldapQueryPassword: TestData.ldapQueryPassword,
+        ldapAuthzQueryTemplate:
+            "dc=percona,dc=com?dn?sub?(&(objectClass=groupOfNames)(member={USER}))",
         setParameter: {authenticationMechanisms: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-1"},
     });
 

--- a/jstests/ldapauthz/ldapauthz_userRoles_with_dn.js
+++ b/jstests/ldapauthz/ldapauthz_userRoles_with_dn.js
@@ -16,9 +16,6 @@
 
     assert(conn, "Cannot start mongod instance");
 
-    // load check roles routine
-    load("jstests/ldapauthz/_check.js");
-
     var db = conn.getDB("$external");
 
     const username = "cn=" + "exttestro" + ",dc=percona,dc=com";

--- a/jstests/ldapauthz/ldapauthz_user_cache.js
+++ b/jstests/ldapauthz/ldapauthz_user_cache.js
@@ -20,9 +20,6 @@
 
     assert(conn, "Cannot start mongod instance");
 
-    // load check roles routine
-    load("jstests/ldapauthz/_check.js");
-
     var db = conn.getDB("$external");
 
     const username = "cn=" + "exttestro" + ",dc=percona,dc=com";

--- a/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
+++ b/jstests/ldapauthz/ldapauthz_user_to_dn_cache.js
@@ -6,12 +6,11 @@
  * - Cache is invalidated when ldapUserToDNCacheSize is changed at runtime
  * - New server parameters can be read and set at runtime
  */
+import {checkConnectionStatus} from "jstests/ldapauthz/_check.js";
 import {createAdminUser} from "jstests/ldapauthz/_setup.js";
 
 (function () {
     "use strict";
-
-    load("jstests/ldapauthz/_check.js");
 
     const username = "exttestro";
     const userpwd = "exttestro9a5S";

--- a/jstests/ldapauthz/lib/BUILD.bazel
+++ b/jstests/ldapauthz/lib/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+
+package(default_visibility = ["//visibility:public"])
+
+mongo_js_library(
+    name = "all_javascript_files",
+    srcs = glob([
+        "*.js",
+    ]),
+)
+
+all_subpackage_javascript_files()
+
+# The mock LDAP server (a Python server built on ldaptor), launched by use_mock_ldap.js.
+# Exported so the ldapauthz_mock suite can ship it as data; it is referenced by relative
+# path at runtime (jstests/ldapauthz/lib/ldap_mock.py).
+exports_files([
+    "ldap_mock.py",
+])

--- a/jstests/ldapauthz/lib/ldap_directory.js
+++ b/jstests/ldapauthz/lib/ldap_directory.js
@@ -1,0 +1,115 @@
+/**
+ * Single source of truth for the mock LDAP directory used by the ldapauthz_mock suite.
+ *
+ * Both ends of the suite derive their data from this module so they cannot drift:
+ *   - the Python mock server (lib/ldap_mock.py) is fed this data as JSON, serialised and
+ *     passed on the command line by lib/ldap_mock.js;
+ *   - the test-side authorization checks (_check.js) build their expectations from the
+ *     same (user -> groups) mapping here.
+ *
+ * The directory contents mirror support-files/ldap-sasl/ldap/{users,groups}.ldif. The
+ * single source of truth is the (short username -> groups) mapping below; everything else
+ * (DNs, passwords, member / memberOf attributes) is derived from it.
+ */
+
+export const BASE_DN = "dc=percona,dc=com";
+
+// The bind/query user used by mongod (ldapQueryUser / ldapQueryPassword).
+export const ADMIN_DN = "cn=admin," + BASE_DN;
+export const ADMIN_PASSWORD = "password";
+
+// Password suffix appended to the short user name, mirroring settings.conf
+// (LDAP_PASS_SUFFIX) and support-files/ldap-sasl/ldap/users.ldif.
+export const PASSWORD_SUFFIX = "9a5S";
+
+// Short user names. The last two exercise DN special-character handling.
+export const USERS = [
+    "exttestro",
+    "exttestrw",
+    "extotherro",
+    "extotherrw",
+    "extbothro",
+    "extbothrw",
+    "exttestrwotherro",
+    "exttestrootherrw",
+    "Surname\\, Name",
+    'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\',
+];
+
+// group cn -> member short user names. Mirrors support-files/ldap-sasl/ldap/groups.ldif.
+export const GROUPS = {
+    "testreaders": ["exttestro", "extbothro", "exttestrootherrw"],
+    "testwriters": ["exttestrw", "extbothrw", "exttestrwotherro"],
+    "otherreaders": ["extotherro", "extbothro", "exttestrwotherro"],
+    "otherwriters": ["extotherrw", "extbothrw", "exttestrootherrw"],
+    "testusers": [
+        "exttestro",
+        "exttestrwotherro",
+        "exttestrw",
+        "exttestrootherrw",
+        "extbothro",
+        "extbothrw",
+    ],
+    "otherusers": [
+        "extotherro",
+        "exttestrwotherro",
+        "extotherrw",
+        "exttestrootherrw",
+        "extbothro",
+        "extbothrw",
+    ],
+};
+
+// The special-character group. groups.ldif stores its DN with character escaping
+// (cn=specchar\,\+\=\\,...) but slapd returns it -- and the tests expect it -- in
+// hex-escaped form. This exact string is emitted on the wire and used as a role.
+export const SPECCHAR_GROUP_DN = "cn=specchar\\2C\\2B\\3D\\5C," + BASE_DN;
+export const SPECCHAR_GROUP_CN = "specchar,+=\\";
+export const SPECCHAR_MEMBERS = ["Surname\\, Name", 'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\'];
+
+export function userDn(shortName) {
+    return "cn=" + shortName + "," + BASE_DN;
+}
+
+export function groupDn(cn) {
+    return "cn=" + cn + "," + BASE_DN;
+}
+
+// Short user names exactly as the tests authenticate them.
+export const shortusernames = USERS;
+
+// user DN -> list of role (group) DNs the user must be authorized for. Derived from
+// GROUPS (and the special-character group) so it stays in sync with the mock directory.
+// Order is irrelevant: _check.js compares the two sides as sets.
+export const rolesmap = (function () {
+    const map = {};
+    for (const short of USERS) {
+        map[userDn(short)] = [];
+    }
+    for (const [cn, members] of Object.entries(GROUPS)) {
+        for (const m of members) {
+            map[userDn(m)].push(groupDn(cn));
+        }
+    }
+    for (const m of SPECCHAR_MEMBERS) {
+        map[userDn(m)].push(SPECCHAR_GROUP_DN);
+    }
+    return map;
+})();
+
+/**
+ * The directory specification handed to lib/ldap_mock.py as JSON (see lib/ldap_mock.js).
+ */
+export function directorySpec() {
+    return {
+        base_dn: BASE_DN,
+        admin_dn: ADMIN_DN,
+        admin_password: ADMIN_PASSWORD,
+        password_suffix: PASSWORD_SUFFIX,
+        users: USERS,
+        groups: GROUPS,
+        specchar_group_dn: SPECCHAR_GROUP_DN,
+        specchar_group_cn: SPECCHAR_GROUP_CN,
+        specchar_members: SPECCHAR_MEMBERS,
+    };
+}

--- a/jstests/ldapauthz/lib/ldap_mock.js
+++ b/jstests/ldapauthz/lib/ldap_mock.js
@@ -1,3 +1,4 @@
+import {directorySpec} from "jstests/ldapauthz/lib/ldap_directory.js";
 import {getPython3Binary} from "jstests/libs/python.js";
 
 const LDAP_MOCK_PATH = "jstests/ldapauthz/lib/ldap_mock.py";
@@ -28,6 +29,12 @@ export class LDAPMock {
      */
     start() {
         let args = [this.python, LDAP_MOCK_PATH, "--port", String(this.port), "--host", this.host];
+        // Feed the directory contents (users, groups, DNs, passwords) to the mock as a
+        // single JSON document so it shares a single source of truth with the test-side
+        // checks (jstests/ldapauthz/lib/ldap_directory.js). _startMongoProgram execs
+        // directly (no shell), so the JSON -- which contains backslashes and other
+        // special characters -- is passed through as one argv element untouched.
+        args.push("--directory-json", JSON.stringify(directorySpec()));
         if (this.verbose) {
             args.push("--verbose");
         }

--- a/jstests/ldapauthz/lib/ldap_mock.js
+++ b/jstests/ldapauthz/lib/ldap_mock.js
@@ -1,0 +1,65 @@
+import {getPython3Binary} from "jstests/libs/python.js";
+
+const LDAP_MOCK_PATH = "jstests/ldapauthz/lib/ldap_mock.py";
+const LDAP_MOCK_START_STR = "LDAP mock server is running on ";
+
+/**
+ * Wrapper that launches the Python mock LDAP server (jstests/ldapauthz/lib/ldap_mock.py)
+ * as a child process. The server implements just enough LDAP for the ldapauthz suite
+ * (simple bind + search) so the tests can run without a real slapd deployment.
+ */
+export class LDAPMock {
+    /**
+     * @param {Object} opts
+     * @param {number} opts.port TCP port the mock should listen on.
+     * @param {string} [opts.host="127.0.0.1"] Interface to bind to.
+     * @param {boolean} [opts.verbose=false] Log binds/searches to stdout.
+     */
+    constructor({port, host = "127.0.0.1", verbose = false}) {
+        this.python = getPython3Binary();
+        this.port = port;
+        this.host = host;
+        this.verbose = verbose;
+        this.pid = null;
+    }
+
+    /**
+     * Start the mock LDAP server and wait until it is listening.
+     */
+    start() {
+        let args = [this.python, LDAP_MOCK_PATH, "--port", String(this.port), "--host", this.host];
+        if (this.verbose) {
+            args.push("--verbose");
+        }
+
+        // Clear buffered output so the readiness check below can't match a stale banner
+        // from an earlier program (mirrors the OIDC IdP mock).
+        clearRawMongoProgramOutput();
+
+        this.pid = _startMongoProgram({args: args});
+        assert(checkProgram(this.pid).alive, "LDAP mock server failed to start");
+
+        const start_msg = LDAP_MOCK_START_STR + this.host + ":" + this.port;
+        assert.soon(() => {
+            // Fail fast (instead of spinning for the full timeout) if the process died
+            // during startup -- e.g. an import error, port conflict, or exception in
+            // ldap_mock.py before it printed its readiness banner. assert.soon has no
+            // process-death detection of its own.
+            assert(
+                checkProgram(this.pid).alive,
+                "LDAP mock server exited during startup; see program output above",
+            );
+            return rawMongoProgramOutput(start_msg) !== "";
+        }, "LDAP mock server did not become ready: " + start_msg);
+    }
+
+    /**
+     * Stop the mock LDAP server if it is running.
+     */
+    stop() {
+        if (this.pid) {
+            stopMongoProgramByPid(this.pid);
+            this.pid = null;
+        }
+    }
+}

--- a/jstests/ldapauthz/lib/ldap_mock.py
+++ b/jstests/ldapauthz/lib/ldap_mock.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""A minimal mock LDAP server for the ldapauthz_mock test suite.
+
+This server replaces a real OpenLDAP (slapd) deployment so that the ldapauthz
+jstests can run hermetically.
+
+It speaks just enough of the LDAPv3 protocol (RFC 4511) for what the ldapauthz
+tests exercise:
+
+  * simple bind (used both for the query/bind user and for PLAIN authentication
+    of the external users),
+  * search with base and subtree scope and (&...) / equality / presence
+    filters, used for:
+      - authorization group lookup
+            dc=percona,dc=com??sub?(&(objectClass=groupOfNames)(member={USER}))
+      - reverse group membership lookup
+            {USER}?memberOf?base
+      - user-to-DN mapping
+            dc=percona,dc=com??sub?(&(objectClass=organizationalPerson)(sn={0}))
+
+The directory contents mirror support-files/ldap-sasl/ldap/{users,groups}.ldif
+and the expectations hard-coded in jstests/ldapauthz/_check.js. The single
+source of truth here is the (short username -> groups) mapping below; everything
+else (DNs, passwords, member / memberOf attributes) is derived from it so it
+cannot drift.
+
+The protocol parsing/encoding is handled by ldaptor; bind and search are
+implemented by hand so the server has full control over how DNs are returned on
+the wire. That matters for the special-character entries: slapd returns DNs with
+hex escaping (e.g. cn=specchar\\2C\\2B\\3D\\5C,...) and _check.js expects exactly
+that form, so those DNs are emitted verbatim rather than being re-serialized by a
+generic DN library.
+"""
+
+import argparse
+import sys
+
+from ldaptor.protocols import pureldap
+from ldaptor.protocols.ldap import ldaperrors
+from ldaptor.protocols.ldap.ldapserver import LDAPServer
+from twisted.internet import reactor
+from twisted.internet.protocol import ServerFactory
+
+BASE_DN = "dc=percona,dc=com"
+
+# The bind/query user used by mongod (ldapQueryUser / ldapQueryPassword).
+ADMIN_DN = "cn=admin,dc=percona,dc=com"
+ADMIN_PASSWORD = "password"
+
+# Password suffix appended to the short user name, mirroring settings.conf
+# (LDAP_PASS_SUFFIX) and support-files/ldap-sasl/ldap/users.ldif.
+PASSWORD_SUFFIX = "9a5S"
+
+# Short user names exactly as listed in jstests/ldapauthz/_check.js
+# (shortusernames). The last two exercise DN special-character handling.
+USERS = [
+    "exttestro",
+    "exttestrw",
+    "extotherro",
+    "extotherrw",
+    "extbothro",
+    "extbothrw",
+    "exttestrwotherro",
+    "exttestrootherrw",
+    "Surname\\, Name",
+    'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\',
+]
+
+# group cn -> member short user names. Mirrors
+# support-files/ldap-sasl/ldap/groups.ldif. The special-character group is keyed
+# by its hex-escaped wire DN (see SPECCHAR_GROUP_DN) because that is the exact
+# string _check.js expects to see returned as a role.
+GROUPS = {
+    "testreaders": ["exttestro", "extbothro", "exttestrootherrw"],
+    "testwriters": ["exttestrw", "extbothrw", "exttestrwotherro"],
+    "otherreaders": ["extotherro", "extbothro", "exttestrwotherro"],
+    "otherwriters": ["extotherrw", "extbothrw", "exttestrootherrw"],
+    "testusers": [
+        "exttestro",
+        "exttestrwotherro",
+        "exttestrw",
+        "exttestrootherrw",
+        "extbothro",
+        "extbothrw",
+    ],
+    "otherusers": [
+        "extotherro",
+        "exttestrwotherro",
+        "extotherrw",
+        "exttestrootherrw",
+        "extbothro",
+        "extbothrw",
+    ],
+}
+
+# The special-character group. groups.ldif stores its DN with character escaping
+# (cn=specchar\,\+\=\\,...) but slapd returns it -- and _check.js expects it --
+# in hex-escaped form. We emit this exact string on the wire.
+SPECCHAR_GROUP_DN = "cn=specchar\\2C\\2B\\3D\\5C,dc=percona,dc=com"
+SPECCHAR_MEMBERS = ["Surname\\, Name", 'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\']
+
+VERBOSE = False
+
+
+def log(*args):
+    if VERBOSE:
+        print("[ldap_mock]", *args, flush=True)
+
+
+def user_dn(short_name):
+    return "cn=" + short_name + "," + BASE_DN
+
+
+def group_dn(cn):
+    return "cn=" + cn + "," + BASE_DN
+
+
+def to_str(value):
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+class Entry:
+    """An in-memory directory entry.
+
+    dn is the exact string emitted on the wire (objectName) and used to build
+    member / memberOf references. attrs maps lower-cased attribute name to a list
+    of string values used for filter matching and to satisfy attribute requests.
+    """
+
+    def __init__(self, dn, attrs, password=None):
+        self.dn = dn
+        self.norm = dn.lower()
+        self.attrs = {k.lower(): list(v) for k, v in attrs.items()}
+        # A synthetic "dn" attribute so that templates requesting ?dn? work.
+        self.attrs.setdefault("dn", [dn])
+        self.password = password
+
+
+def build_directory():
+    """Build the directory from the (user -> groups) source of truth."""
+    entries = []
+
+    # Base entry and the bind/query user.
+    entries.append(Entry(BASE_DN, {"objectclass": ["dcObject", "organization"], "dc": ["percona"]}))
+    entries.append(
+        Entry(
+            ADMIN_DN,
+            {"objectclass": ["organizationalRole"], "cn": ["admin"]},
+            password=ADMIN_PASSWORD,
+        )
+    )
+
+    # Compute group membership keyed by short user name.
+    member_of = {u: [] for u in USERS}
+    for cn, members in GROUPS.items():
+        gdn = group_dn(cn)
+        for m in members:
+            member_of[m].append(gdn)
+    for m in SPECCHAR_MEMBERS:
+        member_of[m].append(SPECCHAR_GROUP_DN)
+
+    # User entries.
+    for short in USERS:
+        dn = user_dn(short)
+        entries.append(
+            Entry(
+                dn,
+                {
+                    "objectclass": ["organizationalPerson", "person"],
+                    "cn": [short],
+                    "sn": [short],
+                    "memberof": member_of[short],
+                },
+                password=short + PASSWORD_SUFFIX,
+            )
+        )
+
+    # Group entries.
+    for cn, members in GROUPS.items():
+        entries.append(
+            Entry(
+                group_dn(cn),
+                {
+                    "objectclass": ["groupOfNames"],
+                    "cn": [cn],
+                    "member": [user_dn(m) for m in members],
+                },
+            )
+        )
+    entries.append(
+        Entry(
+            SPECCHAR_GROUP_DN,
+            {
+                "objectclass": ["groupOfNames"],
+                "cn": ["specchar,+=\\"],
+                "member": [user_dn(m) for m in SPECCHAR_MEMBERS],
+            },
+        )
+    )
+
+    return entries
+
+
+def match_substrings(f, entry):
+    """Evaluate an LDAP substring filter, e.g. (sn=ext*) or (cn=Sur*me*Name).
+
+    Matches case-insensitively against any value of the attribute, honouring the optional
+    initial / any* / final components in order (RFC 4511 4.5.1.7.2). The components must
+    match non-overlapping, left to right.
+    """
+    attr = to_str(f.type).lower()
+    initial = None
+    final = None
+    anys = []
+    for sub in f.substrings:
+        s = to_str(sub.value).lower()
+        if isinstance(sub, pureldap.LDAPFilter_substrings_initial):
+            initial = s
+        elif isinstance(sub, pureldap.LDAPFilter_substrings_final):
+            final = s
+        elif isinstance(sub, pureldap.LDAPFilter_substrings_any):
+            anys.append(s)
+
+    for value in entry.attrs.get(attr, []):
+        v = value.lower()
+        pos = 0
+        if initial is not None:
+            if not v.startswith(initial):
+                continue
+            pos = len(initial)
+        matched = True
+        for a in anys:
+            idx = v.find(a, pos)
+            if idx == -1:
+                matched = False
+                break
+            pos = idx + len(a)
+        if not matched:
+            continue
+        # The final component must not overlap what initial/any already consumed.
+        if final is not None and not (v.endswith(final) and len(v) - len(final) >= pos):
+            continue
+        return True
+    return False
+
+
+def match_filter(f, entry):
+    """Evaluate a parsed ldaptor filter object against an entry."""
+    if isinstance(f, pureldap.LDAPFilter_and):
+        return all(match_filter(x, entry) for x in f)
+    if isinstance(f, pureldap.LDAPFilter_or):
+        return any(match_filter(x, entry) for x in f)
+    if isinstance(f, pureldap.LDAPFilter_not):
+        return not match_filter(f.value, entry)
+    if isinstance(f, pureldap.LDAPFilter_present):
+        attr = to_str(f.value).lower()
+        return len(entry.attrs.get(attr, [])) > 0
+    if isinstance(f, pureldap.LDAPFilter_equalityMatch):
+        attr = to_str(f.attributeDesc.value).lower()
+        val = to_str(f.assertionValue.value).lower()
+        return any(v.lower() == val for v in entry.attrs.get(attr, []))
+    if isinstance(f, pureldap.LDAPFilter_substrings):
+        return match_substrings(f, entry)
+    # Unknown filter -> be permissive so searches are not silently dropped.
+    log("unhandled filter type", type(f).__name__)
+    return True
+
+
+SCOPE_BASE = pureldap.LDAP_SCOPE_baseObject
+SCOPE_ONE = pureldap.LDAP_SCOPE_singleLevel
+SCOPE_SUB = pureldap.LDAP_SCOPE_wholeSubtree
+
+
+def has_unescaped_comma(s):
+    """True if s contains a comma that is not backslash-escaped (RFC 4514 §2.4).
+
+    DNs in this directory use the cn=Surname\\, Name form, so a literal comma inside an
+    RDN must not be mistaken for a DN component separator.
+    """
+    i = 0
+    while i < len(s):
+        if s[i] == "\\":
+            i += 2  # skip the escaped character (e.g. \, or \\)
+            continue
+        if s[i] == ",":
+            return True
+        i += 1
+    return False
+
+
+def in_scope(entry, base_norm, scope):
+    if scope == SCOPE_BASE:
+        return entry.norm == base_norm
+    if scope == SCOPE_ONE:
+        if not entry.norm.endswith("," + base_norm):
+            return False
+        head = entry.norm[: -(len("," + base_norm))]
+        # Single level == exactly one RDN above the base, i.e. no further (unescaped)
+        # component separator in the head.
+        return not has_unescaped_comma(head)
+    # whole subtree (default)
+    return entry.norm == base_norm or entry.norm.endswith("," + base_norm)
+
+
+class MockLDAPServer(LDAPServer):
+    def connectionMade(self):
+        peer = self.transport.getPeer()
+        log("connection from", getattr(peer, "host", "?"), getattr(peer, "port", "?"))
+        LDAPServer.connectionMade(self)
+
+    def handle_LDAPBindRequest(self, request, controls, reply):
+        dn = to_str(request.dn)
+        auth = request.auth
+        if isinstance(auth, str):
+            auth = auth.encode("utf-8")
+
+        # Anonymous bind.
+        if dn == "" and auth == b"":
+            log("bind anonymous -> OK")
+            return pureldap.LDAPBindResponse(resultCode=ldaperrors.Success.resultCode)
+
+        expected = self.factory.passwords.get(dn.lower())
+        if expected is not None and auth == expected.encode("utf-8"):
+            log("bind", dn, "-> OK")
+            return pureldap.LDAPBindResponse(
+                resultCode=ldaperrors.Success.resultCode, matchedDN=dn.encode("utf-8")
+            )
+
+        log("bind", dn, "-> invalidCredentials")
+        return pureldap.LDAPBindResponse(
+            resultCode=ldaperrors.LDAPInvalidCredentials.resultCode,
+            errorMessage=b"invalid credentials",
+        )
+
+    def handle_LDAPSearchRequest(self, request, controls, reply):
+        base_norm = to_str(request.baseObject).lower()
+        scope = request.scope
+        requested = [to_str(a).lower() for a in request.attributes]
+        log("search base=%r scope=%s attrs=%s" % (base_norm, scope, requested))
+
+        count = 0
+        for entry in self.factory.entries:
+            if not in_scope(entry, base_norm, scope):
+                continue
+            if not match_filter(request.filter, entry):
+                continue
+            attributes = self._select_attributes(entry, requested)
+            reply(
+                pureldap.LDAPSearchResultEntry(
+                    objectName=entry.dn.encode("utf-8"), attributes=attributes
+                )
+            )
+            count += 1
+        log("search -> %d entries" % count)
+        return pureldap.LDAPSearchResultDone(resultCode=ldaperrors.Success.resultCode)
+
+    @staticmethod
+    def _select_attributes(entry, requested):
+        def encode(name, values):
+            return (name.encode("utf-8"), [v.encode("utf-8") for v in values])
+
+        # No attributes requested, or "*": return all real attributes (skip the
+        # synthetic "dn" pseudo-attribute and never expose userPassword).
+        if not requested or "*" in requested:
+            return [encode(k, v) for k, v in entry.attrs.items() if k not in ("userpassword", "dn")]
+        # "1.1" means "no attributes".
+        if requested == ["1.1"]:
+            return []
+        result = []
+        for name in requested:
+            if name in entry.attrs:
+                result.append(encode(name, entry.attrs[name]))
+        return result
+
+
+class MockLDAPServerFactory(ServerFactory):
+    protocol = MockLDAPServer
+
+    def __init__(self, entries):
+        self.entries = entries
+        self.passwords = {e.norm: e.password for e in entries if e.password is not None}
+
+
+def main():
+    global VERBOSE
+    parser = argparse.ArgumentParser(description="Mock LDAP server for ldapauthz tests")
+    parser.add_argument("--port", type=int, required=True, help="TCP port to listen on")
+    parser.add_argument("--host", default="127.0.0.1", help="interface to bind to")
+    parser.add_argument("--verbose", action="store_true", help="log binds and searches")
+    args = parser.parse_args()
+    VERBOSE = args.verbose
+
+    entries = build_directory()
+    factory = MockLDAPServerFactory(entries)
+
+    reactor.listenTCP(args.port, factory, interface=args.host)
+    # Printed on stdout so the JS wrapper (ldap_mock.js) can wait for readiness.
+    print("LDAP mock server is running on %s:%d" % (args.host, args.port), flush=True)
+    reactor.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/jstests/ldapauthz/lib/ldap_mock.py
+++ b/jstests/ldapauthz/lib/ldap_mock.py
@@ -18,11 +18,12 @@ tests exercise:
       - user-to-DN mapping
             dc=percona,dc=com??sub?(&(objectClass=organizationalPerson)(sn={0}))
 
-The directory contents mirror support-files/ldap-sasl/ldap/{users,groups}.ldif
-and the expectations hard-coded in jstests/ldapauthz/_check.js. The single
-source of truth here is the (short username -> groups) mapping below; everything
-else (DNs, passwords, member / memberOf attributes) is derived from it so it
-cannot drift.
+The directory contents are not defined here: they are supplied by the JS test
+harness as a single JSON document on the command line (--directory-json), built
+from jstests/ldapauthz/lib/ldap_directory.js. That module is the single source
+of truth shared with the test-side authorization checks (_check.js), so the two
+cannot drift. Everything (DNs, passwords, member / memberOf attributes) is
+derived here from the (short username -> groups) mapping in that document.
 
 The protocol parsing/encoding is handled by ldaptor; bind and search are
 implemented by hand so the server has full control over how DNs are returned on
@@ -33,7 +34,7 @@ generic DN library.
 """
 
 import argparse
-import sys
+import json
 
 from ldaptor.protocols import pureldap
 from ldaptor.protocols.ldap import ldaperrors
@@ -41,78 +42,12 @@ from ldaptor.protocols.ldap.ldapserver import LDAPServer
 from twisted.internet import reactor
 from twisted.internet.protocol import ServerFactory
 
-BASE_DN = "dc=percona,dc=com"
-
-# The bind/query user used by mongod (ldapQueryUser / ldapQueryPassword).
-ADMIN_DN = "cn=admin,dc=percona,dc=com"
-ADMIN_PASSWORD = "password"
-
-# Password suffix appended to the short user name, mirroring settings.conf
-# (LDAP_PASS_SUFFIX) and support-files/ldap-sasl/ldap/users.ldif.
-PASSWORD_SUFFIX = "9a5S"
-
-# Short user names exactly as listed in jstests/ldapauthz/_check.js
-# (shortusernames). The last two exercise DN special-character handling.
-USERS = [
-    "exttestro",
-    "exttestrw",
-    "extotherro",
-    "extotherrw",
-    "extbothro",
-    "extbothrw",
-    "exttestrwotherro",
-    "exttestrootherrw",
-    "Surname\\, Name",
-    'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\',
-]
-
-# group cn -> member short user names. Mirrors
-# support-files/ldap-sasl/ldap/groups.ldif. The special-character group is keyed
-# by its hex-escaped wire DN (see SPECCHAR_GROUP_DN) because that is the exact
-# string _check.js expects to see returned as a role.
-GROUPS = {
-    "testreaders": ["exttestro", "extbothro", "exttestrootherrw"],
-    "testwriters": ["exttestrw", "extbothrw", "exttestrwotherro"],
-    "otherreaders": ["extotherro", "extbothro", "exttestrwotherro"],
-    "otherwriters": ["extotherrw", "extbothrw", "exttestrootherrw"],
-    "testusers": [
-        "exttestro",
-        "exttestrwotherro",
-        "exttestrw",
-        "exttestrootherrw",
-        "extbothro",
-        "extbothrw",
-    ],
-    "otherusers": [
-        "extotherro",
-        "exttestrwotherro",
-        "extotherrw",
-        "exttestrootherrw",
-        "extbothro",
-        "extbothrw",
-    ],
-}
-
-# The special-character group. groups.ldif stores its DN with character escaping
-# (cn=specchar\,\+\=\\,...) but slapd returns it -- and _check.js expects it --
-# in hex-escaped form. We emit this exact string on the wire.
-SPECCHAR_GROUP_DN = "cn=specchar\\2C\\2B\\3D\\5C,dc=percona,dc=com"
-SPECCHAR_MEMBERS = ["Surname\\, Name", 'Question? Mark! *{[(\\<\\>)]} #\\"\\+\\\\']
-
 VERBOSE = False
 
 
 def log(*args):
     if VERBOSE:
         print("[ldap_mock]", *args, flush=True)
-
-
-def user_dn(short_name):
-    return "cn=" + short_name + "," + BASE_DN
-
-
-def group_dn(cn):
-    return "cn=" + cn + "," + BASE_DN
 
 
 def to_str(value):
@@ -138,31 +73,51 @@ class Entry:
         self.password = password
 
 
-def build_directory():
-    """Build the directory from the (user -> groups) source of truth."""
+def build_directory(spec):
+    """Build the directory from the (user -> groups) source of truth.
+
+    spec is the JSON document produced by jstests/ldapauthz/lib/ldap_directory.js
+    (directorySpec()) and passed in via --directory-json.
+    """
+    base_dn = spec["base_dn"]
+    admin_dn = spec["admin_dn"]
+    admin_password = spec["admin_password"]
+    password_suffix = spec["password_suffix"]
+    users = spec["users"]
+    groups = spec["groups"]
+    specchar_group_dn = spec["specchar_group_dn"]
+    specchar_group_cn = spec["specchar_group_cn"]
+    specchar_members = spec["specchar_members"]
+
+    def user_dn(short_name):
+        return "cn=" + short_name + "," + base_dn
+
+    def group_dn(cn):
+        return "cn=" + cn + "," + base_dn
+
     entries = []
 
     # Base entry and the bind/query user.
-    entries.append(Entry(BASE_DN, {"objectclass": ["dcObject", "organization"], "dc": ["percona"]}))
+    entries.append(Entry(base_dn, {"objectclass": ["dcObject", "organization"], "dc": ["percona"]}))
     entries.append(
         Entry(
-            ADMIN_DN,
+            admin_dn,
             {"objectclass": ["organizationalRole"], "cn": ["admin"]},
-            password=ADMIN_PASSWORD,
+            password=admin_password,
         )
     )
 
     # Compute group membership keyed by short user name.
-    member_of = {u: [] for u in USERS}
-    for cn, members in GROUPS.items():
+    member_of = {u: [] for u in users}
+    for cn, members in groups.items():
         gdn = group_dn(cn)
         for m in members:
             member_of[m].append(gdn)
-    for m in SPECCHAR_MEMBERS:
-        member_of[m].append(SPECCHAR_GROUP_DN)
+    for m in specchar_members:
+        member_of[m].append(specchar_group_dn)
 
     # User entries.
-    for short in USERS:
+    for short in users:
         dn = user_dn(short)
         entries.append(
             Entry(
@@ -173,12 +128,12 @@ def build_directory():
                     "sn": [short],
                     "memberof": member_of[short],
                 },
-                password=short + PASSWORD_SUFFIX,
+                password=short + password_suffix,
             )
         )
 
     # Group entries.
-    for cn, members in GROUPS.items():
+    for cn, members in groups.items():
         entries.append(
             Entry(
                 group_dn(cn),
@@ -191,11 +146,11 @@ def build_directory():
         )
     entries.append(
         Entry(
-            SPECCHAR_GROUP_DN,
+            specchar_group_dn,
             {
                 "objectclass": ["groupOfNames"],
-                "cn": ["specchar,+=\\"],
-                "member": [user_dn(m) for m in SPECCHAR_MEMBERS],
+                "cn": [specchar_group_cn],
+                "member": [user_dn(m) for m in specchar_members],
             },
         )
     )
@@ -388,11 +343,16 @@ def main():
     parser = argparse.ArgumentParser(description="Mock LDAP server for ldapauthz tests")
     parser.add_argument("--port", type=int, required=True, help="TCP port to listen on")
     parser.add_argument("--host", default="127.0.0.1", help="interface to bind to")
+    parser.add_argument(
+        "--directory-json",
+        required=True,
+        help="directory contents as JSON (see jstests/ldapauthz/lib/ldap_directory.js)",
+    )
     parser.add_argument("--verbose", action="store_true", help="log binds and searches")
     args = parser.parse_args()
     VERBOSE = args.verbose
 
-    entries = build_directory()
+    entries = build_directory(json.loads(args.directory_json))
     factory = MockLDAPServerFactory(entries)
 
     reactor.listenTCP(args.port, factory, interface=args.host)

--- a/jstests/ldapauthz/lib/use_mock_ldap.js
+++ b/jstests/ldapauthz/lib/use_mock_ldap.js
@@ -1,0 +1,79 @@
+/**
+ * Test override that makes the ldapauthz suite run against the Python mock LDAP server
+ * (jstests/ldapauthz/lib/ldap_mock.py) instead of a real slapd.
+ *
+ * It is imported (once per test) via the `eval` shell option of the ldapauthz_mock suite,
+ * so the individual ldapauthz_*.js test files need no changes.
+ *
+ * Why this wraps MongoRunner rather than starting the mock directly at import time: the
+ * `eval` script runs inside its own MongoProgramScope in the mongo shell (see
+ * mongo_main.cpp), whose destructor kills every spawned program when the eval finishes --
+ * i.e. before the test file runs. A mock started at import time would therefore be killed
+ * before the first mongod starts. Starting it lazily from inside the runMongod wrapper
+ * means it is spawned while the *test file* is executing, so it lives under the test
+ * file's MongoProgramScope.
+ *
+ * The shell also fails a test (exit code != 0) if any child process is still running when
+ * the test file finishes. So the stopMongod wrapper tears the mock down again: every
+ * ldapauthz test stops its mongod(s) at the end, so the mock is always gone before the
+ * end-of-file check. Tearing it down also resets TestData.ldapServers to the sentinel, so
+ * a test that starts a second mongod (e.g. ldapauthz_ldap_timeouts.js) gets a fresh mock.
+ *
+ * Deliberately-invalid addresses such as "localhost:39999" are passed through untouched,
+ * since only the sentinel value is rewritten.
+ */
+import {LDAPMock} from "jstests/ldapauthz/lib/ldap_mock.js";
+
+export const LDAP_MOCK_SENTINEL = "__ldap_mock__";
+
+// Tests read TestData.ldapServers when building their runMongod options; hand them the
+// sentinel so the wrapper below can recognise and rewrite it.
+TestData.ldapServers = LDAP_MOCK_SENTINEL;
+
+let mock = null;
+
+function ensureMock() {
+    if (mock === null) {
+        const port = allocatePort();
+        mock = new LDAPMock({port: port});
+        mock.start();
+        // Update the global so later reads (e.g. a setParameter that switches to a valid
+        // server) resolve to the running mock rather than the sentinel.
+        TestData.ldapServers = "127.0.0.1:" + port;
+    }
+}
+
+function teardownMock() {
+    if (mock !== null) {
+        mock.stop();
+        mock = null;
+        TestData.ldapServers = LDAP_MOCK_SENTINEL;
+    }
+}
+
+const originalRunMongod = MongoRunner.runMongod;
+MongoRunner.runMongod = function (opts) {
+    ensureMock();
+    if (opts && opts.ldapServers === LDAP_MOCK_SENTINEL) {
+        opts = Object.assign({}, opts, {ldapServers: TestData.ldapServers});
+    }
+    try {
+        return originalRunMongod.call(this, opts);
+    } catch (e) {
+        // If mongod fails to start, tear the mock down so it doesn't linger and trip the
+        // shell's end-of-file "child process still running" check, masking the real error.
+        teardownMock();
+        throw e;
+    }
+};
+
+const originalStopMongod = MongoRunner.stopMongod;
+MongoRunner.stopMongod = function (...args) {
+    // finally so the mock is always reaped even if stopMongod throws; otherwise a leaked
+    // mock would trip the shell's end-of-file "child process still running" check.
+    try {
+        return originalStopMongod.apply(this, args);
+    } finally {
+        teardownMock();
+    }
+};

--- a/jstests/ldapauthz/lib/use_mock_ldap.js
+++ b/jstests/ldapauthz/lib/use_mock_ldap.js
@@ -22,6 +22,7 @@
  * Deliberately-invalid addresses such as "localhost:39999" are passed through untouched,
  * since only the sentinel value is rewritten.
  */
+import {ADMIN_DN, ADMIN_PASSWORD} from "jstests/ldapauthz/lib/ldap_directory.js";
 import {LDAPMock} from "jstests/ldapauthz/lib/ldap_mock.js";
 
 export const LDAP_MOCK_SENTINEL = "__ldap_mock__";
@@ -29,6 +30,12 @@ export const LDAP_MOCK_SENTINEL = "__ldap_mock__";
 // Tests read TestData.ldapServers when building their runMongod options; hand them the
 // sentinel so the wrapper below can recognise and rewrite it.
 TestData.ldapServers = LDAP_MOCK_SENTINEL;
+
+// Derive the bind/query credentials from the same source of truth as the mock directory
+// (ldap_directory.js) so they cannot drift from the credentials the mock accepts. The
+// suite YAML therefore does not need to hardcode them.
+TestData.ldapQueryUser = ADMIN_DN;
+TestData.ldapQueryPassword = ADMIN_PASSWORD;
 
 let mock = null;
 
@@ -53,15 +60,17 @@ function teardownMock() {
 
 const originalRunMongod = MongoRunner.runMongod;
 MongoRunner.runMongod = function (opts) {
-    ensureMock();
-    if (opts && opts.ldapServers === LDAP_MOCK_SENTINEL) {
-        opts = Object.assign({}, opts, {ldapServers: TestData.ldapServers});
-    }
     try {
+        // ensureMock() is inside the try so that if mock.start() throws (e.g. the readiness
+        // wait times out), the catch below still reaps the half-started mock: otherwise the
+        // module-level `mock` stays non-null with a live Python process, leaking it past the
+        // shell's end-of-file "child process still running" check and masking the real error.
+        ensureMock();
+        if (opts && opts.ldapServers === LDAP_MOCK_SENTINEL) {
+            opts = Object.assign({}, opts, {ldapServers: TestData.ldapServers});
+        }
         return originalRunMongod.call(this, opts);
     } catch (e) {
-        // If mongod fails to start, tear the mock down so it doesn't linger and trip the
-        // shell's end-of-file "child process still running" check, masking the real error.
         teardownMock();
         throw e;
     }


### PR DESCRIPTION
Adds a hermetic `ldapauthz_mock` resmoke suite so the LDAP authorization tests
can run without an external slapd deployment, and wires it into Bazel.

The suite runs the existing `ldapauthz_*.js` tests unchanged against a minimal
Python mock LDAP server (`jstests/ldapauthz/lib/ldap_mock.py`, built on ldaptor),
launched per-test via a `MongoRunner` override in `use_mock_ldap.js`. Directory
data (users, groups, DNs, passwords) lives in a single source of truth,
`ldap_directory.js`, which is serialized to the mock and used to derive the
test-side checks in `_check.js` so the two cannot drift.

The real-slapd `ldapauthz` suite is intentionally **not** wired into Bazel, since
it needs an external LDAP server.