### PR TITLE
PSMDB-2142: grant ci-gate security-events:read to classify clang-tidy

### DIFF
--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -402,6 +402,7 @@ jobs:
       actions: read # mergai ci status -> get_workflow_runs
       contents: read # checkout
       pull-requests: read # read PR labels (mergai-skip-ci-fix)
+      security-events: read # mergai ci status -> classify clang-tidy via code-scanning analyses
     # Serialize completions for the same branch so two near-simultaneous
     # workflow_run events can't each observe the other as in-progress and both
     # no-op (a deadlock). The last-queued gate sees the full set done. This


### PR DESCRIPTION
ci-gate runs `mergai ci status` with the default GITHUB_TOKEN. Classifying a clang-tidy watched run reads the code-scanning analyses API, which requires security-events read. Without it the request returns 403 and mergai treats the run as non-actionable -- so a clang-tidy failure may not gate as `failure` and ci-handle won't be triggered to fix it.

Add security-events: read to the ci-gate job permissions so the gate can read code-scanning and classify clang-tidy correctly.
