### PR TITLE
PSMDB-2142: re-check CI gate at ci-handle time

### DIFF
--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -445,6 +445,15 @@ jobs:
     # entirely: with it set, even a failure is a no-op and this privileged-ops
     # job never starts.
     if: needs.ci-gate.outputs.state == 'failure' && needs.ci-gate.outputs.skip_ci_fix != 'true'
+    # Serialize approved handle jobs for the same branch. Each watched-workflow
+    # completion enqueues its own ci-handle, and each waits on the privileged-ops
+    # approval independently, so two can be approved close together and race on
+    # `git push` / `mergai notes push`. `cancel-in-progress: false` queues the
+    # later one instead of cancelling a fix mid-push; its handle-time re-check
+    # then sees the first one's pushed result and no-ops.
+    concurrency:
+      group: ci-handle-exec-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
     environment: privileged-ops
     runs-on: ubuntu-latest
     env:
@@ -536,8 +545,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           STATE=$(mergai ci status --state)
+          # Honor a mergai-skip-ci-fix label the same way: ci-gate froze
+          # skip_ci_fix before the approval, but the label can be added during
+          # the approval wait. Re-read it live and, if present, override STATE to
+          # a non-failure sentinel so the fix/comment/push steps below no-op.
+          LABELS=$(gh pr list --head "$HEAD_BRANCH" --state open \
+            --json labels --jq '.[0].labels[].name' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -qx "mergai-skip-ci-fix"; then
+            echo "mergai-skip-ci-fix present at handle time; CI auto-fix suppressed"
+            STATE=skip
+          fi
           echo "Live gate state at handle time: $STATE"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -522,6 +522,25 @@ jobs:
           mergai notes update
           mergai context init
 
+      # Re-evaluate the gate at handle time. ci-gate froze its verdict into
+      # needs.ci-gate.outputs.state *before* the privileged-ops approval; the
+      # branch can recover in between (e.g. a cancelled watched run is re-run
+      # and passes), so that verdict may be stale by the time this job actually
+      # runs. Recompute the live state with the same check ci-gate uses and
+      # route the steps below off it, so an approval granted late (or a
+      # superseded failure) becomes a clean no-op instead of a fix against a
+      # now-green branch. The job-level `if:` still gates the privileged-ops
+      # request on the original failure; this only suppresses acting on it.
+      - name: Re-check gate
+        id: recheck
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          STATE=$(mergai ci status --state)
+          echo "Live gate state at handle time: $STATE"
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+
       # Any watched run for HEAD failed/cancelled. Run the fixer once here; the
       # steps below route the result based on whether a fix commit landed and
       # which branch CI ran on. `mergai ci fix all` resolves the failing runs
@@ -530,7 +549,7 @@ jobs:
       # outputs for the routing steps.
       - name: Apply CI fixes (state=failure)
         id: fix
-        if: needs.ci-gate.outputs.state == 'failure'
+        if: steps.recheck.outputs.state == 'failure'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -550,7 +569,7 @@ jobs:
       # No fix commit (e.g. an unfixable failure): `ci comment post` still
       # publishes the recorded explanation on the run's own PR.
       - name: Post explanation comment (no fix produced)
-        if: needs.ci-gate.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'false'
+        if: steps.recheck.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -562,7 +581,7 @@ jobs:
       # so the fix commit is relocated onto a dedicated `semantic` branch and
       # reviewed via a `semantic` PR (base = main). origin/main is never pushed here.
       - name: Relocate fix to semantic branch (semantic conflict on */main)
-        if: needs.ci-gate.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && endsWith(github.event.workflow_run.head_branch, '/main')
+        if: steps.recheck.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && endsWith(github.event.workflow_run.head_branch, '/main')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -593,7 +612,7 @@ jobs:
       # here -- folding into the merge commit happens only at finalize, after
       # the PR is merged, so the resolve commit survives.
       - name: Push inline fix (review branch)
-        if: needs.ci-gate.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && !endsWith(github.event.workflow_run.head_branch, '/main')
+        if: steps.recheck.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && !endsWith(github.event.workflow_run.head_branch, '/main')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -610,7 +629,7 @@ jobs:
       # Always push notes when a fix was attempted: ci_comments / posted markers
       # may have changed even when no commit was produced.
       - name: Push mergai notes
-        if: needs.ci-gate.outputs.state == 'failure'
+        if: steps.recheck.outputs.state == 'failure'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
ci-gate freezes its verdict into needs.ci-gate.outputs.state before the privileged-ops deployment approval. The branch can recover between the gate and the approval (e.g. a cancelled watched run is re-run and passes), leaving ci-handle to act on a stale failure verdict once approved.

Add a Re-check gate step in ci-handle that recomputes the live state with the same mergai ci status --state check, and route the fix/comment/ push steps off it instead of the frozen gate output. The job-level if: still gates the privileged-ops request on the original failure; this only suppresses acting on it, so a late approval (or a superseded failure) becomes a clean no-op instead of a fix against a now-green branch.
