### PR TITLE
PSMDB-2140: add jstests CI job and test-result reporting

### DIFF
--- a/.bazelrc.psmdb
+++ b/.bazelrc.psmdb
@@ -309,5 +309,60 @@ common:psmdb_remote_unittest --config=remote_unittest
 test:psmdb_remote_unittest --test_tag_filters=mongo_unittest,-intermediate_debug,-incompatible_with_bazel_remote_test,-cpu:2
 
 ################################################################################
+# PSMDB remote jstest profile (psmdb_remote_jstest)
+################################################################################
+# Runs the resmoke jstest suites on the bb-psmdb RBE farm by inheriting upstream
+# --config=remote_test and layering the PSMDB-specific overrides below.
+#
+# WARNING: remote_test sets
+#     --remote_download_regex=.*\.(core|mdmp|gz)$
+# which force-downloads crash artifacts irrespective of --remote_download_outputs=minimal.
+# A resmoke test.outputs is a TreeArtifact that can contain a .gz data archive,
+# and Bazel materializes a TreeArtifact as a unit, so a single match drags the
+# whole tree -- including multi-GB mongod cores -- back to the runner. That regex
+# is allowMultiple in Bazel 7.x (note .bazelrc already sets a global one), so it
+# can ONLY be appended to, never cleared or narrowed from the CLI or a later
+# config -- inheriting remote_test always brings the core|mdmp|gz pattern with it.
+# If those per-failure gigabyte downloads become a problem and cannot be solved at
+# another layer (e.g. disabling core dumps on the workers), STOP inheriting
+# remote_test and instead COPY its flags here verbatim minus the
+# --remote_download_regex line (re-syncing that copy whenever upstream changes
+# remote_test). Inheriting is preferred while it is tolerable because it stays in
+# sync with upstream automatically.
+#
+# The test-tag filter drops what the bb-psmdb scheduler can't run:
+#   -incompatible_with_bazel_remote_test : suites upstream marks RBE-incompatible.
+#   -resources:cpu:2,-cpu:2              : self-clustering suites routed by
+#       bazel/test_exec_properties.bzl to Pool=large_mem_2core_x86_64, for which
+#       bb-psmdb has no workers (dispatch fails FAILED_PRECONDITION). Drop once
+#       that pool is provisioned, same as psmdb_remote_unittest's -cpu:2.
+#   -mozjs_wasm_unsupported              : tests upstream marks unsupported on the
+#       mozjs-wasm JS engine (e.g. mr_bigobject_replace.js, whose server-side JS
+#       uses assert.* which the WASM server scope doesn't provide). resmoke would
+#       normally auto-exclude these after detecting the engine via `mongod
+#       --version`, but that detection does not fire in the Bazel test runner
+#       (mongod isn't runnable at configure time), so the build IS mozjs-wasm yet
+#       the exclusion is skipped. We apply it explicitly here. Drop this once the
+#       shim makes resmoke's engine detection work (then it is handled per-build).
+#
+# --test_tag_filters is last-wins, so the full filter is stated here in one line.
+--config=psmdb_remote_jstest
+common:psmdb_remote_jstest --config=remote_test
+common:psmdb_remote_jstest --test_timeout=5400
+# With --remote_download_outputs=minimal the per-test test.log stays in the
+# remote cache (Bazel's BwoB does not re-fetch the test-runner log to disk even
+# with --remote_download_regex; only test.xml is auto-fetched for the summary).
+# So on a failure the ONLY copy of the log we get on the runner is what
+# --test_output=errors prints to the console (which the CI step tees to a file
+# and uploads). Bazel skips printing any test output larger than
+# --experimental_ui_max_stdouterr_bytes (default 1 MiB) -- a resmoke suite log
+# routinely exceeds that (e.g. ratelimit's ~1.04 MiB log was dropped with
+# "exceeds maximum size ...; skipping"), leaving no diagnosable artifact. Raise
+# the cap to 16 MiB so failing-suite logs print in full and survive in the
+# uploaded console log.
+common:psmdb_remote_jstest --experimental_ui_max_stdouterr_bytes=16777216
+test:psmdb_remote_jstest --test_tag_filters=-incompatible_with_bazel_remote_test,-resources:cpu:2,-cpu:2,-mozjs_wasm_unsupported
+
+################################################################################
 # End of Percona-specific build profiles
 ################################################################################

--- a/.github/actions/test-report/action.yml
+++ b/.github/actions/test-report/action.yml
@@ -1,11 +1,15 @@
 name: "Test report (job summary)"
-description: "Render a pass/fail/flaky table from the Bazel build event log (BEP) into the GitHub job summary"
+description: "Render a pass/fail/flaky table from the Bazel build event log (BEP) and/or a resmoke report.json into the GitHub job summary"
 
 inputs:
   bep-glob:
-    description: "Glob for the BEP JSON file(s) written by --build_event_json_file"
+    description: "Glob for the BEP JSON file(s) written by --build_event_json_file. Set to '' to skip BEP (e.g. a resmoke-only report)."
     required: false
     default: "bazel-bep*.json"
+  resmoke-report:
+    description: "Glob for resmoke report.json file(s) from a LOCAL resmoke run (e.g. the dbtests job, which has no BEP). Merged with the BEP targets."
+    required: false
+    default: ""
   title:
     description: "Heading shown above the results table in the job summary"
     required: false
@@ -24,15 +28,22 @@ runs:
     # pure stdlib and always exits 0, so a report bug can never fail the test job.
     #
     # Reads the BEP (always written locally) rather than globbing test.xml, which
-    # under --remote_download_outputs=minimal stays in the remote cache.
+    # under --remote_download_outputs=minimal stays in the remote cache. The
+    # dbtests job runs resmoke locally (no BEP) and passes resmoke-report instead.
     - name: Write test summary
       shell: bash
       env:
         TEST_REPORT_TITLE: ${{ inputs.title }}
         TEST_REPORT_BEP_GLOB: ${{ inputs.bep-glob }}
+        TEST_REPORT_RESMOKE: ${{ inputs.resmoke-report }}
         TEST_REPORT_DETAILED: ${{ inputs.detailed == 'true' && '--detailed' || '' }}
       run: |
+        resmoke_arg=()
+        if [ -n "${TEST_REPORT_RESMOKE}" ]; then
+          resmoke_arg=(--resmoke-report "${TEST_REPORT_RESMOKE}")
+        fi
         python3 "${GITHUB_ACTION_PATH}/../../../buildscripts/github_test_summary.py" \
           "${TEST_REPORT_BEP_GLOB}" \
           --title "${TEST_REPORT_TITLE}" \
+          "${resmoke_arg[@]}" \
           ${TEST_REPORT_DETAILED}

--- a/.github/actions/test-report/action.yml
+++ b/.github/actions/test-report/action.yml
@@ -1,0 +1,38 @@
+name: "Test report (job summary)"
+description: "Render a pass/fail/flaky table from the Bazel build event log (BEP) into the GitHub job summary"
+
+inputs:
+  bep-glob:
+    description: "Glob for the BEP JSON file(s) written by --build_event_json_file"
+    required: false
+    default: "bazel-bep*.json"
+  title:
+    description: "Heading shown above the results table in the job summary"
+    required: false
+    default: "🧪 Test results"
+  detailed:
+    description: "When 'true', add executed/cached counts and a collapsible per-target table"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # Invoked from the trusted base checkout (./_trusted/.github/actions/test-report)
+    # so the script body is the base-branch copy, never the untrusted PR head -- the
+    # same trust model as the other composite actions in this workflow. The script is
+    # pure stdlib and always exits 0, so a report bug can never fail the test job.
+    #
+    # Reads the BEP (always written locally) rather than globbing test.xml, which
+    # under --remote_download_outputs=minimal stays in the remote cache.
+    - name: Write test summary
+      shell: bash
+      env:
+        TEST_REPORT_TITLE: ${{ inputs.title }}
+        TEST_REPORT_BEP_GLOB: ${{ inputs.bep-glob }}
+        TEST_REPORT_DETAILED: ${{ inputs.detailed == 'true' && '--detailed' || '' }}
+      run: |
+        python3 "${GITHUB_ACTION_PATH}/../../../buildscripts/github_test_summary.py" \
+          "${TEST_REPORT_BEP_GLOB}" \
+          --title "${TEST_REPORT_TITLE}" \
+          ${TEST_REPORT_DETAILED}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -468,6 +468,20 @@ jobs:
             --reportFile=dbtest-report.json \
             2>&1 | tee dbtest-logs/dbtest.log
 
+      # Render a pass/fail table into the job summary from resmoke's report.json.
+      # Same composite action as build/unittests/jstests, but a local resmoke run
+      # emits no Bazel BEP, so bep-glob is cleared and the resmoke report is fed
+      # via resmoke-report instead. if: always() so the summary is present on
+      # failure (the report.json is written even when suites fail).
+      - name: Report dbtest results
+        if: always()
+        uses: ./_trusted/.github/actions/test-report
+        with:
+          title: "🧪 dbtest results"
+          bep-glob: ""
+          resmoke-report: dbtest-report.json
+          detailed: "true"
+
       # On failure, upload the teed resmoke console log (rich per-test failure
       # output), the machine-readable resmoke report.json, and the build BEP.
       # This is the artifact `mergai ci fix` downloads for the build-and-test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -279,6 +279,19 @@ jobs:
           # 'common --remote_download_outputs=all' so only the requested
           # install outputs (plus what local link actions pull on demand) are
           # fetched, instead of every intermediate.
+          #
+          # GIT_COMMIT_HASH is pinned to the constant 'nogitversion' (the same
+          # value remote_unittest pins in .bazelrc) INSTEAD of $(git rev-parse
+          # HEAD). psmdb_buildfarm links locally (CppLink=local), so injecting
+          # the real per-commit SHA changed the version object every push and
+          # invalidated the local link of every binary depending on it -- the
+          # ~1,900 'local' link actions that re-ran on every no-op re-trigger
+          # while compiles were 100% remote cache hits. A constant value keeps
+          # those link-action keys stable across pushes so the uploaded local
+          # link results become remote cache hits on re-runs. The tradeoff is
+          # that the CI-built binaries advertise 'nogitversion' rather than the
+          # real SHA; these are test binaries, not release artifacts, and the
+          # unittests/jstests jobs already accept exactly this tradeoff.
           bazel \
             --output_user_root=/mnt/bazel \
             --host_jvm_args=-Xmx12g \
