### PR TITLE
PSMDB-2032 add a possibility to run e2e tests with mongot non-localdev builds

### DIFF
--- a/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_sharded_collections.yml
+++ b/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_sharded_collections.yml
@@ -25,7 +25,7 @@ selector:
     - jstests/with_mongot/e2e_lib/*_test.js
   exclude_files:
     - jstests/with_mongot/e2e/sharding_no_passthrough/**/*.js
-    # TODO: investigate failures with mongot-community fixture.
+    # TODO: PSMDB-2166
     - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_view.js
     - jstests/with_mongot/e2e_infrastructure_tests/updateSearchIndex.js
     - jstests/with_mongot/e2e/hybridSearch/ranked_fusion_on_view.js

--- a/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_sharded_collections.yml
+++ b/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_sharded_collections.yml
@@ -1,0 +1,71 @@
+# Even though this suite skips auth between mongod and mongot, auth is still required to set up
+# mongot for the fixture.
+config_variables:
+  - &keyFile jstests/with_mongot/keyfile_for_testing
+  - &keyFileData Thiskeyisonlyforrunningthesuitewithauthenticationdontuseitinanytestsdirectly
+  - &authOptions
+    # mongos requires authenticating as the __system user using the admin database.
+    # This is different than non-sharded search e2e suites, which authenticate on
+    # the local db.
+    authenticationDatabase: admin
+    authenticationMechanism: SCRAM-SHA-256
+    password: *keyFileData
+    username: __system
+
+test_kind: js_test
+description: |
+  This suite is identical to mongot_community_e2e_sharded_collections except that it launches
+  mongot-community (configured via YAML and exposing only gRPC) via MongoTCommunityFixture
+  instead of mongot-localdev.
+
+selector:
+  roots:
+    - jstests/with_mongot/e2e/**/*.js
+    - jstests/with_mongot/e2e_infrastructure_tests/*.js
+    - jstests/with_mongot/e2e_lib/*_test.js
+  exclude_files:
+    - jstests/with_mongot/e2e/sharding_no_passthrough/**/*.js
+    # TODO: investigate failures with mongot-community fixture.
+    - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_view.js
+    - jstests/with_mongot/e2e_infrastructure_tests/updateSearchIndex.js
+    - jstests/with_mongot/e2e/hybridSearch/ranked_fusion_on_view.js
+    - jstests/with_mongot/e2e/hybridSearch/hybrid_search_on_view_rejected.js
+    - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_search_view.js
+  exclude_with_any_tags:
+    - assumes_against_mongod_not_mongos
+    - assumes_unsharded_collection
+
+executor:
+  config:
+    shell_options:
+      global_vars:
+        TestData:
+          auth: true
+          authMechanism: SCRAM-SHA-256
+          keyFile: *keyFile
+          keyFileData: *keyFileData
+          roleGraphInvalidationIsFatal: true
+      eval: >-
+        await import("jstests/libs/override_methods/implicitly_shard_accessed_collections.js");
+        jsTest.authenticate(db.getMongo());
+      <<: *authOptions
+  fixture:
+    class: ShardedClusterFixture
+    auth_options: *authOptions
+    launch_mongot_community: true
+    num_shards: 2
+    num_mongos: 3
+    mongod_options:
+      keyFile: *keyFile
+      set_parameters:
+        enableTestCommands: 1
+        featureFlagEgressGrpcForSearch: true
+        useGrpcForSearch: 1
+        skipAuthenticationToMongot: true
+    mongos_options:
+      keyFile: *keyFile
+      set_parameters:
+        enableTestCommands: 1
+        featureFlagEgressGrpcForSearch: true
+        useGrpcForSearch: 1
+        skipAuthenticationToMongot: true

--- a/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_sharded_collections.yml
+++ b/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_sharded_collections.yml
@@ -26,9 +26,7 @@ selector:
   exclude_files:
     - jstests/with_mongot/e2e/sharding_no_passthrough/**/*.js
     # TODO: PSMDB-2166
-    - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_view.js
     - jstests/with_mongot/e2e_infrastructure_tests/updateSearchIndex.js
-    - jstests/with_mongot/e2e/hybridSearch/ranked_fusion_on_view.js
     - jstests/with_mongot/e2e/hybridSearch/hybrid_search_on_view_rejected.js
     - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_search_view.js
   exclude_with_any_tags:

--- a/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_single_node.yml
+++ b/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_single_node.yml
@@ -23,7 +23,7 @@ selector:
     - jstests/with_mongot/e2e_lib/*_test.js
   exclude_files:
     - jstests/with_mongot/e2e/sharding_no_passthrough/**/*.js
-    # TODO: investigate failures with mongot-community fixture.
+    # TODO: PSMDB-2166
     - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_view.js
     - jstests/with_mongot/e2e_infrastructure_tests/updateSearchIndex.js
     - jstests/with_mongot/e2e/hybridSearch/ranked_fusion_on_view.js

--- a/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_single_node.yml
+++ b/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_single_node.yml
@@ -24,9 +24,7 @@ selector:
   exclude_files:
     - jstests/with_mongot/e2e/sharding_no_passthrough/**/*.js
     # TODO: PSMDB-2166
-    - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_view.js
     - jstests/with_mongot/e2e_infrastructure_tests/updateSearchIndex.js
-    - jstests/with_mongot/e2e/hybridSearch/ranked_fusion_on_view.js
     - jstests/with_mongot/e2e/hybridSearch/hybrid_search_on_view_rejected.js
     - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_search_view.js
   exclude_with_any_tags:

