### PR TITLE
PSMDB-1973: refresh PR body after review-handle fixes

### DIFF
--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -674,11 +674,19 @@ jobs:
 
       # Push the inline fix to the PR branch before posting replies, so the
       # "Addressed in <sha>" reply points at a commit that exists on the PR.
+      # Then refresh the PR body from the note's solutions (mirrors ci-handle's
+      # review-branch step) so the review_fix solution shows up as a new
+      # Solution entry in the description, not just in the thread reply.
       - name: Push review-fix commit
         if: steps.pr.outputs.is_mergai == 'true' && steps.review.outputs.fix_produced == 'true'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
-        run: git push origin "HEAD:$HEAD_REF"
+        run: |
+          git push origin "HEAD:$HEAD_REF"
+          mergai pr --repo "$GITHUB_REPOSITORY" update \
+            || echo "::warning::'mergai pr update' failed"
 
       # Publish the recorded replies (fixed / unfixable) to their threads.
       - name: Post review replies


### PR DESCRIPTION
The review-handle job pushed the review-fix commit and posted thread replies but never ran `mergai pr update`, so the review_fix solution recorded on the git note never made it into the PR description's Solutions section. Mirror ci-handle's review-branch step: after pushing the fix, refresh the PR body from the note's solutions so the fix shows up as a new Solution entry, not just in the thread reply.

Stacked on: #1905