@@ -289,7 +302,7 @@ jobs:
             --bes_backend=$RBE_BES_BACKEND \
             --bes_results_url=$RBE_BES_RESULTS_URL \
             --credential_helper=$RBE_CREDENTIAL_HELPER \
-            --define=GIT_COMMIT_HASH=$(git rev-parse HEAD) \
+            --define=GIT_COMMIT_HASH=nogitversion \
             --jobs=300 \
             --keep_going \
             --remote_download_outputs=toplevel \
@@ -504,9 +517,10 @@ jobs:
         uses: ./_trusted/.github/actions/setup-env
 
       # Build just the dbtest install target on RBE. Mirrors the build job's
-      # invocation (same --host_jvm_args / --output_user_root rationale;
-      # GIT_COMMIT_HASH injected so the binary advertises the real version, as
-      # in build).
+      # invocation (same --host_jvm_args / --output_user_root rationale, and the
+      # same GIT_COMMIT_HASH=nogitversion pin -- see the build step for why a
+      # constant keeps the local link-action keys stable across pushes so they
+      # cache-hit on re-runs instead of re-linking every no-op trigger).
       #
       # Unlike the build job, dbtests does NOT pass
       # --remote_download_outputs=toplevel: it must RUN the binary locally, so
@@ -530,7 +544,7 @@ jobs:
             --bes_backend=$RBE_BES_BACKEND \
             --bes_results_url=$RBE_BES_RESULTS_URL \
             --credential_helper=$RBE_CREDENTIAL_HELPER \
-            --define=GIT_COMMIT_HASH=$(git rev-parse HEAD) \
+            --define=GIT_COMMIT_HASH=nogitversion \
             --jobs=300 \
             --keep_going \
             --build_event_json_file=bazel-bep.json \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -295,6 +295,20 @@ jobs:
             --build_event_json_file=bazel-bep.json \
             //src/...
 
+      # Render a pass/fail/skip table into the GitHub job summary by parsing
+      # Bazel's Build Event Protocol JSON (--build_event_json_file above), which
+      # is always written to the runner and carries a testSummary per target --
+      # unlike test.xml, which under minimal output download stays in the remote
+      # cache. if: always() so the summary appears on failure too -- that's when
+      # it's most useful. Loaded from _trusted/ (base branch) like every other
+      # composite action.
+      - name: Report unittest results
+        if: always()
+        uses: ./_trusted/.github/actions/test-report
+        with:
+          title: "🧪 Unit test results"
+          detailed: "true"
+
       # Upload bazel-testlogs (per-target test.log + test.xml JUnit) plus the
       # BEP stream on failure. bazel-testlogs is a symlink into the bazel
       # output base; upload-artifact@v4 follows symlinks. Consumers
@@ -509,6 +523,17 @@ jobs:
             echo "::endgroup::"
           done
           exit $rc
+
+      # Render the jstest results table into the job summary. One Bazel server
+      # (--output_user_root) served every suite above, so bazel-testlogs holds
+      # the reliable batch plus each load-sensitive suite. if: always() so the
+      # summary is present on failure. See the unittests job for the rationale.
+      - name: Report jstest results
+        if: always()
+        uses: ./_trusted/.github/actions/test-report
+        with:
+          title: "🧪 jstest results"
+          detailed: "true"
 
       # Always upload the machine-readable test report: one bazel-bep*.json per
       # invocation (reliable + each load-sensitive suite) carries every target's

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,12 +51,12 @@ env:
   # path to _trusted/ keeps the entire import chain on the trusted copy.
   RBE_CREDENTIAL_HELPER: bb-psmdb.ddns.net=%workspace%/_trusted/bazel/wrapper_hook/credential_helper.py
 
-# Three jobs: gate, build, unittests. `gate` is a no-op whose only purpose
-# is to host the protected `rbe-external` environment so a single
-# maintainer approval authorizes the entire workflow run. `build` and
-# `unittests` depend on `gate` (transitively) and use the unattended `rbe`
-# environment — same secrets, no approval prompt — so the maintainer
-# isn't re-prompted between jobs.
+# Jobs: gate, build, unittests, dbtests, jstests (plus the jstests_gate
+# decider). `gate` is a no-op whose only purpose is to host the protected
+# `rbe-external` environment so a single maintainer approval authorizes the
+# entire workflow run. The test jobs depend on `gate` (transitively) and use
+# the unattended `rbe` environment — same secrets, no approval prompt — so the
+# maintainer isn't re-prompted between jobs.
 #
 # Build and unittests deliberately run on separate runners with separate
 # Bazel servers, so neither shares local state — both pay the action-graph
@@ -161,7 +161,7 @@ jobs:
       - name: Setup environment
         uses: ./_trusted/.github/actions/setup-env
 
-      - name: Build //:install-devcore //:install-dbtest via RBE
+      - name: Build //:install-devcore via RBE
         run: |
           # --host_jvm_args raises the Bazel server's max heap. The default
           # is too small for PSMDB's action graph on a 16 GB GH-hosted
@@ -189,7 +189,7 @@ jobs:
             --keep_going \
             --remote_download_outputs=toplevel \
             --build_event_json_file=bazel-bep.json \
-            //:install-devcore //:install-dbtest
+            //:install-devcore
 
       # Upload BEP on failure so consumers can fetch it via the
       # GH artifacts API and parse the failure deterministically (BEP is
@@ -206,7 +206,19 @@ jobs:
 
   unittests:
     name: unittests
-    needs: build
+    # `needs: [build, dbtests]` -- dbtests is for ORDERING only (unittests waits
+    # for it so the RBE-heavy jobs run one at a time: build -> dbtests ->
+    # unittests -> jstests). The `if` below gates on build success, NOT dbtests
+    # success, so a dbtest failure does not block unittests; the two are
+    # independent test jobs that both run whenever build passed.
+    needs: [build, dbtests]
+    # !cancelled() so unittests still runs when dbtests FAILED (a failed need
+    # would otherwise skip it). Gated on build success: build runs only after
+    # the gate approval, so build.result == 'success' implies rbe-external was
+    # approved.
+    if: >-
+      ${{ !cancelled()
+      && needs.build.result == 'success' }}
     # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
     runs-on: ubuntu-24.04
     # Same unattended `rbe` environment as `build` — see `build.environment`
@@ -326,6 +338,153 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+  # Builds the dbtest binary on RBE and runs the resmoke `dbtest` suite LOCALLY
+  # on the runner. dbtest is a single monolithic mongo_cc_binary
+  # (//src/mongo/dbtests:dbtest, tagged "dbtest") with NO Bazel test target, so
+  # -- unlike the jstests job, which runs each suite ON the remote executors --
+  # the binary is built remotely (a cache hit for most objects, since the build
+  # job compiled the same tree) and then driven by resmoke here. resmoke's
+  # db_test kind enumerates the sub-suites from `dbtest --list` and runs the
+  # binary per suite. The local `run_dbtest.sh` helper performs the same two
+  # steps. dbtest is built HERE (not in the build job) so build only fetches
+  # install-devcore.
+  #
+  # `needs: [gate, build]` so it runs after build and BEFORE unittests:
+  # unittests/jstests order AFTER dbtests (via needs) so the RBE-heavy jobs run
+  # one at a time -- build -> dbtests -> unittests -> jstests -- but each gates
+  # on BUILD success, not on the previous test job, so a failure in one does not
+  # block the others: all three test jobs run whenever build passed. Unlike
+  # jstests it is NOT gated on labels/a variable: dbtest is a deterministic C++
+  # suite, so it always runs. `needs.gate.result == 'success'` preserves the
+  # rbe-external approval gate (it carries the same secrets via the `rbe`
+  # environment).
+  dbtests:
+    name: dbtests
+    needs: [gate, build]
+    if: >-
+      ${{ !cancelled()
+      && needs.gate.result == 'success'
+      && needs.build.result == 'success' }}
+    # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
+    runs-on: ubuntu-24.04
+    # Same unattended `rbe` environment as `build` / `unittests`.
+    environment: rbe
+    # See `build.env` above for why this is at job level, not workflow level.
+    env:
+      PSMDB_RBE_GHA_AUDIENCE: ${{ secrets.PSMDB_RBE_GHA_AUDIENCE }}
+      PSMDB_RBE_OIDC_ISSUER: ${{ secrets.PSMDB_RBE_OIDC_ISSUER }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      # See the matching step in `build` for the rationale behind loading
+      # composite actions from a trusted base checkout under `_trusted/`.
+      - name: Checkout base (trusted) for composite actions
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.base_ref }}
+          path: _trusted
+          fetch-depth: 1
+
+      - name: Fetch tags
+        uses: ./_trusted/.github/actions/fetch-tags
+
+      - name: Free disk space and redirect Bazel to /mnt
+        uses: ./_trusted/.github/actions/free-disk-space
+
+      - name: Setup environment
+        uses: ./_trusted/.github/actions/setup-env
+
+      # Build just the dbtest install target on RBE. Mirrors the build job's
+      # invocation (same --host_jvm_args / --output_user_root rationale;
+      # GIT_COMMIT_HASH injected so the binary advertises the real version, as
+      # in build).
+      #
+      # Unlike the build job, dbtests does NOT pass
+      # --remote_download_outputs=toplevel: it must RUN the binary locally, so
+      # the whole install tree -- bazel-bin/install-dbtest/{bin/dbtest,lib/*.so}
+      # -- and everything those entries resolve to has to be materialized on the
+      # runner. The build job overrides the .bazelrc default to `toplevel` purely
+      # for download efficiency because it never executes what it builds; here we
+      # fall back to that .bazelrc default (--remote_download_outputs=all) so the
+      # install tree and the binary/.so outputs it points at are all present.
+      # (toplevel left the install symlinks' targets unmaterialized, so resmoke
+      # failed with "File not found: bazel-bin/install-dbtest/bin/dbtest".)
+      - name: Build //:install-dbtest via RBE
+        run: |
+          bazel \
+            --output_user_root=/mnt/bazel \
+            --host_jvm_args=-Xmx12g \
+            build \
+            --config=psmdb_buildfarm \
+            --remote_executor=$RBE_REMOTE_EXECUTOR \
+            --remote_cache=$RBE_REMOTE_CACHE \
+            --bes_backend=$RBE_BES_BACKEND \
+            --bes_results_url=$RBE_BES_RESULTS_URL \
+            --credential_helper=$RBE_CREDENTIAL_HELPER \
+            --define=GIT_COMMIT_HASH=$(git rev-parse HEAD) \
+            --jobs=300 \
+            --keep_going \
+            --build_event_json_file=bazel-bep.json \
+            //:install-dbtest
+
+      # Run the resmoke dbtest suite locally against the freshly built binary.
+      # resmoke runs via the poetry venv set up by setup-env. The suite selector
+      # is empty; resmoke enumerates sub-suites from `dbtest --list`. One resmoke
+      # job per CPU. Tee the console to a file (pipefail so resmoke's exit, not
+      # tee's, decides the step result) for the failure-artifact upload.
+      - name: Run dbtest suite (local)
+        run: |
+          mkdir -p dbtest-logs
+          set -o pipefail
+          # Locate the built dbtest binary. The `bazel-bin/...` convenience-symlink
+          # path is unreliable here (the build ran with --output_user_root=/mnt/
+          # bazel and the symlink/config dir did not resolve to the install tree),
+          # so find the real install output under the Bazel output base and hand
+          # resmoke its absolute path. The binary links its libs via rpath
+          # $ORIGIN/../lib, and the install tree keeps lib/ a sibling of bin/, so
+          # an absolute bin/dbtest path still resolves the .so files.
+          echo "::group::locate dbtest binary"
+          echo "workspace=$(pwd)"
+          echo "bazel-bin -> $(readlink bazel-bin 2>/dev/null || echo MISSING)"
+          DBTEST="$(find -L /mnt/bazel -maxdepth 14 -type f -path '*/install-dbtest/bin/dbtest' 2>/dev/null | head -1)"
+          if [ -z "$DBTEST" ]; then
+            DBTEST="$(find -L "$PWD" -maxdepth 8 -type f -path '*/install-dbtest/bin/dbtest' 2>/dev/null | head -1)"
+          fi
+          echo "resolved dbtest=${DBTEST:-NOT FOUND}"
+          [ -n "$DBTEST" ] && ls -la "$(dirname "$DBTEST")" || true
+          echo "::endgroup::"
+          if [ -z "$DBTEST" ]; then
+            echo "ERROR: dbtest binary not found under the Bazel output base after build" >&2
+            exit 1
+          fi
+          poetry run python buildscripts/resmoke.py run \
+            --suites=dbtest \
+            --dbtest="$DBTEST" \
+            --jobs="$(nproc)" \
+            --reportFile=dbtest-report.json \
+            2>&1 | tee dbtest-logs/dbtest.log
+
+      # On failure, upload the teed resmoke console log (rich per-test failure
+      # output), the machine-readable resmoke report.json, and the build BEP.
+      # This is the artifact `mergai ci fix` downloads for the build-and-test
+      # workflow (see .mergai/config.yml). mongod/dbtest core dumps are not
+      # collected.
+      - name: Upload dbtest failure logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dbtest-failure-logs
+          path: |
+            dbtest-logs/
+            dbtest-report.json
+            bazel-bep.json
+          retention-days: 14
+          if-no-files-found: warn
+
   # Decides whether the jstests job runs, from PR labels and a repo/org
   # variable. Runs on a plain runner with no `environment:` so it never triggers
   # an RBE approval prompt. Labels are read fresh via `gh api` (not