--- a/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_single_node.yml
+++ b/buildscripts/resmokeconfig/suites/mongot_community_fixture_e2e_single_node.yml
@@ -1,0 +1,58 @@
+# Even though this suite skips auth between mongod and mongot, auth is still required to set up
+# mongot for the fixture.
+config_variables:
+  - &keyFile jstests/with_mongot/keyfile_for_testing
+  - &keyFileData Thiskeyisonlyforrunningthesuitewithauthenticationdontuseitinanytestsdirectly
+  - &authOptions
+    authenticationDatabase: local
+    authenticationMechanism: SCRAM-SHA-256
+    password: *keyFileData
+    username: __system
+
+test_kind: js_test
+
+description: |
+  This suite is identical to mongot_community_e2e_single_node except that it launches
+  mongot-community (configured via YAML and exposing only gRPC) via MongoTCommunityFixture
+  instead of mongot-localdev.
+
+selector:
+  roots:
+    - jstests/with_mongot/e2e/**/*.js
+    - jstests/with_mongot/e2e_infrastructure_tests/*.js
+    - jstests/with_mongot/e2e_lib/*_test.js
+  exclude_files:
+    - jstests/with_mongot/e2e/sharding_no_passthrough/**/*.js
+    # TODO: investigate failures with mongot-community fixture.
+    - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_view.js
+    - jstests/with_mongot/e2e_infrastructure_tests/updateSearchIndex.js
+    - jstests/with_mongot/e2e/hybridSearch/ranked_fusion_on_view.js
+    - jstests/with_mongot/e2e/hybridSearch/hybrid_search_on_view_rejected.js
+    - jstests/with_mongot/e2e/hybridSearch/score_fusion_on_search_view.js
+  exclude_with_any_tags:
+    - requires_sharding
+
+executor:
+  config:
+    shell_options:
+      global_vars:
+        TestData:
+          auth: true
+          authMechanism: SCRAM-SHA-256
+          keyFile: *keyFile
+          keyFileData: *keyFileData
+          roleGraphInvalidationIsFatal: true
+      eval: jsTest.authenticate(db.getMongo())
+      <<: *authOptions
+  fixture:
+    class: ReplicaSetFixture
+    auth_options: *authOptions
+    launch_mongot_community: true
+    num_nodes: 1
+    mongod_options:
+      keyFile: *keyFile
+      set_parameters:
+        enableTestCommands: 1
+        featureFlagEgressGrpcForSearch: true
+        useGrpcForSearch: 1
+        skipAuthenticationToMongot: true

--- a/buildscripts/resmokelib/config.py
+++ b/buildscripts/resmokelib/config.py
@@ -42,6 +42,7 @@ DEFAULT_MONGO_EXECUTABLE = "mongo"
 DEFAULT_MONGOD_EXECUTABLE = "mongod"
 DEFAULT_MONGOS_EXECUTABLE = "mongos"
 DEFAULT_MONGOT_EXECUTABLE = "mongot-localdev/mongot"
+DEFAULT_MONGOT_COMMUNITY_EXECUTABLE = "mongot-community/mongot"
 DEFAULT_MONGOTEST_EXECUTABLE = "mongotest"
 
 DEFAULT_BENCHMARK_REPETITIONS = 3
