### PR TITLE
PSMDB-2142: harden the mergai workflow so the AI agent can't write to the remote

### DIFF
--- a/.github/actions/setup-mergai-workflow/action.yml
+++ b/.github/actions/setup-mergai-workflow/action.yml
@@ -96,6 +96,17 @@ runs:
         git config user.email "${{ inputs.github-app-id }}+psmdb-bot[bot]@users.noreply.github.com"
         git config merge.conflictstyle diff3
         git config notes.displayRef refs/notes/mergai-marker
+        # Authenticate git pushes from the *process environment* (GH_TOKEN) via a
+        # no-fallback credential helper: a push succeeds only for a step whose
+        # environment carries the token. Combined with `persist-credentials:
+        # false` on the agent checkouts (no token on disk) and mergai stripping
+        # the token from the agent subprocess, the AI agent can never push -- its
+        # empty GH_TOKEN yields an empty password. Only steps that explicitly set
+        # GH_TOKEN/GITHUB_TOKEN (the deterministic push/PR steps) authenticate.
+        # The empty first helper resets any inherited helper (no stored-login
+        # fallback).
+        git config --global credential.https://github.com.helper ""
+        git config --global --add credential.https://github.com.helper '!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n" "${GH_TOKEN:-$GITHUB_TOKEN}"; }; f'
 
     # Install the mergai CLI tool using the dedicated setup action.
     # Supports checking out a specific ref (branch/tag/commit) for testing.

--- a/.github/actions/setup-mergai-workflow/action.yml
+++ b/.github/actions/setup-mergai-workflow/action.yml
@@ -34,6 +34,14 @@ inputs:
   github-app-id:
     description: "GitHub App ID for constructing bot email"
     required: true
+  export-github-token:
+    description: >-
+      Export GH_TOKEN/GITHUB_TOKEN to the job environment (GITHUB_ENV). Set to
+      "false" for jobs that run the AI agent so no write token is reachable (via
+      the environment) during agent execution; those jobs scope the token to
+      their push steps instead.
+    required: false
+    default: "true"
   mergai-ref:
     description: "MergAI git ref to checkout"
     required: false
@@ -83,15 +91,21 @@ runs:
         echo "ANTHROPIC_API_KEY=${{ inputs.claude-api-key }}" >> $GITHUB_ENV
 
     # Configure git for automated commits by the psmdb-bot.
-    # - Sets both GITHUB_TOKEN and GH_TOKEN for compatibility with different tools
+    # - Exports GITHUB_TOKEN/GH_TOKEN job-wide only when export-github-token is
+    #   true (agent jobs disable it and scope the token to their push steps)
     # - Uses GitHub App identity format for the bot email
     # - Enables diff3 conflict style for better merge conflict resolution
     # - Configures git notes display for mergai markers (used for tracking)
     - name: Setup git credentials
       shell: bash
       run: |
-        echo "GITHUB_TOKEN=${{ inputs.github-app-token }}" >> $GITHUB_ENV
-        echo "GH_TOKEN=${{ inputs.github-app-token }}" >> $GITHUB_ENV
+        # Export the token job-wide unless the caller opts out (agent jobs do,
+        # so the write token is not reachable while the agent runs; they scope
+        # it to their push steps instead).
+        if [ "${{ inputs.export-github-token }}" = "true" ]; then
+          echo "GITHUB_TOKEN=${{ inputs.github-app-token }}" >> $GITHUB_ENV
+          echo "GH_TOKEN=${{ inputs.github-app-token }}" >> $GITHUB_ENV
+        fi
         git config user.name "psmdb-bot[bot]"
         git config user.email "${{ inputs.github-app-id }}+psmdb-bot[bot]@users.noreply.github.com"
         git config merge.conflictstyle diff3

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -55,6 +55,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # The AI agent runs in this checkout. Do NOT persist the checkout
+          # credential into .git/config, so a misbehaving or prompt-injected
+          # agent cannot read or reuse it to push. Deterministic pushes
+          # authenticate via the credential helper configured in setup
+          # (GH_TOKEN in the parent process environment).
+          persist-credentials: false
 
       - name: Create GitHub App token
         id: app-token