@@ -375,13 +534,23 @@ jobs:
   # Runs the Percona resmoke jstest suites on RBE. Separate runner / GH check
   # from build+unittests (see the build-vs-unittests rationale block at the top
   # for why distinct runners are intentional). `needs: unittests` so it runs
-  # AFTER unittests (which needs: build) rather than alongside it -- the jstest
-  # suites are heavy and load-sensitive, so serializing them after unittests
-  # avoids competing for the same RBE workers. It does not consume the upstream
+  # AFTER unittests (which orders after dbtests -> build) rather than alongside
+  # it -- the heavy RBE jobs stay serialized (build -> dbtests -> unittests ->
+  # jstests) and avoid competing for the same RBE workers. Ordering only: the
+  # `if` gates on build success, not unittests success, so a unittest (or
+  # dbtest) failure does not block jstests. It does not consume the upstream
   # jobs' artifacts -- mongod/mongos/mongo are rebuilt here as RBE cache hits.
   #
   # Gated on jstests_gate: skipped when ci-skip-jstests is set, or when
   # vars.RUN_JSTESTS=false and ci-run-jstests is absent.
+  #
+  # The `if` uses !cancelled() + explicit result checks (not a bare `needs`)
+  # because jstests must still run after a unittest failure. `needs.gate.result
+  # == 'success'` keeps the security gate: jstests only runs after the
+  # rbe-external approval. `needs.build.result == 'success'` means a failed
+  # build (-> all test jobs skipped) still blocks jstests rather than slipping
+  # through on a 'skipped' result, while a unittest failure (build still
+  # 'success') does not.
   #
   # All jstest-running config lives in `--config=psmdb_remote_jstest`
   # (.bazelrc.psmdb): the remote test-execution strategies inherited from
@@ -399,13 +568,17 @@ jobs:
   #                     2-core pool) -- re-enable once PSMDB-2100 §1 lands.
   jstests:
     name: jstests
-    needs: [gate, unittests, jstests_gate]
+    # `unittests` is in needs for ORDERING (jstests runs after it, so the heavy
+    # jobs stay serialized), but the `if` gates on BUILD success, not unittests
+    # success, so a unittest failure does not block jstests -- both run whenever
+    # build passed. `build` is in needs so the `if` can read needs.build.result.
+    needs: [gate, build, unittests, jstests_gate]
     if: >-
       ${{ !cancelled()
       && needs.gate.result == 'success'
       && needs.jstests_gate.result == 'success'
       && needs.jstests_gate.outputs.should_run == 'true'
-      && needs.unittests.result == 'success' }}
+      && needs.build.result == 'success' }}
     # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
     runs-on: ubuntu-24.04
     # Same unattended `rbe` environment as `build` / `unittests`.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ name: build-and-test
 on:
   pull_request_target:
     # Deliberately NOT triggered on labeled/unlabeled. The workflow is a single
-    # gated pipeline (gate -> format_gate -> build -> dbtests -> unittests ->
+    # gated pipeline (gate -> format_gate -> build -> {dbtests, unittests} ->
     # jstests); whether jstests runs is decided from the PR's labels at run time
     # by jstests_gate,
     # so it does not need a label trigger. Listening to label events would also
@@ -324,18 +324,21 @@ jobs:
 
   unittests:
     name: unittests
-    # `needs: [build, dbtests]` -- dbtests is for ORDERING only (unittests waits
-    # for it so the RBE-heavy jobs run one at a time: build -> dbtests ->
-    # unittests -> jstests). The `if` below gates on build success, NOT dbtests
-    # success, so a dbtest failure does not block unittests; the two are
-    # independent test jobs that both run whenever build passed.
-    needs: [build, dbtests]
-    # !cancelled() so unittests still runs when dbtests FAILED (a failed need
-    # would otherwise skip it). Gated on build success: build runs only after
-    # the gate approval AND format passing, so build.result == 'success' implies
-    # rbe-external was approved, the PR was not a draft, and format passed.
+    # Runs in PARALLEL with dbtests: both depend only on `build`, so once build
+    # succeeds the two test jobs start together (pipeline is build -> {dbtests,
+    # unittests} -> jstests). This trades the old strict serialization (build ->
+    # dbtests -> unittests) for wall-clock: on a cached PR unittests is all
+    # remote cache hits (0 local actions) and dbtests' RBE use is only its build
+    # phase, so the two barely contend for RBE workers; on a real code change
+    # they may compete, which the bb-psmdb farm (300-way jobs) absorbs.
+    needs: [gate, build]
+    # Gated on build success: build runs only after the gate approval AND format
+    # passing, so build.result == 'success' implies rbe-external was approved,
+    # the PR was not a draft, and format passed. !cancelled() keeps the explicit
+    # result check authoritative rather than the bare-needs short-circuit.
     if: >-
       ${{ !cancelled()
+      && needs.gate.result == 'success'
       && needs.build.result == 'success' }}
     # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
     runs-on: ubuntu-24.04
@@ -467,11 +470,11 @@ jobs:
   # steps. dbtest is built HERE (not in the build job) so build only fetches
   # install-devcore.
   #
-  # `needs: [gate, build]` so it runs after build and BEFORE unittests:
-  # unittests/jstests order AFTER dbtests (via needs) so the RBE-heavy jobs run
-  # one at a time -- build -> dbtests -> unittests -> jstests -- but each gates
-  # on BUILD success, not on the previous test job, so a failure in one does not
-  # block the others: all three test jobs run whenever build passed.
+  # `needs: [gate, build]` so it runs right after build, in PARALLEL with
+  # unittests (which also depends only on build). jstests orders AFTER both via
+  # its own needs, so the pipeline is build -> {dbtests, unittests} -> jstests.
+  # Each job gates on BUILD success, not on a sibling test job, so a failure in
+  # one does not block the others: both test jobs run whenever build passed.
   # `needs.gate.result == 'success'` preserves the rbe-external approval gate
   # (it carries the same secrets via the `rbe` environment).
   dbtests:
@@ -623,12 +626,13 @@ jobs:
   # the decision reflects the current label set -- same freshness trick as
   # format.yml / clang-tidy.yml.
   #
-  # `needs: unittests` (with `if: !cancelled()` so it still runs when unittests
-  # is skipped or failed) makes this resolve LATE -- after build/unittests --
-  # so it reads a ci-skip-jstests / ci-run-jstests label applied *while the
-  # build was running* and that label takes effect on the same run. (The
-  # workflow is not triggered by label changes, so toggling a label after the
-  # run finishes only takes effect on the next push.)
+  # `needs: [dbtests, unittests]` (with `if: !cancelled()` so it still runs when
+  # those are skipped or failed) makes this resolve LATE -- after both parallel
+  # test jobs -- so it reads a ci-skip-jstests / ci-run-jstests label applied
+  # *while the build/tests were running* and that label takes effect on the same
+  # run. (The workflow is not triggered by label changes, so toggling a label
+  # after the run finishes only takes effect on the next push.) Depending on
+  # both keeps jstests serialized after the parallel dbtests+unittests pair.
   #
   # Precedence: ci-skip-jstests > ci-run-jstests > vars.RUN_JSTESTS (default run).
   #   - ci-skip-jstests label : force skip.
