### PR TITLE
PSMDB-2150 Populate the packages with a release-specific SBOM (#2008)

### DIFF
--- a/percona-packaging/debian/percona-server-mongodb-server.docs
+++ b/percona-packaging/debian/percona-server-mongodb-server.docs
@@ -1,0 +1,1 @@
+sbom.cdx.json

--- a/percona-packaging/redhat/percona-server-mongodb.spec.template
+++ b/percona-packaging/redhat/percona-server-mongodb.spec.template
@@ -254,7 +254,7 @@ install -m 644 $RPM_BUILD_DIR/%{src_dir}/manpages/* %{buildroot}/%{_mandir}/man1
 %config(noreplace) %{_sysconfdir}/mongod.conf
 %config(noreplace) %{_sysconfdir}/sysconfig/mongod
 %attr(0640,mongod,mongod) %ghost /var/log/mongo/mongod.log
-%doc LICENSE-Community.txt README THIRD-PARTY-NOTICES
+%doc LICENSE-Community.txt README THIRD-PARTY-NOTICES sbom.cdx.json
 
 %files shell
 %defattr(-,root,root,-)

--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -144,6 +144,64 @@ add_percona_yum_repo(){
     return
 }
 
+# Creates a release-specific SBOM from a more general branch-specific one.
+generate_release_sbom() {
+    local src="$1"
+    local dst="$2"
+    [ -r "$src" ] || abort "\`generate_release_sbom\`: source SBOM file \`$src\` is not readable or does not exist"
+    [ -n "$dst" ] || abort '`generate_release_sbom`: destination SBOM filepath is empty'
+
+    # `branch_version` is equal `PSM_VER` with
+    # "last-dot-followed-by-something" removed
+    local branch_version="${PSM_VER%.*}"
+    local release_version="${PSM_VER}-${PSM_RELEASE}"
+
+    local uuid
+    uuid="$(uuidgen --random)" || abort '`generate_release_sbom`: `uuidgen` failed'
+    local timestamp
+    timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" || abort '`generate_release_sbom`: failed to obtain current timestamp'
+
+    jq --indent 2 \
+        --arg uuid "$uuid" \
+        --arg timestamp "$timestamp" \
+        --arg release_version "$release_version" \
+        --arg purl_branch "pkg:github/percona/percona-server-mongodb@v$branch_version" \
+        --arg purl_release "pkg:github/percona/percona-server-mongodb@$release_version" \
+        --arg license_url "https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/tags/psmdb-$release_version/LICENSE-Community.txt" \
+        --arg doc_url "https://docs.percona.com/percona-server-for-mongodb/$branch_version/index.html" \
+        --arg rn_url "https://docs.percona.com/percona-server-for-mongodb/$release_version/release_notes/index.html" \
+        --arg vcs_url "https://github.com/percona/percona-server-mongodb/tree/psmdb-$release_version" \
+        '.serialNumber = "urn:uuid:\($uuid)" | .version = 1 | .metadata = {
+            "timestamp": $timestamp,
+            "lifecycles": [{"phase": "pre-build"}],
+            "component": {
+                "type": "application",
+                "bom-ref": $purl_release,
+                "supplier": {"name": "Percona LLC", "url": ["https://percona.com"]},
+                "author": "Percona LLC",
+                "publisher": "Percona LLC",
+                "group": "percona",
+                "name": "percona-server-mongodb",
+                "version": $release_version,
+                "cpe": "cpe:2.3:a:percona:percona-server-mongodb:\($release_version):*:*:*:*:*:*:*",
+                "purl": $purl_release,
+                "externalReferences": [
+                    {"type": "license", "url": $license_url, "comment": "Server Side Public License 1.0"},
+                    {"type": "website", "url": $doc_url, "comment": "documentation"},
+                    {"type": "release-notes", "url": $rn_url},
+                    {"type": "vcs", "url": $vcs_url}
+                ]
+            },
+            "supplier": {"name": "Percona LLC", "url": ["https://percona.com"]}
+        } | if (.dependencies | any(.ref == $purl_branch)) then
+                (.dependencies[] | select(.ref == $purl_branch)).ref |= $purl_release
+            else
+                error("no dependency entry found matching \($purl_branch)")
+            end
+        | (.dependencies[].dependsOn[] | select(. == $purl_branch)) |= $purl_release' \
+        "$src" > "$dst" || abort '`generate_release_sbom`: `jq` failed'
+}
+
 get_sources(){
     cd "${WORKDIR}"
     if [ "${SOURCE}" = 0 ]
@@ -213,6 +271,8 @@ get_sources(){
     cd ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}
 
     sed -i 's:build-id:build-id=sha1:' SConstruct
+
+    generate_release_sbom "sbom.json" "sbom.cdx.json"
 
     cd ../
     tar --owner=0 --group=0 --exclude=.* -czf ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}.tar.gz ${PRODUCT}-${PSM_VER}-${PSM_RELEASE}
@@ -900,6 +960,10 @@ build_tarball(){
             strip --strip-debug ${PSMDIR}/bin/${target#"build/install/bin/"}
         fi
     done
+
+    mkdir -p ${PSMDIR}/doc
+    cp sbom.cdx.json ${PSMDIR}/doc || abort '`build_tarball`: SBOM copying failed'
+
     #
     cd ${WORKDIR}
     #


### PR DESCRIPTION
The patch generates a release-specific `sbom.cdx.json` file from `sbom.json` and adds it to the source and binary packages and tarballs.

The filename having the additional `.cdx` extension, which is an abbreviation for "CycloneDX", ensures better compatibility with SBOM analyzing tools without further hassle.

The `sbom.cdx.json` file refers to a specific PSMDB version rather than using the more vague `<branch_name>` versioning approach used in `sbom.json`.

The patch also makes sure `sbom.cdx.json` has a unique `serialNumber` for each PSMDB version.