@@ -513,6 +519,10 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          # The AI agent runs in this checkout; do not leave the write token in
+          # .git/config for it to reuse. Deterministic pushes authenticate via
+          # the setup credential helper (GH_TOKEN in the parent process env).
+          persist-credentials: false
 
       - name: Setup workflow environment
         uses: ./.github/actions/setup-mergai-workflow
@@ -741,6 +751,10 @@ jobs:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          # The AI agent runs in this checkout; do not leave the write token in
+          # .git/config for it to reuse. Deterministic pushes authenticate via
+          # the setup credential helper (GH_TOKEN in the parent process env).
+          persist-credentials: false
 
       - name: Setup workflow environment
         if: steps.pr.outputs.is_mergai == 'true'

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -523,6 +523,25 @@ jobs:
           mergai notes update
           mergai context init
 
+      # Re-evaluate the gate at handle time. ci-gate froze its verdict into
+      # needs.ci-gate.outputs.state *before* the privileged-ops approval; the
+      # branch can recover in between (e.g. a cancelled watched run is re-run
+      # and passes), so that verdict may be stale by the time this job actually
+      # runs. Recompute the live state with the same check ci-gate uses and
+      # route the steps below off it, so an approval granted late (or a
+      # superseded failure) becomes a clean no-op instead of a fix against a
+      # now-green branch. The job-level `if:` still gates the privileged-ops
+      # request on the original failure; this only suppresses acting on it.
+      - name: Re-check gate
+        id: recheck
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          STATE=$(mergai ci status --state)
+          echo "Live gate state at handle time: $STATE"
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+
       # Any watched run for HEAD failed/cancelled. Run the fixer once here; the
       # steps below route the result based on whether a fix commit landed and
       # which branch CI ran on. `mergai ci fix all` resolves the failing runs
@@ -531,7 +550,7 @@ jobs:
       # outputs for the routing steps.
       - name: Apply CI fixes (state=failure)
         id: fix
-        if: needs.ci-gate.outputs.state == 'failure'
+        if: steps.recheck.outputs.state == 'failure'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -551,7 +570,7 @@ jobs:
       # No fix commit (e.g. an unfixable failure): `ci comment post` still
       # publishes the recorded explanation on the run's own PR.
       - name: Post explanation comment (no fix produced)
-        if: needs.ci-gate.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'false'
+        if: steps.recheck.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -563,7 +582,7 @@ jobs:
       # so the fix commit is relocated onto a dedicated `semantic` branch and
       # reviewed via a `semantic` PR (base = main). origin/main is never pushed here.
       - name: Relocate fix to semantic branch (semantic conflict on */main)
-        if: needs.ci-gate.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && endsWith(github.event.workflow_run.head_branch, '/main')
+        if: steps.recheck.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && endsWith(github.event.workflow_run.head_branch, '/main')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -594,7 +613,7 @@ jobs:
       # here -- folding into the merge commit happens only at finalize, after
       # the PR is merged, so the resolve commit survives.
       - name: Push inline fix (review branch)
-        if: needs.ci-gate.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && !endsWith(github.event.workflow_run.head_branch, '/main')
+        if: steps.recheck.outputs.state == 'failure' && steps.fix.outputs.fix_produced == 'true' && !endsWith(github.event.workflow_run.head_branch, '/main')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -611,7 +630,7 @@ jobs:
       # Always push notes when a fix was attempted: ci_comments / posted markers
       # may have changed even when no commit was produced.
       - name: Push mergai notes
-        if: needs.ci-gate.outputs.state == 'failure'
+        if: steps.recheck.outputs.state == 'failure'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -93,6 +93,10 @@ jobs:
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           mergai-ref: ${{ inputs['mergai-ref'] || vars.MERGAI_REF || 'master' }}
+          # Do not put the write token in the job environment: this job runs the
+          # AI agent (describe/resolve). The token is scoped to the "publish"
+          # step instead, so it is never reachable while the agent runs.
+          export-github-token: "false"
 
       # Determine the commit to merge to. Precedence:
       #   1. an explicit merge-pick input -> use it, bypassing the gate (the