@@ -637,7 +641,7 @@ jobs:
   #                             'false' => skip unless ci-run-jstests is set.
   jstests_gate:
     name: jstests gate
-    needs: unittests
+    needs: [dbtests, unittests]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     outputs:
@@ -667,13 +671,13 @@ jobs:
 
   # Runs the Percona resmoke jstest suites on RBE. Separate runner / GH check
   # from build+unittests (see the build-vs-unittests rationale block at the top
-  # for why distinct runners are intentional). `needs: unittests` so it runs
-  # AFTER unittests (which orders after dbtests -> build) rather than alongside
-  # it -- the heavy RBE jobs stay serialized (build -> dbtests -> unittests ->
-  # jstests) and avoid competing for the same RBE workers. Ordering only: the
-  # `if` gates on build success, not unittests success, so a unittest (or
-  # dbtest) failure does not block jstests. It does not consume the upstream
-  # jobs' artifacts -- mongod/mongos/mongo are rebuilt here as RBE cache hits.
+  # for why distinct runners are intentional). `needs: [dbtests, unittests]` so
+  # it runs AFTER both parallel test jobs rather than alongside them -- jstests
+  # stays serialized at the tail (build -> {dbtests, unittests} -> jstests) and
+  # avoids competing for the same RBE workers. Ordering only: the `if` gates on
+  # build success, not dbtests/unittests success, so a unittest (or dbtest)
+  # failure does not block jstests. It does not consume the upstream jobs'
+  # artifacts -- mongod/mongos/mongo are rebuilt here as RBE cache hits.
   #
   # Gated on jstests_gate: skipped when ci-skip-jstests is set, or when
   # vars.RUN_JSTESTS=false and ci-run-jstests is absent.
@@ -702,11 +706,12 @@ jobs:
   #                     2-core pool) -- re-enable once PSMDB-2100 §1 lands.
   jstests:
     name: jstests
-    # `unittests` is in needs for ORDERING (jstests runs after it, so the heavy
-    # jobs stay serialized), but the `if` gates on BUILD success, not unittests
-    # success, so a unittest failure does not block jstests -- both run whenever
-    # build passed. `build` is in needs so the `if` can read needs.build.result.
-    needs: [gate, build, unittests, jstests_gate]
+    # `dbtests` and `unittests` are in needs for ORDERING (jstests runs after
+    # both, so the heavy jobs stay serialized), but the `if` gates on BUILD
+    # success, not their success, so a dbtest/unittest failure does not block
+    # jstests -- all run whenever build passed. `build` is in needs so the `if`
+    # can read needs.build.result.
+    needs: [gate, build, dbtests, unittests, jstests_gate]
     # `draft == false` so jstests never runs on a draft (it runs once the PR is
     # marked ready). `build` is in needs so the `if` can read needs.build.result
     # (which implies format passed via format_gate).

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,8 +10,9 @@ name: build-and-test
 on:
   pull_request_target:
     # Deliberately NOT triggered on labeled/unlabeled. The workflow is a single
-    # gated pipeline (gate -> build -> dbtests -> unittests -> jstests); whether
-    # jstests runs is decided from the PR's labels at run time by jstests_gate,
+    # gated pipeline (gate -> format_gate -> build -> dbtests -> unittests ->
+    # jstests); whether jstests runs is decided from the PR's labels at run time
+    # by jstests_gate,
     # so it does not need a label trigger. Listening to label events would also
     # make every label a producer like mergai stamps on a PR (ci-skip-clang-tidy
     # / ci-skip-format, meant for other workflows) spawn an extra run that skips
@@ -43,6 +44,10 @@ permissions:
   # Lets the jstests_gate job read fresh PR labels via
   # `gh api repos/.../pulls/<N>` to decide whether the jstests job runs.
   pull-requests: read
+  # Lets the format_gate job read the `format` workflow runs for this PR head SHA
+  # via `gh api repos/.../actions/workflows/format.yml/runs` and hold build until
+  # format has passed.
+  actions: read
 
 # RBE endpoints are shared between jobs. Pinned here so additions like
 # integration-tests/jsttests can reuse the same values without drift.
@@ -65,10 +70,12 @@ env:
   # path to _trusted/ keeps the entire import chain on the trusted copy.
   RBE_CREDENTIAL_HELPER: bb-psmdb.ddns.net=%workspace%/_trusted/bazel/wrapper_hook/credential_helper.py
 
-# Jobs: gate, build, unittests, dbtests, jstests (plus the jstests_gate
-# decider). `gate` is a no-op whose only purpose is to host the protected
-# `rbe-external` environment so a single maintainer approval authorizes the
-# entire workflow run. The test jobs depend on `gate` (transitively) and use
+# Jobs: gate, format_gate, build, unittests, dbtests, jstests (plus the
+# jstests_gate decider). `gate` is a no-op whose only purpose is to host the
+# protected `rbe-external` environment so a single maintainer approval authorizes
+# the entire workflow run. `format_gate` waits for the `format` workflow and
+# gates `build`; the test jobs inherit the format requirement transitively via
+# build. See those jobs. The test jobs depend on `gate` (transitively) and use
 # the unattended `rbe` environment — same secrets, no approval prompt — so the
 # maintainer isn't re-prompted between jobs.
 #
@@ -119,15 +126,92 @@ jobs:
       - run: |
           echo "RBE access approved for PR #${{ github.event.pull_request.number }} by ${{ github.actor }}"
 
+  # Format gate. `build` waits for it, so build never starts until the `format`
+  # workflow has passed (format is ~6 min, so the happy-path delay is small). The
+  # test jobs inherit this transitively: they gate on build success, and build
+  # only succeeds after format passed. A format FAILURE skips build (and the test
+  # jobs that chain off it), so we don't burn RBE on a SHA that a format fix will
+  # supersede (this run is then cancelled by concurrency.cancel-in-progress when
+  # the fix lands).
+  #
+  # clang-tidy is deliberately NOT gated here: its workflow concludes `success`
+  # even when clang-tidy reports findings (those surface as Code Scanning alerts,
+  # not a failing run, because the non-strict .clang-tidy has no WarningsAsErrors),
+  # so a gate on its run conclusion would only catch infra failures, not lint
+  # findings -- not worth holding the pipeline on.
+  #
+  # `format` runs on `pull_request` against the SAME head SHA as this
+  # `pull_request_target` run, so the gate locates the format run for that SHA
+  # and waits for it to conclude. The workflow ALWAYS produces a run: on the
+  # ci-skip-format label the analyze job is skipped but the run still concludes
+  # `success`, so requiring conclusion == 'success' treats that skip case as a
+  # pass and only a genuine FAILURE (or cancellation) blocks build.
+  #
+  # The poll loop is unbounded on purpose: a slow-but-passing format run must not
+  # wrongly skip build. The hard backstop is the job-level timeout
+  # (`timeout-minutes`, GitHub's 6h default); if the run never concludes the job
+  # times out -> `passed` stays empty -> build skips (fail-safe). In practice
+  # format is superseded by its own concurrency.cancel-in-progress on a new push,
+  # which makes the run conclude `cancelled` and the loop exit promptly.
+  #
+  # Job ID uses an underscore (so expressions can use dot access, consistent with
+  # jstests_gate); the display `name` uses a hyphen for the PR check label.
+  format_gate:
+    name: format-gate
+    needs: gate
+    # Skipped on a draft, exactly like build. build additionally requires
+    # passed == 'true', which is empty (falsey) when this job is skipped, so a
+    # draft stays fully skipped and consistent.
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-24.04
+    outputs:
+      passed: ${{ steps.wait.outputs.passed }}
+    steps:
+      - name: Wait for format to pass
+        id: wait
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          WORKFLOW: format.yml
+        run: |
+          set -euo pipefail
+          # Poll the workflow's latest run for this PR head SHA until it
+          # completes, then read its conclusion. status/conclusion stay empty
+          # while the run hasn't appeared or is still running. Unbounded; the
+          # job-level timeout is the backstop (see the comment above the job).
+          status=""; conclusion=""
+          while :; do
+            read -r status conclusion < <(gh api \
+              "repos/$REPO/actions/workflows/$WORKFLOW/runs?head_sha=$HEAD_SHA&per_page=1" \
+              --jq '.workflow_runs[0] | "\(.status) \(.conclusion)"' 2>/dev/null || echo " ")
+            echo "[$WORKFLOW] status=${status:-none} conclusion=${conclusion:-none}" >&2
+            [ "$status" = "completed" ] && break
+            sleep 30
+          done
+          if [ "$conclusion" = "success" ]; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+            echo "format passed -> build will run."
+          else
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping build/tests (format conclusion=${conclusion:-none})."
+          fi
+
   build:
     name: build
-    needs: gate
-    # Runs after gate approval on every non-draft trigger. Skipped while the PR
-    # is a DRAFT (draft == false guard) so a draft gets no heavy CI; marking it
-    # ready fires `ready_for_review` (draft == false) and build runs then.
-    # unittests and dbtests chain off `needs.build.result == 'success'`, so they
-    # inherit the draft skip automatically; jstests carries its own draft guard.
-    if: ${{ github.event.pull_request.draft == false }}
+    needs: [gate, format_gate]
+    # Runs after gate approval AND format passing, on every non-draft trigger.
+    # Skipped while the PR is a DRAFT (draft == false guard) so a draft gets no
+    # heavy CI; marking it ready fires `ready_for_review` (draft == false) and
+    # build runs then. needs.format_gate.outputs.passed holds build until format
+    # has passed (~6 min); it is empty (falsey) when format failed or was
+    # skipped, so a format failure skips build (and the test jobs that chain off
+    # it). unittests and dbtests chain off `needs.build.result == 'success'`, so
+    # they inherit the draft + format skip automatically; jstests carries its own
+    # draft guard.
+    if: >-
+      ${{ github.event.pull_request.draft == false
+      && needs.format_gate.outputs.passed == 'true' }}
     # Pinned to ubuntu-24.04 (not ubuntu-latest) because this workflow
     # depends on runner specifics that change silently when GH rolls the
     # alias forward: the /mnt ephemeral-disk layout assumed by
@@ -235,8 +319,8 @@ jobs:
     needs: [build, dbtests]
     # !cancelled() so unittests still runs when dbtests FAILED (a failed need
     # would otherwise skip it). Gated on build success: build runs only after