@@ -103,6 +104,7 @@ DEFAULTS = {
     "mongos_executable": None,
     "mongos_set_parameters": [],
     "mongot-localdev/mongot_executable": None,
+    "mongot-community/mongot_executable": None,
     "mongot_set_parameters": [],
     "mongocryptd_set_parameters": [],
     "mongo_set_parameters": [],
@@ -602,6 +604,9 @@ MONGOS_SET_PARAMETERS = []
 
 # The path to the mongot executable used by resmoke.py.
 MONGOT_EXECUTABLE = None
+
+# The path to the mongot-community executable used by resmoke.py.
+MONGOT_COMMUNITY_EXECUTABLE = None
 
 # The --setParameter options passed to mongot.
 MONGOT_SET_PARAMETERS = []

--- a/buildscripts/resmokelib/configure_resmoke.py
+++ b/buildscripts/resmokelib/configure_resmoke.py
@@ -751,7 +751,14 @@ flags in common: {common_set}
         # Windows PATH variable requires absolute paths.
         _config.INSTALL_DIR = os.path.abspath(_expand_user(os.path.normpath(_config.INSTALL_DIR)))
 
-        for binary in ["mongo", "mongod", "mongos", "mongot-localdev/mongot", "dbtest"]:
+        for binary in [
+            "mongo",
+            "mongod",
+            "mongos",
+            "mongot-localdev/mongot",
+            "mongot-community/mongot",
+            "dbtest",
+        ]:
             keyname = binary + "_executable"
             if config.get(keyname, None) is None:
                 config[keyname] = os.path.join(_config.INSTALL_DIR, binary)
@@ -813,6 +820,9 @@ flags in common: {common_set}
     _config.MONGO_SET_PARAMETERS = _merge_set_params(config.pop("mongo_set_parameters"))
 
     _config.MONGOT_EXECUTABLE = _expand_user(config.pop("mongot-localdev/mongot_executable"))
+    _config.MONGOT_COMMUNITY_EXECUTABLE = _expand_user(
+        config.pop("mongot-community/mongot_executable")
+    )
     mongot_set_parameters = config.pop("mongot_set_parameters")
     _config.MONGOT_SET_PARAMETERS = _merge_set_params(mongot_set_parameters)
 

--- a/buildscripts/resmokelib/core/programs.py
+++ b/buildscripts/resmokelib/core/programs.py
@@ -274,6 +274,19 @@ def mongot_program(
     return make_process(logger, args, **process_kwargs), final_mongot_options
 
 
+def mongot_community_program(
+    logger, job_num, executable=None, config_path=None, process_kwargs=None
+) -> tuple[process.Process, Any]:
+    """Return a Process instance that starts mongot-community with a config file."""
+    executable = utils.default_if_none(
+        utils.default_if_none(executable, config.MONGOT_COMMUNITY_EXECUTABLE),
+        config.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE,
+    )
+    args = [executable, "--config", config_path]
+    process_kwargs = make_historic(utils.default_if_none(process_kwargs, {}))
+    return make_process(logger, args, **process_kwargs), {}
+
+
 def mongo_shell_program(
     logger: logging.Logger,
     test_name: str,

--- a/buildscripts/resmokelib/core/programs.py
+++ b/buildscripts/resmokelib/core/programs.py
@@ -282,7 +282,12 @@ def mongot_community_program(
         utils.default_if_none(executable, config.MONGOT_COMMUNITY_EXECUTABLE),
         config.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE,
     )
-    args = [executable, "--config", config_path]
+    # --internalListAllIndexesForTesting puts mongot-community in e2e test mode: it includes numDocs
+    # in $listSearchIndexes responses, returns all indexes, and (critically for suite runtime) runs
+    # the CommunityMetadataUpdater every 2s instead of every 30s so newly created search indexes
+    # become queryable promptly. Without it, every createSearchIndex/dropSearchIndex waits on the
+    # 30s metadata refresh cadence, making the suite dramatically slower.
+    args = [executable, "--config", config_path, "--internalListAllIndexesForTesting"]
     process_kwargs = make_historic(utils.default_if_none(process_kwargs, {}))
     return make_process(logger, args, **process_kwargs), {}
 

--- a/buildscripts/resmokelib/testing/fixtures/README.md
+++ b/buildscripts/resmokelib/testing/fixtures/README.md
@@ -11,6 +11,7 @@ Specify any of the following as the `fixture` in your [Suite](../../../../builds
 - [`ExternalShardedClusterFixture`](./shardedcluster.py) - Fixture to interact with external sharded cluster fixture.
 - [`MongoDFixture`](./standalone.py) - Fixture which provides JSTests with a standalone mongod to run against.
 - [`MongoTFixture`](./mongot.py) - Fixture which provides JSTests with a mongot to run alongside a mongod.
+- [`MongoTCommunityFixture`](./mongot_community.py) - Fixture which provides JSTests with a mongot-community process configured via YAML and exposing only gRPC.
 - [`MultiReplicaSetFixture`](./multi_replica_set.py) - Fixture which provides JSTests with a set of replica sets to run against.
 - [`MultiShardedClusterFixture`](./multi_sharded_cluster.py) - Fixture which provides JSTests with a set of sharded clusters to run against.
 - [`ReplicaSetFixture`](./replicaset.py) - Fixture which provides JSTests with a replica set to run against.

--- a/buildscripts/resmokelib/testing/fixtures/_builder.py
+++ b/buildscripts/resmokelib/testing/fixtures/_builder.py
@@ -190,6 +190,7 @@ class ReplSetBuilder(FixtureBuilder):
         """
 
         launch_mongot = kwargs.get("launch_mongot")
+        launch_mongot_community = kwargs.get("launch_mongot_community")
         use_priority_ports = kwargs.get("use_priority_ports")
         self._mutate_kwargs(kwargs)
         mixed_bin_versions, old_bin_version = _extract_multiversion_options(kwargs)
@@ -221,6 +222,7 @@ class ReplSetBuilder(FixtureBuilder):
                 mongod_binary_versions[node_index],
                 is_multiversion,
                 launch_mongot,
+                launch_mongot_community,
                 use_priority_ports,
             )
             replset.install_mongod(node)
@@ -236,10 +238,14 @@ class ReplSetBuilder(FixtureBuilder):
                     BinVersionEnum.NEW,
                     is_multiversion,
                     launch_mongot,
+                    launch_mongot_community,
                     use_priority_ports,
                 )
 
-        if launch_mongot:
+        if launch_mongot_community:
+            for mongod in replset.nodes:
+                mongod.setup_mongot_community_params()
+        elif launch_mongot:
             for mongod in replset.nodes:
                 mongod.setup_mongot_params()
 
@@ -347,6 +353,7 @@ class ReplSetBuilder(FixtureBuilder):
         cur_version: str,
         is_multiversion: bool,
         launch_mongot: bool,
+        launch_mongot_community: bool,
         use_priority_port: bool,
     ) -> FixtureContainer:
         """Make a fixture container with configured mongod fixture(s) in it.
@@ -404,6 +411,7 @@ class ReplSetBuilder(FixtureBuilder):
             preserve_dbpath=replset.preserve_dbpath,
             port=new_fixture_port,
             launch_mongot=launch_mongot,
+            launch_mongot_community=launch_mongot_community,
             load_extensions=[],
             use_priority_port=use_priority_port,
             uds_path_prefix=replset.uds_path_prefix,
@@ -467,6 +475,7 @@ class ShardedClusterBuilder(FixtureBuilder):
                 config_shard,
                 kwargs["num_rs_nodes_per_shard"],
                 launch_mongot=False,
+                launch_mongot_community=False,
                 use_priority_ports=use_priority_ports,
             )
         sharded_cluster.install_configsvr(config_svr)
@@ -476,6 +485,7 @@ class ShardedClusterBuilder(FixtureBuilder):
         nodes = [(node, True) for node in config_svr._all_mongo_d_s_t()]
 
         launch_mongot = kwargs.get("launch_mongot")
+        launch_mongot_community = kwargs.get("launch_mongot_community")
         for rs_shard_index in range(kwargs["num_shards"]):
             if rs_shard_index != config_shard:
                 rs_shard = self._new_rs_shard(
@@ -485,6 +495,7 @@ class ShardedClusterBuilder(FixtureBuilder):
                     rs_shard_index,
                     kwargs["num_rs_nodes_per_shard"],
                     launch_mongot,
+                    launch_mongot_community,
                     use_priority_ports=use_priority_ports,
                 )
                 sharded_cluster.install_rs_shard(rs_shard)
@@ -518,7 +529,12 @@ class ShardedClusterBuilder(FixtureBuilder):
         # each MongoTFixture needs to know the port of the MongoSFixture.
         router_endpoint_for_mongot = sharded_cluster.mongos[-1].port
 
-        if launch_mongot:
+        if launch_mongot_community:
+            for shard in sharded_cluster.shards:
+                for node in shard.nodes:
+                    node.setup_mongot_community_params(router_endpoint_for_mongot)
+                shard.mongot_grpc_port = shard.nodes[-1].mongot_grpc_port
+        elif launch_mongot:
             for shard in sharded_cluster.shards:
                 for node in shard.nodes:
                     node.setup_mongot_params(router_endpoint_for_mongot)
@@ -663,6 +679,7 @@ class ShardedClusterBuilder(FixtureBuilder):
         rs_shard_index: int,
         num_rs_nodes_per_shard: int,
         launch_mongot: bool,
+        launch_mongot_community: bool,
         use_priority_ports: bool = False,
     ) -> ReplicaSetFixture:
         """Return a replica set fixture configured as a shard in a sharded cluster.
@@ -673,6 +690,7 @@ class ShardedClusterBuilder(FixtureBuilder):
         :param rs_shard_index: replica set shard index
         :param num_rs_nodes_per_shard: the number of nodes in a replica set per shard
         :param launch_mongot: bool indicating if each shard needs to startup a mongot
+        :param launch_mongot_community: bool indicating if each shard needs mongot-community
         :param use_priority_ports: whether to use priority ports for replica set nodes
         :return: replica set fixture configured as a shard in a sharded cluster
         """
@@ -680,6 +698,7 @@ class ShardedClusterBuilder(FixtureBuilder):
         rs_shard_logger = sharded_cluster.get_rs_shard_logger(rs_shard_index)
         rs_shard_kwargs = sharded_cluster.get_rs_shard_kwargs(rs_shard_index)
         rs_shard_kwargs["launch_mongot"] = launch_mongot
+        rs_shard_kwargs["launch_mongot_community"] = launch_mongot_community
         rs_shard_kwargs["use_priority_ports"] = use_priority_ports
         # Parent ShardedClusterFixture already loaded extensions; see comment above in _new_mongod().
         rs_shard_kwargs["load_extensions"] = []

--- a/buildscripts/resmokelib/testing/fixtures/fixturelib.py
+++ b/buildscripts/resmokelib/testing/fixtures/fixturelib.py
@@ -87,6 +87,19 @@ class FixtureLib:
             logger, job_num, executable, process_kwargs, mongot_options
         )
 
+    def mongot_community_program(
+        self,
+        logger: logging.Logger,
+        job_num: int,
+        executable=None,
+        config_path=None,
+        process_kwargs=None,
+    ):
+        """Return a Process instance that starts mongot-community with a config file."""
+        return core.programs.mongot_community_program(
+            logger, job_num, executable, config_path, process_kwargs
+        )
+
     def generic_program(self, logger: logging.Logger, args, process_kwargs=None, **kwargs):
         """Return a Process instance that starts an arbitrary executable.
 
@@ -184,6 +197,8 @@ class _FixtureConfig(object):
         self.MONGOS_SET_PARAMETERS = config.MONGOS_SET_PARAMETERS
         self.DEFAULT_MONGOT_EXECUTABLE = config.DEFAULT_MONGOT_EXECUTABLE
         self.MONGOT_EXECUTABLE = config.MONGOT_EXECUTABLE
+        self.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE = config.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE
+        self.MONGOT_COMMUNITY_EXECUTABLE = config.MONGOT_COMMUNITY_EXECUTABLE
         self.DBPATH_PREFIX = config.DBPATH_PREFIX
         self.DEFAULT_DBPATH_PREFIX = config.DEFAULT_DBPATH_PREFIX
         self.DOCKER_COMPOSE_BUILD_IMAGES = config.DOCKER_COMPOSE_BUILD_IMAGES

--- a/buildscripts/resmokelib/testing/fixtures/mongot_community.py
+++ b/buildscripts/resmokelib/testing/fixtures/mongot_community.py
@@ -210,6 +210,7 @@ class MongoTCommunityFixture(interface.Fixture, interface._DockerComposeInterfac
     def get_dbpath_prefix(self):
         """Return the data directory used by mongot-community."""
         return self.data_dir
+
     def get_node_info(self):
         """Return a list of NodeInfo objects."""
         if self.mongot is None:

--- a/buildscripts/resmokelib/testing/fixtures/mongot_community.py
+++ b/buildscripts/resmokelib/testing/fixtures/mongot_community.py
@@ -208,9 +208,8 @@ class MongoTCommunityFixture(interface.Fixture, interface._DockerComposeInterfac
         return self.mongot is not None and self.mongot.poll() is None
 
     def get_dbpath_prefix(self):
-        """Return the _dbpath, as this is the root of the data directory."""
-        return self._dbpath
-
+        """Return the data directory used by mongot-community."""
+        return self.data_dir
     def get_node_info(self):
         """Return a list of NodeInfo objects."""
         if self.mongot is None:

--- a/buildscripts/resmokelib/testing/fixtures/mongot_community.py
+++ b/buildscripts/resmokelib/testing/fixtures/mongot_community.py
@@ -1,0 +1,298 @@
+"""Mongot community fixture for executing JSTests against.
+
+The mongot-community binary is configured exclusively via a YAML config file and
+exposes only a gRPC ingress interface (no MongoRPC). This fixture generates that
+config file and launches mongot-community with ``--config``.
+"""
+
+import os
+import shutil
+import time
+import urllib.error
+import urllib.request
+
+import yaml
+
+from buildscripts.resmokelib.testing.fixtures import interface
+
+
+def _scram_auth_block(mongot_community_options, auth_source):
+    """Build a scramAuth block for a MongoConnectionConfig (replicaSet or router)."""
+    return {
+        "username": mongot_community_options.get("syncUsername", "__system"),
+        "passwordFile": mongot_community_options["passwordFile"],
+        "authSource": auth_source,
+    }
+
+
+def _generate_mongot_community_config(mongot_community_options):
+    """Build the mongot-community YAML config from fixture options."""
+    replica_auth_source = mongot_community_options.get("replicaAuthSource", "local")
+    sync_source = {
+        "replicaSet": {
+            "hostAndPort": mongot_community_options["mongodHostAndPort"],
+            "scramAuth": _scram_auth_block(mongot_community_options, replica_auth_source),
+        },
+    }
+
+    if "routerHostAndPort" in mongot_community_options:
+        router_auth_source = mongot_community_options.get("routerAuthSource", "admin")
+        sync_source["router"] = {
+            "hostAndPort": mongot_community_options["routerHostAndPort"],
+            "scramAuth": _scram_auth_block(mongot_community_options, router_auth_source),
+        }
+
+    return {
+        "syncSource": sync_source,
+        "storage": {"dataPath": mongot_community_options["dataPath"]},
+        "server": {
+            "grpc": {
+                "address": "127.0.0.1:{}".format(mongot_community_options["grpcPort"]),
+                "tls": {"mode": "disabled"},
+            }
+        },
+        "metrics": {"enabled": False},
+        "healthCheck": {
+            "address": "127.0.0.1:{}".format(mongot_community_options["healthCheckPort"])
+        },
+        "logging": {"verbosity": "INFO"},
+    }
+
+
+class MongoTCommunityFixture(interface.Fixture, interface._DockerComposeInterface):
+    """Fixture which provides JSTests with a mongot-community process."""
+
+    def __init__(self, logger, job_num, fixturelib, dbpath_prefix=None, mongot_community_options=None):
+        interface.Fixture.__init__(self, logger, job_num, fixturelib, dbpath_prefix=dbpath_prefix)
+        self.mongot_community_options = self.fixturelib.default_if_none(mongot_community_options, {})
+        self.mongot_executable = self.fixturelib.default_if_none(
+            self.config.MONGOT_COMMUNITY_EXECUTABLE, self.config.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE
+        )
+        self.grpc_port = self.mongot_community_options["grpcPort"]
+        self.health_check_port = self.mongot_community_options["healthCheckPort"]
+        self.data_dir = self.mongot_community_options["dataPath"]
+        self.config_path = self.mongot_community_options["configPath"]
+        self.password_file = self.mongot_community_options["passwordFile"]
+        self.mongot = None
+
+    def _write_config_files(self):
+        os.makedirs(self.data_dir, exist_ok=True)
+        os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
+
+        with open(self.mongot_community_options["keyFile"], "r", encoding="utf-8") as key_file:
+            key_file_contents = key_file.read()
+
+        with open(self.password_file, "w", encoding="utf-8") as password_file:
+            password_file.write(key_file_contents)
+        os.chmod(self.password_file, 0o400)
+
+        config_contents = _generate_mongot_community_config(self.mongot_community_options)
+        with open(self.config_path, "w", encoding="utf-8") as config_file:
+            yaml.safe_dump(config_contents, config_file, default_flow_style=False)
+
+    def setup(self):
+        """Set up and launch mongot-community."""
+        self._write_config_files()
+
+        launcher = MongotCommunityLauncher(self.fixturelib)
+        mongot, _ = launcher.launch_mongot_community_program(
+            self.logger,
+            self.job_num,
+            executable=self.mongot_executable,
+            config_path=self.config_path,
+        )
+
+        try:
+            msg = (
+                "Starting mongot-community on grpc port {} ...\n{}".format(
+                    self.grpc_port, mongot.as_command()
+                )
+            )
+            self.logger.info(msg)
+            mongot.start()
+            msg = "mongot-community started on grpc port {} with pid {}".format(
+                self.grpc_port, mongot.pid
+            )
+            self.logger.info(msg)
+        except Exception as err:
+            msg = "Failed to start mongot-community on grpc port {:d}: {}".format(
+                self.grpc_port, err
+            )
+            self.logger.exception(msg)
+            raise self.fixturelib.ServerFailure(msg)
+
+        self.mongot = mongot
+
+    def _all_mongo_d_s_t(self):
+        """Return the `mongot-community` `Process` instance."""
+        return [self]
+
+    def pids(self):
+        """:return: pids owned by this fixture if any."""
+        out = [self.mongot.pid] if self.mongot is not None else []
+        if not out:
+            self.logger.debug(
+                "Mongot-community not running when gathering mongot community fixture pid."
+            )
+        return out
+
+    def _do_teardown(self, finished=False, mode=None):
+        if self.config.NOOP_MONGO_D_S_PROCESSES:
+            self.logger.info(
+                "This is running against an External System Under Test setup with "
+                "`docker-compose.yml` -- skipping teardown."
+            )
+            return
+
+        if self.mongot is None:
+            self.logger.warning("The mongot-community fixture has not been set up yet.")
+            return
+
+        if mode == interface.TeardownMode.ABORT:
+            self.logger.info(
+                "Attempting to send SIGABRT from resmoke to mongot-community on grpc port "
+                "%d with pid %d...",
+                self.grpc_port,
+                self.mongot.pid,
+            )
+        else:
+            self.logger.info(
+                "Stopping mongot-community on grpc port %d with pid %d...",
+                self.grpc_port,
+                self.mongot.pid,
+            )
+
+        if not self.is_running():
+            exit_code = self.mongot.poll()
+            msg = (
+                "mongot-community on grpc port {:d} was expected to be running, but wasn't. "
+                "Process exited with code {:d}."
+            ).format(self.grpc_port, exit_code)
+            self.logger.warning(msg)
+            raise self.fixturelib.ServerFailure(msg)
+
+        self.mongot.stop(mode)
+        exit_code = self.mongot.wait()
+
+        if exit_code == 143 or (mode is not None and exit_code == -(mode.value)):
+            self.logger.info(
+                "Successfully stopped mongot-community on grpc port {:d}.".format(self.grpc_port)
+            )
+        else:
+            self.logger.warning(
+                "Stopped mongot-community on grpc port {:d}. Process exited with code {:d}.".format(
+                    self.grpc_port, exit_code
+                )
+            )
+            raise self.fixturelib.ServerFailure(
+                "mongot-community on grpc port {:d} with pid {:d} exited with code {:d}".format(
+                    self.grpc_port, self.mongot.pid, exit_code
+                )
+            )
+
+        self.logger.info("Begin deleting mongot-community data files in fixture teardown")
+        for path in (self.data_dir, self.config_path, self.password_file):
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                elif os.path.isfile(path):
+                    os.remove(path)
+            except OSError as error:
+                self.logger.error("Hit OS error trying to delete %s: %s", path, error)
+        self.logger.info("Finished deleting mongot-community data files in fixture teardown")
+
+    def is_running(self):
+        """Return true if mongot-community is still operating."""
+        return self.mongot is not None and self.mongot.poll() is None
+
+    def get_dbpath_prefix(self):
+        """Return the _dbpath, as this is the root of the data directory."""
+        return self._dbpath
+
+    def get_node_info(self):
+        """Return a list of NodeInfo objects."""
+        if self.mongot is None:
+            self.logger.warning("The mongot-community fixture has not been set up yet.")
+            return []
+
+        info = interface.NodeInfo(
+            full_name=self.logger.full_name,
+            name=self.logger.name,
+            port=self.grpc_port,
+            pid=self.mongot.pid,
+        )
+        return [info]
+
+    def get_internal_connection_string(self):
+        """Return the internal gRPC connection string."""
+        return "localhost:{}".format(self.grpc_port)
+
+    def await_ready(self):
+        """Block until mongot-community's health check endpoint reports SERVING."""
+        deadline = time.time() + MongoTCommunityFixture.AWAIT_READY_TIMEOUT_SECS
+        health_url = "http://127.0.0.1:{}/health".format(self.health_check_port)
+
+        while True:
+            exit_code = self.mongot.poll()
+            if exit_code is not None:
+                raise self.fixturelib.ServerFailure(
+                    "Could not connect to mongot-community health check on port {}, process "
+                    "ended unexpectedly with code {}.".format(self.health_check_port, exit_code)
+                )
+
+            try:
+                with urllib.request.urlopen(health_url, timeout=1) as response:
+                    if 200 <= response.status < 300:
+                        break
+            except urllib.error.HTTPError as err:
+                # Mongot returns 503 until replication is initialized.
+                if err.code == 503:
+                    pass
+                else:
+                    raise self.fixturelib.ServerFailure(
+                        "Unexpected HTTP status {} from mongot-community health check on port "
+                        "{}.".format(err.code, self.health_check_port)
+                    )
+            except (urllib.error.URLError, TimeoutError):
+                pass
+
+            remaining = deadline - time.time()
+            if remaining <= 0.0:
+                raise self.fixturelib.ServerFailure(
+                    "Failed to connect to mongot-community health check on port {} after "
+                    "{} seconds".format(
+                        self.health_check_port,
+                        MongoTCommunityFixture.AWAIT_READY_TIMEOUT_SECS,
+                    )
+                )
+
+            self.logger.info(
+                "Waiting for mongot-community health check on port %d to report SERVING.",
+                self.health_check_port,
+            )
+            time.sleep(0.1)
+
+        self.logger.info(
+            "Successfully contacted mongot-community health check on port %d.",
+            self.health_check_port,
+        )
+
+
+class MongotCommunityLauncher(object):
+    """Class with utilities for launching mongot-community."""
+
+    def __init__(self, fixturelib):
+        """Initialize MongotCommunityLauncher."""
+        self.fixturelib = fixturelib
+        self.config = fixturelib.get_config()
+
+    def launch_mongot_community_program(
+        self, logger, job_num, executable=None, config_path=None, process_kwargs=None
+    ):
+        """Return a Process instance that starts mongot-community with ``--config``."""
+        executable = self.fixturelib.default_if_none(
+            executable, self.config.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE
+        )
+        return self.fixturelib.mongot_community_program(
+            logger, job_num, executable, config_path, process_kwargs
+        )

--- a/buildscripts/resmokelib/testing/fixtures/mongot_community.py
+++ b/buildscripts/resmokelib/testing/fixtures/mongot_community.py
@@ -62,9 +62,13 @@ def _generate_mongot_community_config(mongot_community_options):
 class MongoTCommunityFixture(interface.Fixture, interface._DockerComposeInterface):
     """Fixture which provides JSTests with a mongot-community process."""
 
-    def __init__(self, logger, job_num, fixturelib, dbpath_prefix=None, mongot_community_options=None):
+    def __init__(
+        self, logger, job_num, fixturelib, dbpath_prefix=None, mongot_community_options=None
+    ):
         interface.Fixture.__init__(self, logger, job_num, fixturelib, dbpath_prefix=dbpath_prefix)
-        self.mongot_community_options = self.fixturelib.default_if_none(mongot_community_options, {})
+        self.mongot_community_options = self.fixturelib.default_if_none(
+            mongot_community_options, {}
+        )
         self.mongot_executable = self.fixturelib.default_if_none(
             self.config.MONGOT_COMMUNITY_EXECUTABLE, self.config.DEFAULT_MONGOT_COMMUNITY_EXECUTABLE
         )
@@ -103,10 +107,8 @@ class MongoTCommunityFixture(interface.Fixture, interface._DockerComposeInterfac
         )
 
         try:
-            msg = (
-                "Starting mongot-community on grpc port {} ...\n{}".format(
-                    self.grpc_port, mongot.as_command()
-                )
+            msg = "Starting mongot-community on grpc port {} ...\n{}".format(
+                self.grpc_port, mongot.as_command()
             )
             self.logger.info(msg)
             mongot.start()

--- a/buildscripts/resmokelib/testing/fixtures/mongot_community.py
+++ b/buildscripts/resmokelib/testing/fixtures/mongot_community.py
@@ -80,6 +80,14 @@ class MongoTCommunityFixture(interface.Fixture, interface._DockerComposeInterfac
         self.mongot = None
 
     def _write_config_files(self):
+        # Erase any leftover data dir from a previous run (e.g. one that exited abruptly) to avoid
+        # zombie index entries in the config journal being picked up on startup.
+        if os.path.isdir(self.data_dir):
+            self.logger.info(
+                "Removing pre-existing mongot-community data dir before startup: %s", self.data_dir
+            )
+            shutil.rmtree(self.data_dir, ignore_errors=True)
+
         os.makedirs(self.data_dir, exist_ok=True)
         os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
 

--- a/buildscripts/resmokelib/testing/fixtures/replicaset.py
+++ b/buildscripts/resmokelib/testing/fixtures/replicaset.py
@@ -82,6 +82,7 @@ class ReplicaSetFixture(interface.ReplFixture, interface._DockerComposeInterface
         initial_sync_uninitialized_fcv=False,
         hide_initial_sync_node_from_conn_string=False,
         launch_mongot=False,
+        launch_mongot_community=False,
         load_extensions=None,
         skip_extensions_signature_verification=False,
         router_endpoint_for_mongot: Optional[int] = None,
@@ -158,6 +159,7 @@ class ReplicaSetFixture(interface.ReplFixture, interface._DockerComposeInterface
         self.fcv = None
         # Used by suites that run search integration tests.
         self.launch_mongot = launch_mongot
+        self.launch_mongot_community = launch_mongot_community
         # Used to set --mongoHostAndPort startup option on mongot.
         self.router_endpoint_for_mongot = router_endpoint_for_mongot
         # Use the values given from the command line if they exist for linear_chain and num_nodes.
@@ -325,6 +327,8 @@ class ReplicaSetFixture(interface.ReplFixture, interface._DockerComposeInterface
             # want to skip reconfiguring the replset (which adds the other nodes
             # to the auto-bootstrapped replset).
             self.logger.info("Configuration exists. Skipping initializing the replset.")
+            self._await_mongot_community()
+            self.removeshard_teardown_marker = False
             return
 
         if self.write_concern_majority_journal_default is not None:
@@ -392,7 +396,15 @@ class ReplicaSetFixture(interface.ReplFixture, interface._DockerComposeInterface
             for ind in range(2, len(members) + 1):
                 self._add_node_to_repl_set(client, repl_config, ind, members)
 
+        self._await_mongot_community()
+
         self.removeshard_teardown_marker = False
+
+    def _await_mongot_community(self):
+        """Wait for mongot-community after the replica set is initialized."""
+        for node in self.nodes:
+            if node.launch_mongot_community_bool and node.mongot is not None:
+                node.await_mongot_community_ready()
 
     def _all_mongo_d_s_t(self):
         """Return a list of all `mongo{d,s,t}` `Process` instances in this fixture."""

--- a/buildscripts/resmokelib/testing/fixtures/shardedcluster.py
+++ b/buildscripts/resmokelib/testing/fixtures/shardedcluster.py
@@ -54,6 +54,7 @@ class ShardedClusterFixture(interface.Fixture, interface._DockerComposeInterface
         replica_set_endpoint=False,
         random_migrations=False,
         launch_mongot=False,
+        launch_mongot_community=False,
         load_extensions=None,
         skip_extensions_signature_verification=False,
         set_cluster_parameter=None,
@@ -77,6 +78,7 @@ class ShardedClusterFixture(interface.Fixture, interface._DockerComposeInterface
         # The mongotHost and searchIndexManagementHostAndPort options cannot be set on mongos_options yet because
         # the port value is only assigned in MongoDFixture initialization, which happens later.
         self.launch_mongot = launch_mongot
+        self.launch_mongot_community = launch_mongot_community
 
         # mongod options
         self.mongod_options = self.fixturelib.make_historic(
@@ -257,14 +259,13 @@ class ShardedClusterFixture(interface.Fixture, interface._DockerComposeInterface
         for mongos in self.mongos:
             mongos.mongos_options["configdb"] = self.configsvr.get_internal_connection_string()
 
-        if self.launch_mongot:
-            # These mongot parameters are popped from shard.mongod_options when mongod is launched in above
-            # setup() call. As such, the final values can't be cleanly copied over from mongod_options, but
-            # need to be recreated here.
-            if self.mongos[0].mongos_options["set_parameters"].get("useGrpcForSearch"):
+        if self.launch_mongot_community or self.launch_mongot:
+            if self.launch_mongot_community or self.mongos[0].mongos_options["set_parameters"].get(
+                "useGrpcForSearch"
+            ):
                 # If mongos & mongod are configured to use egress gRPC for search, then set the
                 # `mongotHost` parameter to the mongot listening address expecting communication via
-                # the MongoDB gRPC protocol (which we configured in setup_mongot_params).
+                # the MongoDB gRPC protocol.
                 self.mongotHost = "localhost:" + str(self.shards[-1].mongot_grpc_port)
             else:
                 self.mongotHost = "localhost:" + str(self.shards[-1].mongot_port)

--- a/buildscripts/resmokelib/testing/fixtures/standalone.py
+++ b/buildscripts/resmokelib/testing/fixtures/standalone.py
@@ -41,6 +41,7 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
         preserve_dbpath: bool = False,
         port: Optional[int] = None,
         launch_mongot: bool = False,
+        launch_mongot_community: bool = False,
         load_extensions=None,
         skip_extensions_signature_verification=False,
         use_priority_port: bool = False,
@@ -58,7 +59,9 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
             dbpath_prefix (Optional[str], optional): Sets the dbpath_prefix. Defaults to None.
             preserve_dbpath (bool, optional): preserve_dbpath. Defaults to False.
             port (Optional[int], optional): Port to use for mongod. Defaults to None.
-            launch_mongot (bool, optional): Should mongot be launched as well. Defaults to False.
+            launch_mongot (bool, optional): Should mongot-localdev be launched as well. Defaults to False.
+            launch_mongot_community (bool, optional): Should mongot-community be launched as well.
+                Defaults to False.
             load_extensions (list, optional): List of extension names to load at startup.
                 Use ["*"] to discover and load all *_mongo_extension.so files.
                 Use specific names (e.g. ["add_fields_match"]) to load individual extensions.
@@ -155,8 +158,21 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
             self.priority_port = fixturelib.get_next_port(job_num)
             self.mongod_options["priorityPort"] = self.priority_port
 
-        if launch_mongot:
+        if launch_mongot and launch_mongot_community:
+            raise ValueError("Cannot launch both mongot-localdev and mongot-community")
+
+        if launch_mongot_community:
+            self.launch_mongot_community_bool = True
+            self.launch_mongot_bool = False
+            self.mongot_grpc_port = fixturelib.get_next_port(job_num)
+            self.mongot_health_port = fixturelib.get_next_port(job_num)
+            self.mongod_options["mongotHost"] = "localhost:" + str(self.mongot_grpc_port)
+            self.mongod_options["searchIndexManagementHostAndPort"] = self.mongod_options[
+                "mongotHost"
+            ]
+        elif launch_mongot:
             self.launch_mongot_bool = True
+            self.launch_mongot_community_bool = False
 
             # mongot exposes two ports that it will listen for ingress communication on: "port",
             # which expects the MongoRPC protocol, and "grpcPort", which expects the MongoDB
@@ -179,10 +195,13 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
             ]
         else:
             self.launch_mongot_bool = False
-        # If a suite enables launching mongot, the necessary startup options for the MongoTFixture will be created in
-        # setup_mongot_params() which is called by the builders after all other fixture types have been setup (and
-        # therefore all other nodes have been assigned ports, which allows mongot to connect to a given mongod or
-        # mongos. The MongoTFixture is then launched by the MongoDFixture in setup().
+            self.launch_mongot_community_bool = False
+        # If a suite enables launching mongot, the necessary startup options for the MongoTFixture
+        # or MongoTCommunityFixture will be created in setup_mongot_params() or
+        # setup_mongot_community_params() which is called by the builders after all other fixture
+        # types have been setup (and therefore all other nodes have been assigned ports, which
+        # allows mongot to connect to a given mongod or mongos). The fixture is then launched by
+        # the MongoDFixture in setup().
         self.mongot = None
 
         if "featureFlagGRPC" in self.config.ENABLED_FEATURE_FLAGS or self.mongod_options[
@@ -204,6 +223,26 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
 
         mongot.setup()
         self.mongot = mongot
+        self.mongot.await_ready()
+
+    def launch_mongot_community(self):
+        mongot = self.fixturelib.make_fixture(
+            "MongoTCommunityFixture",
+            self.logger,
+            self.job_num,
+            dbpath_prefix=self.get_dbpath_prefix(),
+            mongot_community_options=self.mongot_community_options,
+        )
+
+        mongot.setup()
+        self.mongot = mongot
+
+    def await_mongot_community_ready(self):
+        """Block until mongot-community is ready to serve traffic."""
+        if self.mongot is None:
+            raise self.fixturelib.ServerFailure(
+                "Cannot await mongot-community readiness before it has been launched."
+            )
         self.mongot.await_ready()
 
     def setup(self, temporary_flags={}):
@@ -248,7 +287,9 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
             raise self.fixturelib.ServerFailure(msg)
 
         self.mongod = mongod
-        if self.launch_mongot_bool:
+        if self.launch_mongot_community_bool:
+            self.launch_mongot_community()
+        elif self.launch_mongot_bool:
             self.launch_mongot()
 
     def _all_mongo_d_s_t(self):
@@ -305,6 +346,39 @@ class MongoDFixture(interface.Fixture, interface._DockerComposeInterface):
 
         mongot_options["keyFile"] = self.mongod_options["keyFile"]
         self.mongot_options = mongot_options
+
+    def setup_mongot_community_params(self, router_endpoint_for_mongot: Optional[int] = None):
+        if "keyFile" not in self.mongod_options:
+            raise self.fixturelib.ServerFailure("Cannot launch mongot without providing a keyfile")
+
+        dbpath_prefix = self.get_dbpath_prefix()
+        # Each mongot requires its own unique config journal to persist index definitions,
+        # replication status, etc. to disk. Use the same cwd-relative path as MongoTFixture.
+        data_dir = "data/config_journal_" + str(self.mongot_grpc_port)
+        config_path = os.path.join(
+            dbpath_prefix, "mongot_community_config_{}.yml".format(self.mongot_grpc_port)
+        )
+        password_file = os.path.join(
+            dbpath_prefix, "mongot_community_password_{}".format(self.mongot_grpc_port)
+        )
+
+        mongot_community_options = {
+            "grpcPort": self.mongot_grpc_port,
+            "healthCheckPort": self.mongot_health_port,
+            "mongodHostAndPort": "localhost:" + str(self.port),
+            "keyFile": self.mongod_options["keyFile"],
+            "passwordFile": password_file,
+            "dataPath": data_dir,
+            "configPath": config_path,
+            "syncUsername": "__system",
+        }
+        if router_endpoint_for_mongot is not None:
+            mongot_community_options["routerHostAndPort"] = "localhost:" + str(
+                router_endpoint_for_mongot
+            )
+            mongot_community_options["routerAuthSource"] = "admin"
+
+        self.mongot_community_options = mongot_community_options
 
     def await_ready(self):
         """Block until the fixture can be used for testing."""


### PR DESCRIPTION
This pull request introduces support for running JSTests with the `mongot-community` process (configured via YAML and exposing only gRPC) through a new fixture, `MongoTCommunityFixture`. It also adds two new resmoke suite configurations for end-to-end testing with `mongot-community`, and updates the resmoke infrastructure to handle the new binary and fixture.