@@ -183,12 +187,20 @@ jobs:
             exit 1
           fi
 
+      # Agent phase: runs the AI agent (describe via `mergai merge`, and
+      # `mergai resolve` on conflicts) and prepares branches locally. This step
+      # has NO GitHub write token in its environment (setup was called with
+      # export-github-token: false), so a misbehaving or prompt-injected agent
+      # has no reachable credential to push with. All remote writes happen in
+      # the separate "publish" step below. The merge outcome is recorded as an
+      # output so publish knows which branches to push.
       - name: merge
+        id: merge
         if: steps.pick.outputs.pick != ''
         env:
           MERGAI_AGENT: ${{ inputs['mergai-agent'] }}
         run: |
-          # Fetch and merge notes from remote
+          # Fetch and merge notes from remote (read-only; public repo)
           mergai notes update
 
           # Build merge command with optional agent
@@ -199,21 +211,37 @@ jobs:
             RESOLVE_CMD="$RESOLVE_CMD --agent \"$MERGAI_AGENT\""
           fi
 
-          # Attempt merge; exit code 0 = success, 1 = conflicts
+          # Attempt merge; exit code 0 = success, 1 = conflicts. Only local
+          # commits/branch-creates happen here -- pushing is deferred to publish.
           if eval $MERGE_CMD; then
             echo "Merge successful. Committing merge."
             mergai commit merge              # Create merge commit with note attached
             mergai branch create main        # Create and checkout main working branch
-            mergai branch push main          # Push main branch to origin
-            mergai notes push                # Push mergai notes to remote
-            mergai pr --repo "$GITHUB_REPOSITORY" create main --skip-commit-list-on-failure
+            echo "result=success" >> "$GITHUB_OUTPUT"
           else
             echo "Merge conflict detected. Processing with resolution."
             mergai commit conflict           # Commit conflict state with markers
             mergai branch create conflict    # Create branch with conflict markers
             mergai branch create solution    # Create branch for AI solution
-            eval $RESOLVE_CMD                # Run AI conflict resolution (yolo mode)
+            eval $RESOLVE_CMD                # Run AI conflict resolution
             mergai commit solution           # Commit resolved files with note
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Publish phase: the ONLY step given the write token. The agent has run
+      # and exited in the previous step, so the token is never reachable by it.
+      # Pushes authenticate via the setup credential helper (GH_TOKEN in this
+      # step's environment); PR creation uses gh (also GH_TOKEN).
+      - name: publish
+        if: steps.merge.outputs.result != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ "${{ steps.merge.outputs.result }}" = "success" ]; then
+            mergai branch push main          # Push main branch to origin
+            mergai notes push                # Push mergai notes to remote
+            mergai pr --repo "$GITHUB_REPOSITORY" create main --skip-commit-list-on-failure
+          else
             mergai branch push solution      # Push solution branch
             mergai branch push conflict      # Push conflict branch
             mergai notes push                # Push mergai notes to remote
@@ -475,6 +503,24 @@ jobs:
           app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
 
+      # Read-only token for the steps that run the AI agent (`mergai ci fix`
+      # reads CI logs/artifacts). Even if the agent recovers this token from the
+      # environment, it cannot write. The write token (app-token) is scoped to
+      # the push/comment steps only.
+      - name: Create read-only GitHub App token
+        id: app-token-ro
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: read
+          permission-issues: read
+          permission-actions: read
+          # `mergai ci fix` reads clang-tidy SARIF via the code-scanning API,
+          # which requires security_events read.
+          permission-security-events: read
+
       # -----------------------------------------------------------------------
       # Why we trust github.event.workflow_run.head_branch / head_sha here
       # -----------------------------------------------------------------------