-    # the gate approval, so build.result == 'success' implies rbe-external was
-    # approved (and the PR was not a draft).
+    # the gate approval AND format passing, so build.result == 'success' implies
+    # rbe-external was approved, the PR was not a draft, and format passed.
     if: >-
       ${{ !cancelled()
       && needs.build.result == 'success' }}
@@ -380,6 +464,8 @@ jobs:
   dbtests:
     name: dbtests
     needs: [gate, build]
+    # Gated on build success, which implies the gate approval AND format passing
+    # (build gates on format_gate). No separate lint gate here.
     if: >-
       ${{ !cancelled()
       && needs.gate.result == 'success'
@@ -608,7 +694,8 @@ jobs:
     # build passed. `build` is in needs so the `if` can read needs.build.result.
     needs: [gate, build, unittests, jstests_gate]
     # `draft == false` so jstests never runs on a draft (it runs once the PR is
-    # marked ready). `build` is in needs so the `if` can read needs.build.result.
+    # marked ready). `build` is in needs so the `if` can read needs.build.result
+    # (which implies format passed via format_gate).
     if: >-
       ${{ !cancelled()
       && needs.gate.result == 'success'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -313,11 +313,15 @@ jobs:
           if-no-files-found: ignore
 
   # Decides whether the jstests job runs, from PR labels and a repo/org
-  # variable. Runs on a plain runner with no `environment:` and does NOT depend
-  # on `gate`, so it resolves immediately and never triggers an RBE approval
-  # prompt. Labels are read fresh via `gh api` (not github.event.*.labels) so
-  # the decision reflects the current label set even on a re-run -- same
-  # freshness trick as format.yml / clang-tidy.yml.
+  # variable. Runs on a plain runner with no `environment:` so it never triggers
+  # an RBE approval prompt. Labels are read fresh via `gh api` (not
+  # github.event.*.labels) so the decision reflects the current label set even
+  # on a re-run -- same freshness trick as format.yml / clang-tidy.yml.
+  #
+  # `needs: unittests` (with `if: !cancelled()` so it still runs when unittests
+  # is skipped or failed) makes this resolve LATE -- after the build -- so a
+  # ci-skip-jstests / ci-run-jstests label applied while the build was running
+  # takes effect on the same run instead of only the next push.
   #
   # Precedence: ci-skip-jstests > ci-run-jstests > vars.RUN_JSTESTS (default run).
   #   - ci-skip-jstests label : force skip.
@@ -326,6 +330,8 @@ jobs:
   #                             'false' => skip unless ci-run-jstests is set.
   jstests_gate:
     name: jstests gate
+    needs: unittests
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
@@ -379,8 +385,13 @@ jobs:
   #                     2-core pool) -- re-enable once PSMDB-2100 §1 lands.
   jstests:
     name: jstests
-    needs: [unittests, jstests_gate]
-    if: ${{ needs.jstests_gate.outputs.should_run == 'true' }}
+    needs: [gate, unittests, jstests_gate]
+    if: >-
+      ${{ !cancelled()
+      && needs.gate.result == 'success'
+      && needs.jstests_gate.result == 'success'
+      && needs.jstests_gate.outputs.should_run == 'true'
+      && needs.unittests.result == 'success' }}
     # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
     runs-on: ubuntu-24.04
     # Same unattended `rbe` environment as `build` / `unittests`.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,9 @@ permissions:
   # when this permission is granted, and without them the helper cannot
   # mint a GH OIDC id_token to exchange for a Dex JWT.
   id-token: write
+  # Lets the jstests_gate job read fresh PR labels via
+  # `gh api repos/.../pulls/<N>` to decide whether the jstests job runs.
+  pull-requests: read
 
 # RBE endpoints are shared between jobs. Pinned here so additions like
 # integration-tests/jsttests can reuse the same values without drift.
@@ -308,3 +311,232 @@ jobs:
             bazel-bep.json
           retention-days: 14
           if-no-files-found: ignore
+
+  # Decides whether the jstests job runs, from PR labels and a repo/org
+  # variable. Runs on a plain runner with no `environment:` and does NOT depend
+  # on `gate`, so it resolves immediately and never triggers an RBE approval
+  # prompt. Labels are read fresh via `gh api` (not github.event.*.labels) so
+  # the decision reflects the current label set even on a re-run -- same
+  # freshness trick as format.yml / clang-tidy.yml.
+  #
+  # Precedence: ci-skip-jstests > ci-run-jstests > vars.RUN_JSTESTS (default run).
+  #   - ci-skip-jstests label : force skip.
+  #   - ci-run-jstests label  : force run (overrides a default-off variable).
+  #   - vars.RUN_JSTESTS      : project default. Unset or 'true' => run;
+  #                             'false' => skip unless ci-run-jstests is set.
+  jstests_gate:
+    name: jstests gate
+    runs-on: ubuntu-24.04
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Decide whether to run jstests
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_JSTESTS: ${{ vars.RUN_JSTESTS }}
+        run: |
+          # Fetch the PR's current labels (fresh, not from the trigger payload).
+          LABELS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.labels[].name' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -qx "ci-skip-jstests"; then
+            echo "ci-skip-jstests label present -> skipping jstests"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -qx "ci-run-jstests"; then
+            echo "ci-run-jstests label present -> running jstests"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$RUN_JSTESTS" = "false" ]; then
+            echo "vars.RUN_JSTESTS=false and no run label -> skipping jstests"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "default -> running jstests"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Runs the Percona resmoke jstest suites on RBE. Separate runner / GH check
+  # from build+unittests (see the build-vs-unittests rationale block at the top
+  # for why distinct runners are intentional). `needs: unittests` so it runs
+  # AFTER unittests (which needs: build) rather than alongside it -- the jstest
+  # suites are heavy and load-sensitive, so serializing them after unittests
+  # avoids competing for the same RBE workers. It does not consume the upstream
+  # jobs' artifacts -- mongod/mongos/mongo are rebuilt here as RBE cache hits.
+  #
+  # Gated on jstests_gate: skipped when ci-skip-jstests is set, or when
+  # vars.RUN_JSTESTS=false and ci-run-jstests is absent.
+  #
+  # All jstest-running config lives in `--config=psmdb_remote_jstest`
+  # (.bazelrc.psmdb): the remote test-execution strategies inherited from
+  # remote_test (which brings its core/mdmp/gz force-download regex with it), the
+  # test_timeout, and the -incompatible_with_bazel_remote_test / -cpu:2 tag
+  # filter. Keeping it there lets a local
+  # `bazel test --config=psmdb_buildfarm --config=psmdb_remote_jstest ...`
+  # reproduce CI byte-for-byte.
+  #
+  # Suites are grouped the same way as the run_percona_jstests.sh helper:
+  #   - reliable      : pass consistently -> one parallel invocation.
+  #   - load-sensitive: flake under full-farm contention -> one at a time.
+  #   - skipped       : aggregation_tde_* (EMFILE / RLIMIT_NOFILE) and
+  #                     replica_sets_tde_*/sharding_tde_* (resources:cpu:2, no
+  #                     2-core pool) -- re-enable once PSMDB-2100 §1 lands.
+  jstests:
+    name: jstests
+    needs: [unittests, jstests_gate]
+    if: ${{ needs.jstests_gate.outputs.should_run == 'true' }}
+    # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
+    runs-on: ubuntu-24.04
+    # Same unattended `rbe` environment as `build` / `unittests`.
+    environment: rbe
+    # See `build.env` above for why this is at job level, not workflow level.
+    env:
+      PSMDB_RBE_GHA_AUDIENCE: ${{ secrets.PSMDB_RBE_GHA_AUDIENCE }}
+      PSMDB_RBE_OIDC_ISSUER: ${{ secrets.PSMDB_RBE_OIDC_ISSUER }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      # See the matching step in `build` for the rationale behind loading
+      # composite actions from a trusted base checkout under `_trusted/`.
+      - name: Checkout base (trusted) for composite actions
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.base_ref }}
+          path: _trusted
+          fetch-depth: 1
+
+      - name: Fetch tags
+        uses: ./_trusted/.github/actions/fetch-tags
+
+      - name: Free disk space and redirect Bazel to /mnt
+        uses: ./_trusted/.github/actions/free-disk-space
+
+      - name: Setup environment
+        uses: ./_trusted/.github/actions/setup-env
+
+      # Reliable suites: run together in one parallel invocation. See the build
+      # step for why --host_jvm_args / --output_user_root are set; GIT_COMMIT_HASH
+      # is deliberately omitted (as in unittests) to keep the remote CppLink cache
+      # key stable across pushes.
+      - name: Run reliable jstest suites via RBE
+        run: |
+          mkdir -p jstest-logs
+          # Tee the console to a file as a fallback. The primary diagnostic source
+          # is the per-test test.log collected from bazel-testlogs below: under
+          # --remote_download_outputs=minimal those stay in the remote cache, so
+          # --remote_download_regex force-downloads just test.log/test.xml to the
+          # runner (the global .bazelrc regex only covers test.xml). The tee still
+          # helps when a failure log exceeds --experimental_ui_max_stdouterr_bytes
+          # and bazel skips printing it.
+          # pipefail so bazel's exit status (not tee's) decides the step result.
+          set -o pipefail
+          bazel \
+            --output_user_root=/mnt/bazel \
+            --host_jvm_args=-Xmx12g \
+            test \
+            --config=psmdb_buildfarm \
+            --config=psmdb_remote_jstest \
+            --remote_executor=$RBE_REMOTE_EXECUTOR \
+            --remote_cache=$RBE_REMOTE_CACHE \
+            --bes_backend=$RBE_BES_BACKEND \
+            --bes_results_url=$RBE_BES_RESULTS_URL \
+            --credential_helper=$RBE_CREDENTIAL_HELPER \
+            --jobs=300 \
+            --keep_going \
+            --test_output=errors \
+            --remote_download_regex='.*/test\.(log|xml)$' \
+            --build_event_json_file=bazel-bep.json \
+            //jstests/knobs:knobs \
+            //jstests/percona/noPassthroughWithMongod:percona_no_passthrough_with_mongod \
+            //jstests/redaction:redaction \
+            //jstests/telemetry:telemetry \
+            //jstests/audit:audit \
+            //jstests/oidc:oidc \
+            //jstests/ldapauthz:ldapauthz_mock 2>&1 | tee jstest-logs/reliable.log
+
+      # Load-sensitive suites: each on its own invocation so it gets the workers
+      # uncontended (they flake when run alongside the full fan-out). Keep going
+      # across all of them and fail the step if any failed. The Bazel server (one
+      # --output_user_root) persists across iterations, so bazel-testlogs/
+      # accumulates every suite's logs for the failure-artifact upload.
+      - name: Run load-sensitive jstest suites via RBE (one at a time)
+        run: |
+          mkdir -p jstest-logs
+          # pipefail so the teed pipeline reports bazel's exit, not tee's.
+          set -o pipefail
+          rc=0
+          for t in \
+            //jstests/ratelimit:ratelimit \
+            //jstests/backup:backup \
+            //jstests/backup:backup_tde_cbc \
+            //jstests/backup:backup_tde_gcm \
+            //jstests/percona/tde:tde_cbc \
+            //jstests/percona/tde:tde_gcm \
+            //jstests/percona/tde:core_tde_cbc \
+            //jstests/percona/tde:core_tde_gcm; do
+            echo "::group::$t"
+            name=$(echo "$t" | sed 's#[/:]#_#g')
+            # Tee each suite's console (incl. failed-test logs via
+            # --test_output=errors) so the failure artifact has its diagnostics.
+            bazel \
+              --output_user_root=/mnt/bazel \
+              --host_jvm_args=-Xmx12g \
+              test \
+              --config=psmdb_buildfarm \
+              --config=psmdb_remote_jstest \
+              --remote_executor=$RBE_REMOTE_EXECUTOR \
+              --remote_cache=$RBE_REMOTE_CACHE \
+              --bes_backend=$RBE_BES_BACKEND \
+              --bes_results_url=$RBE_BES_RESULTS_URL \
+              --credential_helper=$RBE_CREDENTIAL_HELPER \
+              --jobs=300 \
+              --keep_going \
+              --test_output=errors \
+              --remote_download_regex='.*/test\.(log|xml)$' \
+              --build_event_json_file="bazel-bep-${name}.json" \
+              "$t" 2>&1 | tee "jstest-logs/${name}.log" || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
+
+      # Always upload the machine-readable test report: one bazel-bep*.json per
+      # invocation (reliable + each load-sensitive suite) carries every target's
+      # status. Uploaded on success too so results are downloadable from any run.
+      - name: Upload jstest reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jstest-reports
+          path: bazel-bep*.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      # On failure, gather the diagnostics. The primary source is the per-test
+      # test.log/test.xml under bazel-testlogs: the jstest test steps add
+      # --remote_download_regex='.*/test\.(log|xml)$' so those two files are
+      # downloaded to the runner even under --remote_download_outputs=minimal
+      # (without it they would stay in the remote cache and this copy would be
+      # empty). The teed console logs (jstest-logs/) are kept as a fallback for
+      # logs bazel skips printing when they exceed the UI byte cap. mongod core
+      # dumps are intentionally never downloaded.
+      - name: Collect jstest failure logs
+        if: failure()
+        run: |
+          mkdir -p jstest-failure-logs
+          cp -f jstest-logs/*.log jstest-failure-logs/ 2>/dev/null || true
+          cp -f bazel-bep*.json jstest-failure-logs/ 2>/dev/null || true
+          if [ -e bazel-testlogs ]; then
+            mkdir -p jstest-failure-logs/testlogs
+            cp -RL "$(readlink -f bazel-testlogs)"/. jstest-failure-logs/testlogs/ 2>/dev/null || true
+          fi
+          echo "Collected:"
+          find jstest-failure-logs -type f 2>/dev/null | sort
+
+      - name: Upload jstest failure logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jstest-failure-logs
+          path: jstest-failure-logs/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,12 +9,26 @@ name: build-and-test
 # whose required reviewers must approve every push.
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # Deliberately NOT triggered on labeled/unlabeled. The workflow is a single
+    # gated pipeline (gate -> build -> dbtests -> unittests -> jstests); whether
+    # jstests runs is decided from the PR's labels at run time by jstests_gate,
+    # so it does not need a label trigger. Listening to label events would also
+    # make every label a producer like mergai stamps on a PR (ci-skip-clang-tidy
+    # / ci-skip-format, meant for other workflows) spawn an extra run that skips
+    # the heavy jobs and shadows the real code run -- the regression that made
+    # build/unittests/dbtests show "skipped" on mergai PRs.
+    #
+    # ready_for_review runs the heavy jobs for a PR opened as a draft: they are
+    # gated on `draft == false` (see their `if:` below) so they skip while the
+    # PR is a draft and run once it is marked ready. Code events
+    # (opened/synchronize/reopened) run them directly on a non-draft PR.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - "mergai/**"
 
-# Cancel in-flight jobs of this workflow when a new commit lands on the same PR.
+# One concurrency group per PR: a newer code event (push, reopen, ready) for the
+# same PR supersedes an older in-flight run (cancel-in-progress).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -92,7 +106,8 @@ jobs:
   # environment authorizes the entire workflow run's downstream RBE
   # access, including the `unittests` job that doesn't run until ~30
   # minutes later. The maintainer reviewing the PR is implicitly
-  # approving every job that transitively depends on `gate`.
+  # approving every job that transitively depends on `gate`. Runs on every
+  # trigger; once approved the rest of the pipeline proceeds.
   gate:
     name: gate
     runs-on: ubuntu-24.04
@@ -107,6 +122,12 @@ jobs:
   build:
     name: build
     needs: gate
+    # Runs after gate approval on every non-draft trigger. Skipped while the PR
+    # is a DRAFT (draft == false guard) so a draft gets no heavy CI; marking it
+    # ready fires `ready_for_review` (draft == false) and build runs then.
+    # unittests and dbtests chain off `needs.build.result == 'success'`, so they
+    # inherit the draft skip automatically; jstests carries its own draft guard.
+    if: ${{ github.event.pull_request.draft == false }}
     # Pinned to ubuntu-24.04 (not ubuntu-latest) because this workflow
     # depends on runner specifics that change silently when GH rolls the
     # alias forward: the /mnt ephemeral-disk layout assumed by
@@ -215,7 +236,7 @@ jobs:
     # !cancelled() so unittests still runs when dbtests FAILED (a failed need
     # would otherwise skip it). Gated on build success: build runs only after
     # the gate approval, so build.result == 'success' implies rbe-external was
-    # approved.
+    # approved (and the PR was not a draft).
     if: >-
       ${{ !cancelled()
       && needs.build.result == 'success' }}
@@ -353,11 +374,9 @@ jobs:
   # unittests/jstests order AFTER dbtests (via needs) so the RBE-heavy jobs run
   # one at a time -- build -> dbtests -> unittests -> jstests -- but each gates
   # on BUILD success, not on the previous test job, so a failure in one does not
-  # block the others: all three test jobs run whenever build passed. Unlike
-  # jstests it is NOT gated on labels/a variable: dbtest is a deterministic C++
-  # suite, so it always runs. `needs.gate.result == 'success'` preserves the
-  # rbe-external approval gate (it carries the same secrets via the `rbe`
-  # environment).
+  # block the others: all three test jobs run whenever build passed.
+  # `needs.gate.result == 'success'` preserves the rbe-external approval gate
+  # (it carries the same secrets via the `rbe` environment).
   dbtests:
     name: dbtests
     needs: [gate, build]
@@ -500,15 +519,16 @@ jobs:
           if-no-files-found: warn
 
   # Decides whether the jstests job runs, from PR labels and a repo/org
-  # variable. Runs on a plain runner with no `environment:` so it never triggers
-  # an RBE approval prompt. Labels are read fresh via `gh api` (not
-  # github.event.*.labels) so the decision reflects the current label set even
-  # on a re-run -- same freshness trick as format.yml / clang-tidy.yml.
+  # variable. Labels are read fresh via `gh api` (not github.event.*.labels) so
+  # the decision reflects the current label set -- same freshness trick as
+  # format.yml / clang-tidy.yml.
   #
   # `needs: unittests` (with `if: !cancelled()` so it still runs when unittests
-  # is skipped or failed) makes this resolve LATE -- after the build -- so a
-  # ci-skip-jstests / ci-run-jstests label applied while the build was running
-  # takes effect on the same run instead of only the next push.
+  # is skipped or failed) makes this resolve LATE -- after build/unittests --
+  # so it reads a ci-skip-jstests / ci-run-jstests label applied *while the
+  # build was running* and that label takes effect on the same run. (The
+  # workflow is not triggered by label changes, so toggling a label after the
+  # run finishes only takes effect on the next push.)
   #
   # Precedence: ci-skip-jstests > ci-run-jstests > vars.RUN_JSTESTS (default run).
   #   - ci-skip-jstests label : force skip.
@@ -558,13 +578,13 @@ jobs:
   # Gated on jstests_gate: skipped when ci-skip-jstests is set, or when
   # vars.RUN_JSTESTS=false and ci-run-jstests is absent.
   #
-  # The `if` uses !cancelled() + explicit result checks (not a bare `needs`)
-  # because jstests must still run after a unittest failure. `needs.gate.result
-  # == 'success'` keeps the security gate: jstests only runs after the
-  # rbe-external approval. `needs.build.result == 'success'` means a failed
-  # build (-> all test jobs skipped) still blocks jstests rather than slipping
-  # through on a 'skipped' result, while a unittest failure (build still
-  # 'success') does not.
+  # The `if` uses !cancelled() + explicit result checks (not a bare `needs`) so
+  # jstests still runs after a unittest failure. `needs.gate.result ==
+  # 'success'` keeps the security gate (jstests only runs after the rbe-external
+  # approval), and `needs.build.result == 'success'` means a failed build
+  # (-> all test jobs skipped) still blocks jstests rather than slipping through
+  # on a 'skipped' result, while a unittest failure (build still 'success')
+  # does not.
   #
   # All jstest-running config lives in `--config=psmdb_remote_jstest`
   # (.bazelrc.psmdb): the remote test-execution strategies inherited from
@@ -587,11 +607,14 @@ jobs:
     # success, so a unittest failure does not block jstests -- both run whenever
     # build passed. `build` is in needs so the `if` can read needs.build.result.
     needs: [gate, build, unittests, jstests_gate]
+    # `draft == false` so jstests never runs on a draft (it runs once the PR is
+    # marked ready). `build` is in needs so the `if` can read needs.build.result.
     if: >-
       ${{ !cancelled()
       && needs.gate.result == 'success'
       && needs.jstests_gate.result == 'success'
       && needs.jstests_gate.outputs.should_run == 'true'
+      && github.event.pull_request.draft == false
       && needs.build.result == 'success' }}
     # See `build.runs-on` above for why this is pinned, not `ubuntu-latest`.
     runs-on: ubuntu-24.04

--- a/.mergai/config.yml
+++ b/.mergai/config.yml
@@ -593,15 +593,20 @@ workflows:
       # Default: <workflow name> (here: clang-tidy)
       # code_scanning_tool_name: clang-tidy
 
-  # `build-and-test` covers the two jobs in `.github/workflows/build-and-test.yml`:
-  # the `build` and the `unittests` jobs.
+  # `build-and-test` covers the three jobs in `.github/workflows/build-and-test.yml`:
+  # the `build`, `unittests`, and `jstests` jobs.
   # Mergai's workflow_run trigger fires once for the whole workflow, so a single
-  # entry covers both jobs; the BEP context builder decides what to feed the agent
-  # based on which artifact is present in the failing run.
+  # entry covers all three jobs; the BEP context builder decides what to feed the
+  # agent based on which artifact is present in the failing run.
+  #
+  # The jobs run sequentially (build -> unittests -> jstests), so at most one
+  # failure artifact is present per run: a failing job blocks the ones after it.
   #
   # Capped at 2 attempts: like clang-tidy, build/test fixes need human-grade
   # judgement and shouldn't loop indefinitely on flakes or environmental
-  # failures.
+  # failures. This matters most for jstests, whose load-sensitive suites can
+  # flake; the agent is instructed to return `unfixable` for likely flakes
+  # rather than editing source, and the cap bounds the rest.
   build-and-test:
     enabled: true
     max_attempts: 2
@@ -615,8 +620,13 @@ workflows:
       source: artifact
       # The build job uploads `build-failure-artifacts` (bazel-bep.json);
       # the unittests job uploads `unittest-failure-artifacts` (bazel-bep.json
-      # plus bazel-testlogs/ with per-target test.log and JUnit test.xml).
-      # Only one is present per failing run (unittests is gated on build).
+      # plus bazel-testlogs/ with per-target test.log and JUnit test.xml);
+      # the jstests job uploads `jstest-failure-logs` (one bazel-bep*.json per
+      # resmoke invocation -- bazel-bep.json for the reliable batch plus
+      # bazel-bep-<suite>.json per load-sensitive suite -- the teed console
+      # logs, and a testlogs/ tree of per-target test.log/test.xml). Only one
+      # is present per failing run (each job is gated on the previous one).
       artifact_name:
         - build-failure-artifacts
         - unittest-failure-artifacts
+        - jstest-failure-logs

--- a/.mergai/config.yml
+++ b/.mergai/config.yml
@@ -593,14 +593,23 @@ workflows:
       # Default: <workflow name> (here: clang-tidy)
       # code_scanning_tool_name: clang-tidy
 
-  # `build-and-test` covers the three jobs in `.github/workflows/build-and-test.yml`:
-  # the `build`, `unittests`, and `jstests` jobs.
+  # `build-and-test` covers the jobs in `.github/workflows/build-and-test.yml`:
+  # `build`, `unittests`, `dbtests`, and `jstests`.
   # Mergai's workflow_run trigger fires once for the whole workflow, so a single
-  # entry covers all three jobs; the BEP context builder decides what to feed the
+  # entry covers all the jobs; the BEP context builder decides what to feed the
   # agent based on which artifact is present in the failing run.
   #
-  # The jobs run sequentially (build -> unittests -> jstests), so at most one
-  # failure artifact is present per run: a failing job blocks the ones after it.
+  # build -> dbtests -> unittests -> jstests run sequentially on RBE, but each
+  # test job is gated only on build success (not on the preceding test job), so
+  # one test failure doesn't block the later test jobs. More than one failure
+  # artifact can therefore be present in a run; the context builder picks up
+  # whichever artifact(s) are present.
+  #
+  # NOTE: dbtests runs resmoke LOCALLY (the dbtest binary has no Bazel test
+  # target), so its `dbtest-failure-logs` artifact carries the teed resmoke
+  # console log + report.json rather than a Bazel BEP. The other artifacts carry
+  # bazel-bep*.json. If the bazel context builder needs a BEP to extract the
+  # failure, the dbtest console log is the fallback the agent reads.
   #
   # Capped at 2 attempts: like clang-tidy, build/test fixes need human-grade
   # judgement and shouldn't loop indefinitely on flakes or environmental
@@ -621,12 +630,14 @@ workflows:
       # The build job uploads `build-failure-artifacts` (bazel-bep.json);
       # the unittests job uploads `unittest-failure-artifacts` (bazel-bep.json
       # plus bazel-testlogs/ with per-target test.log and JUnit test.xml);
+      # the dbtests job uploads `dbtest-failure-logs` (the teed resmoke console
+      # log, resmoke's report.json, and the build bazel-bep.json);
       # the jstests job uploads `jstest-failure-logs` (one bazel-bep*.json per
       # resmoke invocation -- bazel-bep.json for the reliable batch plus
       # bazel-bep-<suite>.json per load-sensitive suite -- the teed console
-      # logs, and a testlogs/ tree of per-target test.log/test.xml). Only one
-      # is present per failing run (each job is gated on the previous one).
+      # logs, and a testlogs/ tree of per-target test.log/test.xml).
       artifact_name:
         - build-failure-artifacts
         - unittest-failure-artifacts
+        - dbtest-failure-logs
         - jstest-failure-logs

--- a/buildscripts/github_test_summary.py
+++ b/buildscripts/github_test_summary.py
@@ -1,0 +1,252 @@
+"""Append a pass/fail summary of Bazel test targets to the GitHub job summary.
+
+Reads the Build Event Protocol JSON (Bazel's --build_event_json_file), building on
+the testSummary parse in buildscripts/gather_failed_tests.py. The BEP is always
+written locally and carries a testSummary event per target with its overallStatus
+-- unlike test.xml, which under --remote_download_outputs=minimal stays in the
+remote cache and is not on the runner.
+
+A target is reported as one of three outcomes so a cancelled or interrupted run
+stays honest:
+  * passed     -- overallStatus PASSED or FLAKY (passed on retry);
+  * failed     -- a failing overallStatus, OR any individual testResult failed
+                  (the latter catches a real failure even when the suite's
+                  aggregate summary never finalized because the run was killed);
+  * incomplete -- a target that was started but never reached a verdict
+                  (NO_STATUS / INCOMPLETE), e.g. the in-flight suite when the
+                  workflow is cancelled.
+
+With --detailed (used for unittests), the summary also reports how many targets
+actually executed vs were served from cache (per-testResult cachedLocally /
+executionInfo.cachedRemotely) and adds a collapsible per-target table.
+
+Writes Markdown to $GITHUB_STEP_SUMMARY (or stdout when unset, for local runs).
+Always exits 0 -- reporting must never mask the real `bazel test` exit code.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+PASSING = {"PASSED", "FLAKY"}
+FAILING = {"FAILED", "TIMEOUT", "REMOTE_FAILURE", "FAILED_TO_BUILD"}
+
+# Render order and icon for each outcome.
+OUTCOME_RANK = {"failed": 0, "incomplete": 1, "skipped": 2, "passed": 3}
+OUTCOME_ICON = {"failed": "❌", "incomplete": "⚠️", "skipped": "⚪", "passed": "✅"}
+
+
+def summary_duration_ms(summary):
+    """Wall-clock duration of a target in ms: last stop minus first start, with
+    totalRunDurationMillis (cumulative across shards/runs) as a fallback."""
+    start = summary.get("firstStartTimeMillis")
+    stop = summary.get("lastStopTimeMillis")
+    try:
+        if start is not None and stop is not None:
+            return max(0, int(stop) - int(start))
+    except (TypeError, ValueError):
+        pass
+    try:
+        return int(summary["totalRunDurationMillis"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def fmt_duration(ms):
+    if ms is None:
+        return "—"
+    if ms < 1000:
+        return f"{ms} ms"
+    seconds = ms / 1000.0
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(round(seconds)), 60)
+    if minutes < 60:
+        return f"{minutes}m{secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m"
+
+
+def parse_bep(paths):
+    """Return {label: {outcome, cached, failed_runs, total_runs, duration_ms}} from BEP."""
+    summaries = {}  # label -> (overallStatus, failed_runs, total_runs)
+    result_failed = set()  # labels with at least one failing individual testResult
+    executed = set()  # labels with at least one freshly-executed testResult
+    cached = set()  # labels with at least one cache-hit testResult
+    skipped = set()  # labels skipped by --test_tag_filters (aborted/SKIPPED, no testSummary)
+    for path in paths:
+        with open(path, "rt", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                event_id = event.get("id", {})
+                if "testSummary" in event_id:
+                    label = event_id["testSummary"]["label"]
+                    summary = event["testSummary"]
+                    status = summary.get("overallStatus", "NO_STATUS")
+                    entry = (
+                        status,
+                        len(summary.get("failed", [])),
+                        summary.get("totalRunCount", 0),
+                        summary_duration_ms(summary),
+                    )
+                    # If a label recurs across invocations, keep the worst outcome.
+                    prev = summaries.get(label)
+                    if prev is None or (status not in PASSING and prev[0] in PASSING):
+                        summaries[label] = entry
+                elif "testResult" in event_id:
+                    label = event_id["testResult"]["label"]
+                    result = event.get("testResult", {})
+                    if result.get("status") in FAILING:
+                        result_failed.add(label)
+                    if result.get("cachedLocally") or result.get("executionInfo", {}).get(
+                        "cachedRemotely"
+                    ):
+                        cached.add(label)
+                    else:
+                        executed.add(label)
+                elif event.get("aborted", {}).get("reason") == "SKIPPED":
+                    # A target filtered out by --test_tag_filters: reported as an
+                    # aborted/SKIPPED event with no testSummary/testResult.
+                    label = event_id.get("targetCompleted", {}).get("label")
+                    if label:
+                        skipped.add(label)
+
+    targets = {}
+    for label in set(summaries) | result_failed | skipped:
+        if label in skipped and label not in summaries and label not in result_failed:
+            targets[label] = {
+                "outcome": "skipped",
+                "cached": False,
+                "failed_runs": 0,
+                "total_runs": 0,
+                "duration_ms": None,
+            }
+            continue
+        status, failed_runs, total_runs, duration_ms = summaries.get(
+            label, ("NO_STATUS", 0, 0, None)
+        )
+        # Check PASSING first: a finalized PASSED/FLAKY verdict wins even when the
+        # BEP also carries a failed individual testResult (a flaky suite logs the
+        # losing run before the passing retry). result_failed only decides the
+        # outcome when the summary never finalized (NO_STATUS / INCOMPLETE).
+        if status in PASSING:
+            outcome = "passed"
+        elif status in FAILING or label in result_failed:
+            outcome = "failed"
+        else:
+            outcome = "incomplete"
+        targets[label] = {
+            "outcome": outcome,
+            # Cached only if it was served from cache and never freshly executed.
+            "cached": label in cached and label not in executed,
+            "failed_runs": failed_runs,
+            "total_runs": total_runs,
+            "duration_ms": duration_ms,
+        }
+    return targets
+
+
+def render(targets, title, detailed):
+    out = [f"## {title}", ""]
+    if not targets:
+        out.append("⚠️ No test results found in the build event log.")
+        return "\n".join(out) + "\n"
+
+    failed = sorted(l for l, t in targets.items() if t["outcome"] == "failed")
+    incomplete = sorted(l for l, t in targets.items() if t["outcome"] == "incomplete")
+    skipped = sorted(l for l, t in targets.items() if t["outcome"] == "skipped")
+    passed = len(targets) - len(failed) - len(incomplete) - len(skipped)
+
+    counts = []
+    if failed:
+        counts.append(f"{len(failed)} failed")
+    if incomplete:
+        counts.append(f"{len(incomplete)} incomplete")
+    counts.append(f"{passed} passed")
+    if skipped:
+        counts.append(f"{len(skipped)} skipped")
+    icon = "❌" if failed else ("⚠️" if incomplete else "✅")
+    headline = f"{icon} {', '.join(counts)} ({len(targets)} targets)"
+    if detailed:
+        # executed/cached are over the targets that actually ran (not skipped).
+        tested = len(targets) - len(skipped)
+        cached = sum(1 for t in targets.values() if t["cached"])
+        headline += f" — {tested - cached} executed, {cached} cached"
+    out.append(headline)
+
+    if failed or incomplete:
+        out += ["", "### Failures", "", "| Target | Status | Runs failed |", "| --- | --- | --- |"]
+        for label in failed:
+            t = targets[label]
+            out.append(f"| `{label}` | failed | {t['failed_runs']}/{t['total_runs'] or '?'} |")
+        for label in incomplete:
+            out.append(f"| `{label}` | incomplete (no verdict) | — |")
+
+    if skipped:
+        out += ["", f"<details><summary>{len(skipped)} skipped</summary>", ""]
+        out += [f"- `{label}`" for label in skipped]
+        out += ["", "</details>"]
+
+    if detailed:
+        out += ["", f"<details><summary>All {len(targets)} targets</summary>", ""]
+        out += ["| Target | Status | Time | Runs | Source |", "| --- | --- | --- | --- | --- |"]
+        for label in sorted(targets, key=lambda l: (OUTCOME_RANK[targets[l]["outcome"]], l)):
+            t = targets[label]
+            if t["outcome"] == "skipped":
+                source = "—"
+            else:
+                source = "cached" if t["cached"] else "executed"
+            runs = str(t["total_runs"]) if t["total_runs"] else "—"
+            out.append(
+                f"| `{label}` | {OUTCOME_ICON[t['outcome']]} {t['outcome']} "
+                f"| {fmt_duration(t['duration_ms'])} | {runs} | {source} |"
+            )
+        out += ["", "</details>"]
+
+    out.append("")
+    return "\n".join(out) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "bep_glob", nargs="?", default="bazel-bep*.json", help="glob for BEP JSON file(s)"
+    )
+    parser.add_argument("--title", default="🧪 Test results", help="summary heading")
+    parser.add_argument(
+        "--detailed",
+        action="store_true",
+        help="add executed/cached counts and a per-target table",
+    )
+    args = parser.parse_args()
+
+    paths = sorted(glob.glob(args.bep_glob))
+    targets = parse_bep(paths)
+
+    text = render(targets, args.title, args.detailed)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(text)
+    else:
+        sys.stdout.write(text)
+    print(
+        f"github_test_summary: {len(paths)} BEP file(s), {len(targets)} target(s)", file=sys.stderr
+    )
+
+
+if __name__ == "__main__":
+    # Reporting must never mask the real test exit code.
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001
+        print(f"github_test_summary: non-fatal error: {exc}", file=sys.stderr)
+    sys.exit(0)

--- a/buildscripts/github_test_summary.py
+++ b/buildscripts/github_test_summary.py
@@ -154,10 +154,70 @@ def parse_bep(paths):
     return targets
 
 
+def parse_resmoke(paths):
+    """Return {test_file: {outcome, cached, failed_runs, total_runs, duration_ms}}
+    from resmoke report.json file(s).
+
+    Used by the dbtests job, which runs resmoke LOCALLY (the dbtest binary has no
+    Bazel test target, so there is no BEP). The report schema is
+    {"results": [{"test_file", "status", "exit_code", "start", "end", ...}]}
+    where status is an Evergreen status string. Outcomes are mapped to match
+    parse_bep so render() is shared:
+      * pass                  -> passed;
+      * skip / silentfail     -> skipped (silentfail is a silenced/known failure);
+      * anything else         -> failed (fail, timeout, error, ...).
+    """
+    targets = {}
+    for path in paths:
+        try:
+            with open(path, "rt", encoding="utf-8", errors="replace") as fh:
+                results = json.load(fh).get("results", [])
+        except (OSError, ValueError):
+            continue
+        for r in results:
+            label = r.get("test_file") or r.get("display_test_name") or "?"
+            status = (r.get("status") or "").lower()
+            if status == "pass":
+                outcome = "passed"
+            elif status in ("skip", "silentfail"):
+                outcome = "skipped"
+            else:
+                outcome = "failed"
+            duration_ms = None
+            start, end = r.get("start"), r.get("end")
+            try:
+                if start is not None and end is not None:
+                    duration_ms = max(0, int((float(end) - float(start)) * 1000))
+            except (TypeError, ValueError):
+                duration_ms = None
+            failed_run = 1 if outcome == "failed" else 0
+            prev = targets.get(label)
+            if prev is None:
+                targets[label] = {
+                    "outcome": outcome,
+                    "cached": False,
+                    "failed_runs": failed_run,
+                    "total_runs": 1,
+                    "duration_ms": duration_ms,
+                }
+            else:
+                # A test can recur in one report (e.g. --repeatTests). Accumulate
+                # the run counts/duration across the repeats and keep the worst
+                # outcome, so the summary reflects every run rather than just the
+                # last one.
+                prev["total_runs"] += 1
+                prev["failed_runs"] += failed_run
+                if duration_ms is not None:
+                    prev["duration_ms"] = (prev["duration_ms"] or 0) + duration_ms
+                if outcome == "failed":
+                    prev["outcome"] = "failed"
+    return targets
+
+
 def render(targets, title, detailed):
     out = [f"## {title}", ""]
     if not targets:
-        out.append("⚠️ No test results found in the build event log.")
+        out.append("⚠️ No test results found.")
         return "\n".join(out) + "\n"
 
     failed = sorted(l for l, t in targets.items() if t["outcome"] == "failed")
@@ -226,10 +286,22 @@ def main():
         action="store_true",
         help="add executed/cached counts and a per-target table",
     )
+    parser.add_argument(
+        "--resmoke-report",
+        default="",
+        help=(
+            "glob for resmoke report.json file(s) from a LOCAL resmoke run (e.g. the "
+            "dbtests job). Merged into the BEP targets so render() is shared."
+        ),
+    )
     args = parser.parse_args()
 
-    paths = sorted(glob.glob(args.bep_glob))
-    targets = parse_bep(paths)
+    bep_paths = sorted(glob.glob(args.bep_glob)) if args.bep_glob else []
+    targets = parse_bep(bep_paths)
+
+    resmoke_paths = sorted(glob.glob(args.resmoke_report)) if args.resmoke_report else []
+    if resmoke_paths:
+        targets.update(parse_resmoke(resmoke_paths))
 
     text = render(targets, args.title, args.detailed)
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
@@ -239,7 +311,9 @@ def main():
     else:
         sys.stdout.write(text)
     print(
-        f"github_test_summary: {len(paths)} BEP file(s), {len(targets)} target(s)", file=sys.stderr
+        f"github_test_summary: {len(bep_paths)} BEP file(s), "
+        f"{len(resmoke_paths)} resmoke report(s), {len(targets)} target(s)",
+        file=sys.stderr,
     )
 
 


### PR DESCRIPTION
Adds a jstests CI job to the `build-and-test` workflow, the Bazel RBE
profile it runs on, the gating that keeps it correct alongside the other
pipeline jobs, and a GitHub job-summary report for both unittests and
jstests.

- **jstests job** - runs the wired Percona resmoke suites on RBE: a
  reliable batch in one invocation (includes the hermetic `ldapauthz_mock`
  suite alongside `oidc`) plus load-sensitive suites one at a time. Gated
  behind the same `rbe-external` approval as the existing build/unittests
  jobs. Whether it runs is decided by a separate `jstests_gate` job from
  the PR's labels and the `vars.RUN_JSTESTS` repo/org variable -
  precedence `ci-skip-jstests` > `ci-run-jstests` > `vars.RUN_JSTESTS`
  (default: run).
- **Gating** - `jstests_gate` resolves late (`needs: unittests`,
  `if: !cancelled()`) and reads labels after the build, so a label
  flipped mid-run takes effect on the same run. `jstests` keys off
  `!cancelled()` + explicit result checks: `gate == success` keeps the
  RBE approval, `jstests_gate == success` ensures the decision was made,
  and `unittests == success` (which implies build succeeded) blocks
  jstests on a failed build.
- **Bazel config** - defines the `psmdb_remote_jstest` `--config` profile
  in `.bazelrc.psmdb` so the suites run on the bb-psmdb RBE farm (inherits
  upstream `remote_test`, layers PSMDB test-timeout, log-cap, and
  tag-exclusion overrides).
- **Reporting** - a trusted composite action parses Bazel's BEP and
  writes a pass/fail/incomplete/skipped summary to `$GITHUB_STEP_SUMMARY`
  for both unittests and jstests, with collapsible per-target / per-suite
  tables and reconciled totals.
  
  Stacked on : #1905