### PR TITLE
PSMDB-2150 Populate the packages with a release-specific SBOM (#2008)

### DIFF
--- a/percona-packaging/debian/percona-server-mongodb-server.docs
+++ b/percona-packaging/debian/percona-server-mongodb-server.docs
@@ -1,0 +1,1 @@
+sbom.cdx.json

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -247,7 +247,7 @@ install -m 644 $RPM_BUILD_DIR/%{src_dir}/manpages/* %{buildroot}/%{_mandir}/man1
 %config(noreplace) %{_sysconfdir}/mongod.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/mongod
 %attr(0640,mongod,mongod) %ghost /var/log/mongo/mongod.log
-%doc LICENSE-Community.txt README THIRD-PARTY-NOTICES
+%doc LICENSE-Community.txt README THIRD-PARTY-NOTICES sbom.cdx.json
 
 %files shell
 %defattr(-,root,root,-)

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -135,6 +135,64 @@ check_workdir(){
     [ -d "$WORKDIR" ] || abort "\`$WORKDIR\` is not a directory."
 }
 
+# Creates a release-specific SBOM from a more general branch-specific one.
+generate_release_sbom() {
+    local src="$1"
+    local dst="$2"
+    [ -r "$src" ] || abort "\`generate_release_sbom\`: source SBOM file \`$src\` is not readable or does not exist"
+    [ -n "$dst" ] || abort '`generate_release_sbom`: destination SBOM filepath is empty'
+
+    # `branch_version` is equal `PSM_VER` with
+    # "last-dot-followed-by-something" removed
+    local branch_version="${PSM_VER%.*}"
+    local release_version="${PSM_VER}-${PSM_RELEASE}"
+
+    local uuid
+    uuid="$(uuidgen --random)" || abort '`generate_release_sbom`: `uuidgen` failed'
+    local timestamp
+    timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" || abort '`generate_release_sbom`: failed to obtain current timestamp'
+
+    jq --indent 2 \
+        --arg uuid "$uuid" \
+        --arg timestamp "$timestamp" \
+        --arg release_version "$release_version" \
+        --arg purl_branch "pkg:github/percona/percona-server-mongodb@v$branch_version" \
+        --arg purl_release "pkg:github/percona/percona-server-mongodb@$release_version" \
+        --arg license_url "https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/tags/psmdb-$release_version/LICENSE-Community.txt" \
+        --arg doc_url "https://docs.percona.com/percona-server-for-mongodb/$branch_version/index.html" \
+        --arg rn_url "https://docs.percona.com/percona-server-for-mongodb/$release_version/release_notes/index.html" \
+        --arg vcs_url "https://github.com/percona/percona-server-mongodb/tree/psmdb-$release_version" \
+        '.serialNumber = "urn:uuid:\($uuid)" | .version = 1 | .metadata = {
+            "timestamp": $timestamp,
+            "lifecycles": [{"phase": "pre-build"}],
+            "component": {
+                "type": "application",
+                "bom-ref": $purl_release,
+                "supplier": {"name": "Percona LLC", "url": ["https://percona.com"]},
+                "author": "Percona LLC",
+                "publisher": "Percona LLC",
+                "group": "percona",
+                "name": "percona-server-mongodb",
+                "version": $release_version,
+                "cpe": "cpe:2.3:a:percona:percona-server-mongodb:\($release_version):*:*:*:*:*:*:*",
+                "purl": $purl_release,
+                "externalReferences": [
+                    {"type": "license", "url": $license_url, "comment": "Server Side Public License 1.0"},
+                    {"type": "website", "url": $doc_url, "comment": "documentation"},
+                    {"type": "release-notes", "url": $rn_url},
+                    {"type": "vcs", "url": $vcs_url}
+                ]
+            },
+            "supplier": {"name": "Percona LLC", "url": ["https://percona.com"]}
+        } | if (.dependencies | any(.ref == $purl_branch)) then
+                (.dependencies[] | select(.ref == $purl_branch)).ref |= $purl_release
+            else
+                error("no dependency entry found matching \($purl_branch)")
+            end
+        | (.dependencies[].dependsOn[] | select(. == $purl_branch)) |= $purl_release' \
+        "$src" > "$dst" || abort '`generate_release_sbom`: `jq` failed'
+}
+
 get_sources(){
     cd "${WORKDIR}"
     if [ "${SOURCE}" = 0 ]
@@ -240,6 +298,8 @@ get_sources(){
     fi
     # Scrub nested .git (submodules, mongo-tools clone) regardless of whitelist.
     find . -name '.git' -prune -exec rm -rf {} +
+
+    generate_release_sbom "sbom.json" "sbom.cdx.json"
 
     cd ..
     tar --owner=0 --group=0 -czf ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}.tar.gz ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}
@@ -349,8 +409,9 @@ install_deps() {
         OPENSSL_EXCLUDE=""
         yum -y update
       fi
-      yum -y install wget sudo
-      yum -y install perl
+      # Note. The `util-linux` package provides the `uuidgen` utility,
+      # which is used in `generate_release_sbom` alongside `jq`.
+      yum -y install wget sudo perl jq util-linux
       if [ x"$ARCH" = "xx86_64" ]; then
         yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
         percona-release enable tools testing
@@ -437,6 +498,9 @@ install_deps() {
       INSTALL_LIST="${INSTALL_LIST} build-essential libgssapi-krb5-2 libxml2-dev"
       # PSMDB-2072: systemtap-sdt-dev is in ADDITIONAL_PACKAGES for
       # ubuntu:22.04 and ubuntu:24.04 (SERVER-93258 d4c639cf4a7 init).
+
+      # `jq` and `uuid-runtime` are needed by `generate_release_sbom`
+      INSTALL_LIST="${INSTALL_LIST} jq uuid-runtime"
 
       if [ x"${DEBIAN}" = "xjammy" ] || [ x"${DEBIAN}" = "xnoble" ]; then
         INSTALL_LIST="${INSTALL_LIST} systemtap-sdt-dev"
@@ -820,9 +884,12 @@ build_tarball(){
     export USE_SSE=1
     #
 
-    # Finally build Percona Server for MongoDB with Bazel
     cd ${PSMDIR_ABS}
 
+    mkdir -p ${PSMDIR}/doc
+    cp sbom.cdx.json ${PSMDIR}/doc || abort '`build_tarball`: SBOM copying failed'
+
+    # Finally build Percona Server for MongoDB with Bazel
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     export OPT_LINKFLAGS="${LINKFLAGS} -Wl,--build-id=sha1"
     python3 buildscripts/install_bazel.py


### PR DESCRIPTION
The patch generates a release-specific `sbom.cdx.json` file from `sbom.json` and adds it to the source and binary packages and tarballs.

The filename having the additional `.cdx` extension, which is an abbreviation for "CycloneDX", ensures better compatibility with SBOM analyzing tools without further hassle.

The `sbom.cdx.json` file refers to a specific PSMDB version rather than using the more vague `<branch_name>` versioning approach used in `sbom.json`.

The patch also makes sure `sbom.cdx.json` has a unique `serialNumber` for each PSMDB version.


(cherry picked from commit fe3600fb943fa5a25695467ba20fd9b0a8e77b40)