@@ -536,8 +582,14 @@ jobs:
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           mergai-ref: master
+          # This job runs the AI agent (`mergai ci fix`). Keep the write token
+          # out of the job environment; the agent/read steps use the read-only
+          # token and the write token is scoped to the push/comment steps.
+          export-github-token: "false"
 
       - name: Fetch and load mergai notes
+        env:
+          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
         run: |
           mergai notes update
           mergai context init
@@ -554,7 +606,7 @@ jobs:
       - name: Re-check gate
         id: recheck
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
           GH_REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
@@ -582,7 +634,9 @@ jobs:
         id: fix
         if: steps.recheck.outputs.state == 'failure'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Read-only: the agent runs here. `mergai ci fix all` only downloads
+          # CI artifacts/logs and commits locally; the write steps below push.
+          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           before=$(git rev-parse HEAD)
@@ -709,6 +763,20 @@ jobs:
           app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
 
+      # Read-only token for the read/agent steps (`mergai review fix` reads the
+      # PR's review threads and, after deferring --ack, no longer writes). Even
+      # if the agent recovers this token, it cannot write. The write token
+      # (app-token) is scoped to the push / review-post steps only.
+      - name: Create read-only GitHub App token
+        id: app-token-ro
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: read
+          permission-issues: read
+
       # Resolve the PR number and head branch from whichever event fired, and
       # confirm it is a mergai PR (head branch under mergai/). The issue_comment
       # payload has no head ref, so we look it up; a non-mergai PR sets
@@ -716,7 +784,7 @@ jobs:
       - name: Resolve PR
         id: pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           # CUTOFF pins the run to the comment set as it stood when it was
@@ -769,9 +837,16 @@ jobs:
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           mergai-ref: master
+          # This job runs the AI agent (`mergai review fix`). Keep the write
+          # token out of the job environment; the agent/read steps use the
+          # read-only token and the write token is scoped to the push /
+          # review-post steps.
+          export-github-token: "false"
 
       - name: Fetch and load mergai notes
         if: steps.pr.outputs.is_mergai == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
         run: |
           mergai notes update
           mergai context init
@@ -784,15 +859,18 @@ jobs:
         id: review
         if: steps.pr.outputs.is_mergai == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Read-only: the agent runs here. `mergai review fix` reads the PR's
+          # review threads and commits the fix locally; --ack only *records* the
+          # acknowledgement on the note (posted later by `mergai review post`).
+          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           CUTOFF: ${{ steps.pr.outputs.cutoff }}
         run: |
           before=$(git rev-parse HEAD)
-          # --ack posts a short acknowledgement comment on the PR (how many
-          # comments were found / addressed / ignored, even if none) for quick
-          # feedback. --since pins the comment set to the trigger time (CUTOFF).
+          # --ack records a short acknowledgement (how many comments were found /
+          # addressed / ignored, even if none) on the note; `mergai review post`
+          # publishes it. --since pins the comment set to the trigger time (CUTOFF).
           mergai review fix --pr-number "$PR_NUMBER" --since "$CUTOFF" --ack
           after=$(git rev-parse HEAD)
           if [ "$before" != "$after" ]; then
@@ -808,6 +886,9 @@ jobs:
       - name: Push review-fix commit
         if: steps.pr.outputs.is_mergai == 'true' && steps.review.outputs.fix_produced == 'true'
         env:
+          # Write token (scoped to this push): the setup credential helper reads
+          # GH_TOKEN, and the job environment no longer carries a token.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: git push origin "HEAD:$HEAD_REF"
 

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -446,6 +446,15 @@ jobs:
     # entirely: with it set, even a failure is a no-op and this privileged-ops
     # job never starts.
     if: needs.ci-gate.outputs.state == 'failure' && needs.ci-gate.outputs.skip_ci_fix != 'true'
+    # Serialize approved handle jobs for the same branch. Each watched-workflow
+    # completion enqueues its own ci-handle, and each waits on the privileged-ops
+    # approval independently, so two can be approved close together and race on
+    # `git push` / `mergai notes push`. `cancel-in-progress: false` queues the
+    # later one instead of cancelling a fix mid-push; its handle-time re-check
+    # then sees the first one's pushed result and no-ops.
+    concurrency:
+      group: ci-handle-exec-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
     environment: privileged-ops
     runs-on: ubuntu-latest
     env:
@@ -537,8 +546,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           STATE=$(mergai ci status --state)
+          # Honor a mergai-skip-ci-fix label the same way: ci-gate froze
+          # skip_ci_fix before the approval, but the label can be added during
+          # the approval wait. Re-read it live and, if present, override STATE to
+          # a non-failure sentinel so the fix/comment/push steps below no-op.
+          LABELS=$(gh pr list --head "$HEAD_BRANCH" --state open \
+            --json labels --jq '.[0].labels[].name' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -qx "mergai-skip-ci-fix"; then
+            echo "mergai-skip-ci-fix present at handle time; CI auto-fix suppressed"
+            STATE=skip
+          fi
           echo "Live gate state at handle time: $STATE"
           echo "state=$STATE" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -328,7 +328,7 @@ jobs:
           setup-mergai: "true"
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
-          mergai-ref: master
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
 
       # Run finalize and force-push main branch.
       - name: Finalize semantic fixes into the merge commit
@@ -430,7 +430,7 @@ jobs:
           setup-gemini: "false"
           setup-claude: "false"
           setup-mergai: "true"
-          mergai-ref: master
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
 
       # Gate: reduce the latest run of each watched workflow for the current
       # HEAD to a single token (in-progress|success|failure|none). Exit code is
@@ -581,7 +581,7 @@ jobs:
           claude-api-key: ${{ secrets.CLAUDE_API_KEY }}
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
-          mergai-ref: master
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
           # This job runs the AI agent (`mergai ci fix`). Keep the write token
           # out of the job environment; the agent/read steps use the read-only
           # token and the write token is scoped to the push/comment steps.
@@ -836,7 +836,7 @@ jobs:
           claude-api-key: ${{ secrets.CLAUDE_API_KEY }}
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
-          mergai-ref: master
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
           # This job runs the AI agent (`mergai review fix`). Keep the write
           # token out of the job environment; the agent/read steps use the
           # read-only token and the write token is scoped to the push /
@@ -1000,7 +1000,7 @@ jobs:
           setup-mergai: "true"
           github-app-token: ${{ steps.app-token.outputs.token }}
           github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
-          mergai-ref: master
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
 
       # Rebase the branch onto the current base tip and force-push it.
       #   1. fetch the latest base branch tip;


### PR DESCRIPTION
The mergai agent (describe/resolve/ci-fix/review-fix) ran in jobs that had a
GitHub **write** token in the environment and on disk, so a prompt-injected
agent could push or call write APIs. This PR confines the write token to the
deterministic, non-agent steps. Workflow-only change; the agent-side hardening
(token strip, tool limits) is in Percona-Lab/mergai#34.

**Credential confinement**
- `persist-credentials: false` on agent checkouts (no token in `.git/config`), plus a credential helper in setup so pushes authenticate from `GH_TOKEN` at push time.
- New `export-github-token` input lets agent jobs skip exporting the write token job-wide:
  - `trigger-merge`: `merge` step split into an agent phase (no token) and a `publish` step that alone holds the write token.
  - `ci-handle` / `review-handle`: agent steps use a **read-only** token (ci-handle also `security_events: read` for code-scanning); the write token is scoped to the push/comment steps only.

**CI-gate robustness**
- `ci-handle` re-checks the live gate at handle time, honors a late `mergai-skip-ci-fix` label, and serializes per branch.

**Consistency**
- All jobs resolve `mergai-ref` from `${{ vars.MERGAI_REF || 'master' }}`.

**Validation:** run green end-to-end on a fork (MERGAI_REF → hardened mergai) with zero denied tool calls — trigger-merge (clean + conflict), review-handle, ci-handle (inline / semantic-relocate / no-op paths), solution-merged, semantic-merged; all writes succeed from the write-token steps.
