### PR TITLE
PSMDB-2142: reorganize CI deployment environments and relax approvals for trusted triggers

### DIFF
--- a/.github/MERGAI.md
+++ b/.github/MERGAI.md
@@ -163,8 +163,8 @@ longer fast-forwardable and `/fast-forward` fails. Post a `/mergai rebase` comme
 force-pushes it. The rebase preserves merge commits and mergai notes and reuses previously recorded
 conflict solutions, so the PR becomes fast-forwardable again (then post `/fast-forward`).
 
-Like the other comment-driven commands, it runs under the `privileged-ops` environment, so a
-required reviewer must approve the run before it acts. If the rebase hits conflicts it cannot
+Like `/fast-forward`, it runs under the `push-approve` environment (whereas `/mergai review fix`
+uses `ai-approve`), so a required reviewer must approve the run before it acts. If the rebase hits conflicts it cannot
 auto-resolve, the bot comments on the PR and you must rebase locally
 (`mergai notes update && mergai context init && mergai rebase origin/<base>`).
 

--- a/.github/MERGAI.md
+++ b/.github/MERGAI.md
@@ -56,7 +56,9 @@ behavior stays in `mergai.yml`'s `trigger-merge` job, which it dispatches unchan
 | `workflow_dispatch`               | Always (manual test); **not** gated by the enable toggles                                                             |
 | `pull_request` closed on `master` | Only if `MERGAI_FOLLOWUP_MERGE_ENABLED == 'true'` and a merged `mergai/*/main` PR — chains the next merge immediately |
 
-The pick happens in two phases so AI tokens are only ever spent in the privileged job:
+The pick happens in two phases so AI tokens are only ever spent in the secret-bearing
+`trigger-merge` job (see
+[Deployment environments & security model](#deployment-environments--security-model)):
 
 1. **Gate (here, token-free):** `mergai fork merge-pick --plan` decides _whether_ to merge (go/no-go
    over fork status). If the gate is closed, the workflow stops. It also stops early if a mergai PR
@@ -68,6 +70,90 @@ The pick happens in two phases so AI tokens are only ever spent in the privilege
 > The cron _cadence_ is a literal in the workflow file — GitHub does not allow a variable there.
 > `MERGAI_PERIODIC_MERGE_ENABLED` only turns scheduled runs on/off; to change the frequency, edit
 > the `cron:` expression in `periodic-merge.yml`.
+
+## Deployment Environments & Security Model
+
+GitHub Actions **deployment environments** are the security boundary for the mergai workflows. Each
+environment does two independent things:
+
+1. **Carries secrets** — a job can read an environment's secrets only if it declares that
+   environment.
+2. **Optionally gates on human approval** — an environment with _required reviewers_ pauses any job
+   targeting it until a reviewer approves the deployment.
+
+We keep those two concerns separate, so environments come in pairs: `<purpose>` (ungated) and
+`<purpose>-approve` (approval-gated by the `dev-psmdb-approvers` team).
+
+| Environment        | Secrets it carries             | Approval           | Deployment branches             |
+| ------------------ | ------------------------------ | ------------------ | ------------------------------- |
+| `ai`               | AI-agent creds                 | none               | `master`, `mergai/**`           |
+| `ai-approve`       | same AI creds                  | required reviewers | none (the reviewer is the gate) |
+| `push-approve`     | none (App token is repo-level) | required reviewers | none                            |
+| `rbe`              | RBE OIDC secrets               | none               | all branches (see below)        |
+| `rbe-approve`      | same RBE OIDC secrets          | required reviewers | none                            |
+| _(no environment)_ | none (App token is repo-level) | none               | —                               |
+
+The GitHub App token (`PSMDB_BOT_GH_APP_ID` / `PSMDB_BOT_GH_APP_PRIVATE_KEY`) is a
+**repository-level** secret, so any job can mint a write token without an environment — which is why
+the finalize jobs run under no environment at all.
+
+> **Operator note:** create all five environments in **Settings → Environments** (with the
+> reviewers, secrets, and deployment branches above) **before** these workflows first run. GitHub
+> auto-creates a referenced-but-undefined environment with **no** protection rules, which would
+> silently open the gated paths.
+
+### Why this is safe
+
+Three structural facts underpin the whole model:
+
+1. **The gating logic can't be self-promoted.** For `pull_request_target`, `workflow_run`,
+   `issue_comment` and `pull_request_review`, GitHub always reads the workflow file from the
+   **base/default branch**, never the PR head. A PR that edits `mergai.yml` / `build-and-test.yml`
+   to route itself to an ungated environment does **not** change the gating of its own run.
+2. **Ungated environments can't be reached from an untrusted ref.** `ai`'s deployment-branch policy
+   allows only `master` + `mergai/**`. `workflow_dispatch` can be triggered on _any_ ref, but a run
+   dispatched on another branch is **denied the `ai` secrets** by that policy — so the environment's
+   branch policy (not the trigger) is what stops a feature branch from reading the AI secrets. `rbe`
+   is deliberately **not** branch-restricted: `build-and-test.yml` runs on `pull_request_target`,
+   and GitHub evaluates the environment deployment-branch rule against the **PR head branch**, so
+   any restriction would block ordinary same-repo PR builds (feature branches). What keeps untrusted
+   (fork) code off `rbe` is the same-repo **gate ternary** — fork PRs resolve to `rbe-approve` and
+   require approval — together with the fact that `build-and-test.yml` is the only workflow that
+   references `rbe`, and only via `pull_request_target` (whose workflow file is read from the base
+   branch, so a PR can't add its own `rbe` reference). The approval-gated environments need no
+   branch restriction either — the required reviewer is the control.
+3. **Trust is decided by the trigger, not a spoofable field.** A job runs ungated only when the
+   _trigger itself_ proves the actor has write access (see below). `author_association` is never
+   used to skip a required-reviewer gate; the CLI's `trusted_associations` allow-list is a
+   _post-approval_ content filter (which commenters the agent acts on after `ai-approve`), not a
+   deployment bypass.
+
+### Per-job rationale
+
+The question for every job is: **does the trigger inherently prove the actor has write access?** If
+yes → ungated. If no → approval-gated. If the job needs no secrets at all → no environment.
+
+| Workflow                       | Job(s)                                                    | Trigger                                                                             | Environment            | Approval | Why                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `mergai.yml`                   | `trigger-merge`                                           | `workflow_dispatch`                                                                 | `ai`                   | No       | Only users with **write access** can dispatch a workflow (GitHub platform rule), so the trigger _is_ the trust boundary — an approval would be redundant. Runs the AI agent, so needs the AI secrets.                                                                                                                                                                    |
+| `mergai.yml`                   | `solution-merged`, `semantic-merged`                      | `pull_request` closed with `merged == true`                                         | _(none)_               | No       | Only a **write-access** user can merge a PR, so `merged == true` proves trust. These jobs finalize with the repo-level App token only — no AI/RBE secrets — so they need no environment.                                                                                                                                                                                 |
+| `mergai.yml`                   | `ci-gate`                                                 | `workflow_run` on `mergai/**`, same-repo only                                       | _(none)_               | No       | Read-only: computes the aggregate CI state with the default `GITHUB_TOKEN`. No secrets, no writes → no environment and no approval. Still carries the same-repo guard (see `ci-handle`) so a fork can't drive the state machine.                                                                                                                                         |
+| `mergai.yml`                   | `ci-handle`                                               | `workflow_run` on `mergai/**` + `ci-gate` failure, same-repo only                   | `ai`                   | No       | The `mergai/**` branch filter is **not** sufficient — a fork PR can name its head branch `mergai/...` and spoof `workflow_run.head_branch`. The real trust boundary is the same-repo guard `workflow_run.head_repository.full_name == github.repository` (on both `ci-gate` and `ci-handle`); do not remove it as redundant. Runs the AI fixer, so needs the AI secrets. |
+| `mergai.yml`                   | `review-handle`                                           | `issue_comment` `/mergai review fix` **or** `pull_request_review` changes-requested | `ai-approve`           | **Yes**  | A comment or review can come from **any** user — not inherently trusted. Approval is required before the AI agent and secrets are exposed. The CLI `process_external: false` filter is a second layer (untrusted authors' instructions are ignored even after approval).                                                                                                 |
+| `mergai.yml`                   | `rebase-handle`                                           | `issue_comment` `/mergai rebase`                                                    | `push-approve`         | **Yes**  | Any user can comment → approval required. Force-pushes the mergai branch; needs only the App token, so no AI/RBE secrets.                                                                                                                                                                                                                                                |
+| `fast-forward.yml`             | `fast-forward`                                            | `issue_comment` `/fast-forward`                                                     | `push-approve`         | **Yes**  | Any user can comment, and the job **pushes to `master`** (protected). Approval is the primary gate; the in-job `getCollaboratorPermissionLevel` check (write/maintain/admin) and fork-PR rejection are a second layer.                                                                                                                                                   |
+| `build-and-test.yml`           | `gate`                                                    | `pull_request_target`                                                               | `rbe` \| `rbe-approve` | Cond.    | A branch exists in this repo only if a **write-access** actor pushed it, so same-repo (`head.repo.full_name == github.repository`) → ungated `rbe`; fork/external PRs → `rbe-approve` (approval). The single `gate` approval authorizes the whole downstream pipeline.                                                                                                   |
+| `build-and-test.yml`           | `build`, `unittests`, `dbtests`, `jstests`                | `needs: gate`                                                                       | `rbe`                  | Inherit  | Run only after `gate` (transitively via `needs`), so the gate is the single approval point. Local resmoke execution of PR-head code is therefore reached only after the gate passed — same-repo (trusted) or an `rbe-approve` reviewer approved a fork PR.                                                                                                               |
+| `build-and-test.yml`           | `format_gate`, `jstests_gate`                             | `pull_request_target`                                                               | _(none)_               | No       | Label/skip decision jobs (whether format / jstests run). Read-only, no secrets, no environment.                                                                                                                                                                                                                                                                          |
+| `periodic-merge.yml`           | `periodic-merge` (decide + dispatch)                      | `schedule` / `workflow_dispatch` / `pull_request` closed on `master`                | _(none)_               | No       | Token-free go/no-go decision, then dispatches `trigger-merge` with the App token. Triggers are repo-controlled (dispatch requires write; schedule is repo-controlled; the follow-up is gated by a repo variable). The secret-bearing work is deferred to `trigger-merge` (`ai`).                                                                                         |
+| `update-fork-status.yml`       | `update-status`                                           | `push` to `master` / `workflow_dispatch` / `schedule`                               | _(none)_               | No       | Publishes the fork-status dashboard with the App token. All triggers are trusted (push to `master` and dispatch require write access; schedule is repo-controlled). No secrets beyond the App token.                                                                                                                                                                     |
+| `format.yml`, `clang-tidy.yml` | `check-skip`, `analyze` (+ `changed_files` in clang-tidy) | `pull_request`                                                                      | _(none)_               | No       | Plain `pull_request` (not `_target`): runs in the fork's context with a **read-only** token and **no** access to secrets, so untrusted PR code can never reach a secret. No environment needed.                                                                                                                                                                          |
+
+**Net effect.** The trusted day-to-day loop — periodic merges, team-dispatched merges, merge
+finalization, and automated CI fixes on the bot-created `mergai/**` branches — runs with **zero**
+approvals. The only runs that pause for a `dev-psmdb-approvers` click are the ones whose trigger
+cannot prove write access: comment/review-driven commands (`review-handle`, `rebase-handle`,
+`fast-forward`) and CI for fork/external PRs (`rbe-approve`).
 
 ## Repository Variables
 
@@ -87,11 +173,11 @@ below.
 Controls how `trigger-merge` selects the commit to merge **when dispatched without an explicit
 `merge-pick` SHA**. An explicit SHA always bypasses the mode and the gate.
 
-| Value                                                    | Honors gate? | Window cap? | How it picks the commit                                                                                                                               |
-| -------------------------------------------------------- | ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gate` _(default; also any unset or unrecognized value)_ | yes          | yes         | Deterministic: first prioritized strategy match within the candidate window, else the window tip (`merge-pick --gate`).                               |
-| `ai`                                                     | yes          | yes         | An AI agent chooses the best merge boundary within the candidate window (`merge-pick --ai`; spends AI tokens, hence runs only in the privileged job). |
-| `next`                                                   | **no**       | **no**      | Raw `merge-pick --next`: the first prioritized strategy match, with no gate and no window cap.                                                        |
+| Value                                                    | Honors gate? | Window cap? | How it picks the commit                                                                                                                                                   |
+| -------------------------------------------------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gate` _(default; also any unset or unrecognized value)_ | yes          | yes         | Deterministic: first prioritized strategy match within the candidate window, else the window tip (`merge-pick --gate`).                                                   |
+| `ai`                                                     | yes          | yes         | An AI agent chooses the best merge boundary within the candidate window (`merge-pick --ai`; spends AI tokens, hence runs only in the secret-bearing `trigger-merge` job). |
+| `next`                                                   | **no**       | **no**      | Raw `merge-pick --next`: the first prioritized strategy match, with no gate and no window cap.                                                                            |
 
 In `gate` and `ai` modes, a closed gate (or nothing to merge) yields an empty pick and the merge
 steps are skipped — no PR is created. `next` ignores the gate entirely.
@@ -164,8 +250,8 @@ force-pushes it. The rebase preserves merge commits and mergai notes and reuses 
 conflict solutions, so the PR becomes fast-forwardable again (then post `/fast-forward`).
 
 Like `/fast-forward`, it runs under the `push-approve` environment (whereas `/mergai review fix`
-uses `ai-approve`), so a required reviewer must approve the run before it acts. If the rebase hits conflicts it cannot
-auto-resolve, the bot comments on the PR and you must rebase locally
+uses `ai-approve`), so a required reviewer must approve the run before it acts. If the rebase hits
+conflicts it cannot auto-resolve, the bot comments on the PR and you must rebase locally
 (`mergai notes update && mergai context init && mergai rebase origin/<base>`).
 
 ## Canceling a Merge

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,12 +105,15 @@ env:
 # trying to ship build artifacts between runners.
 #
 # One-time environment setup (GH repo settings UI):
-#   - `rbe-approve`: required reviewers = dev-psmdb team. Carries
+#   - `rbe-approve`: required reviewers = dev-psmdb-approvers team. Carries
 #     PSMDB_RBE_GHA_AUDIENCE + PSMDB_RBE_OIDC_ISSUER secrets.
 #   - `rbe`: NO required reviewers. Same two secrets, same values.
-#     "Deployment branches and tags" restricted to `master` and
-#     `mergai/**` so a feature-branch workflow can't target `rbe`
-#     and bypass the gate.
+#     "Deployment branches and tags" = ALL branches. This workflow runs on
+#     pull_request_target and GitHub evaluates the environment branch rule
+#     against the PR HEAD ref, so restricting `rbe` to `master`/`mergai/**`
+#     would block ordinary same-repo PR builds (feature branches). Fork PRs
+#     are kept off `rbe` by the gate ternary below (they resolve to
+#     `rbe-approve` and require approval), not by a branch rule.
 #
 # One-time repo/org Variables (GH repo settings UI -> Variables):
 #   - PSMDB_RBE_ENABLED = 'true' to run the RBE pipeline (see the env block

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ name: build-and-test
 # break RBE. Because we still need to build the PR's source, the checkout step
 # below overrides the default base ref to the PR head SHA. That re-introduces
 # the "pwn-request" risk (running untrusted code with a secret), which is
-# mitigated by routing untrusted authors through the rbe-external environment
+# mitigated by routing untrusted authors through the rbe-approve environment
 # whose required reviewers must approve every push.
 on:
   pull_request_target:
@@ -87,7 +87,7 @@ env:
 
 # Jobs: gate, format_gate, build, unittests, binary_tests, jstests (plus the
 # jstests_gate decider). `gate` is a no-op whose only purpose is to host the
-# protected `rbe-external` environment so a single maintainer approval authorizes
+# protected `rbe-approve` environment so a single maintainer approval authorizes
 # the entire workflow run. `format_gate` waits for the `format` workflow and
 # gates `build`; the test jobs inherit the format requirement transitively via
 # build. See those jobs. The test jobs depend on `gate` (transitively) and use
@@ -105,7 +105,7 @@ env:
 # trying to ship build artifacts between runners.
 #
 # One-time environment setup (GH repo settings UI):
-#   - `rbe-external`: required reviewers = dev-psmdb team. Carries
+#   - `rbe-approve`: required reviewers = dev-psmdb team. Carries
 #     PSMDB_RBE_GHA_AUDIENCE + PSMDB_RBE_OIDC_ISSUER secrets.
 #   - `rbe`: NO required reviewers. Same two secrets, same values.
 #     "Deployment branches and tags" restricted to `master` and
@@ -121,24 +121,26 @@ env:
 #   - PSMDB_RBE_HOST: the RBE host (no scheme/port); used to build the
 #     credential-helper flag (see the env block above).
 #
-# First-version trust model: every run goes through `gate` and pays the
-# approval cost, internal and external alike. Planned next step (NOT YET
-# IMPLEMENTED — needs security review + CODEOWNERS on .github/** first):
-# make `gate.environment` conditional on author_association so internal
-# PRs skip the approval. The ternary below sketches that; do NOT enable
-# it without first (1) auditing how a malicious .github/actions/**
-# change could exfiltrate the OIDC credential in the unattended path,
-# and (2) wiring CODEOWNERS on .github/** to dev-psmdb so the code-
-# review half of the gate actually fires.
+# Trust model: same-repo PRs (head repo == base repo) route to the ungated
+# `rbe` environment; forks/external PRs route to `rbe-approve` and pay the
+# approval cost. A branch can only exist in this repo if someone with write
+# access pushed it, so same-repo is the trust signal -- mergai bot PRs
+# (mergai/** on this repo) and maintainers' own branches skip the approval,
+# forks do not. author_association is intentionally NOT used (spoofable in some
+# contexts); same-repo is the reliable signal.
 #
-#   environment: ${{ (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) && 'rbe' || 'rbe-external' }}
+# SECURITY PREREQUISITES for the production repo (defense in depth; less
+# critical on a personal test fork): (1) audit how a malicious
+# .github/actions/** change could exfiltrate the OIDC credential on the now
+# unattended `rbe` path, and (2) wire CODEOWNERS on .github/** to dev-psmdb so
+# such an edit cannot be merged.
 jobs:
-  # No-op gatekeeper. The approval click on this job's `rbe-external`
-  # environment authorizes the entire workflow run's downstream RBE
-  # access, including the `unittests` job that doesn't run until ~30
-  # minutes later. The maintainer reviewing the PR is implicitly
-  # approving every job that transitively depends on `gate`. Runs on every
-  # trigger; once approved the rest of the pipeline proceeds.
+  # No-op gatekeeper. For fork/external PRs the approval click on this job's
+  # `rbe-approve` environment authorizes the entire workflow run's downstream
+  # RBE access, including the `unittests` job that doesn't run until ~30
+  # minutes later -- the maintainer reviewing the PR is implicitly approving
+  # every job that transitively depends on `gate`. Same-repo PRs resolve to the
+  # ungated `rbe` environment and proceed with no click. Runs on every trigger.
   gate:
     name: gate
     # Master switch for the entire RBE pipeline: `vars.PSMDB_RBE_ENABLED` must
@@ -148,7 +150,7 @@ jobs:
     # dark on a repo/fork that has not opted into remote Bazel.
     if: ${{ vars.PSMDB_RBE_ENABLED == 'true' }}
     runs-on: ubuntu-24.04
-    environment: rbe-external
+    environment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'rbe' || 'rbe-approve' }}
     steps:
       # Fail fast on RBE misconfiguration. This job runs only when
       # PSMDB_RBE_ENABLED == 'true', and in that case every RBE endpoint variable
@@ -282,12 +284,12 @@ jobs:
     # after retesting those assumptions.
     runs-on: ubuntu-24.04
     # Unattended environment (no required reviewers). Carries the same
-    # secrets as `rbe-external` so the credential helper resolves the
+    # secrets as `rbe-approve` so the credential helper resolves the
     # same OIDC audience/issuer values without a fresh approval prompt.
     # The `gate` job above is what authorizes us to be in `rbe` here.
     environment: rbe
     # Job-level env (not workflow-level) so environment-scoped secrets on
-    # `rbe` / `rbe-external` resolve correctly — workflow-level env can
+    # `rbe` / `rbe-approve` resolve correctly — workflow-level env can
     # only read repo/org secrets, never environment ones.
     env:
       PSMDB_RBE_GHA_AUDIENCE: ${{ secrets.PSMDB_RBE_GHA_AUDIENCE }}
@@ -395,10 +397,11 @@ jobs:
     # barely contend for RBE workers; on a real code change they may compete,
     # which the bb-psmdb farm (300-way jobs) absorbs.
     needs: [gate, build]
-    # Gated on build success: build runs only after the gate approval AND format
-    # passing, so build.result == 'success' implies rbe-external was approved,
-    # the PR was not a draft, and format passed. !cancelled() keeps the explicit
-    # result check authoritative rather than the bare-needs short-circuit.
+    # Gated on build success: build runs only after the gate passed AND format
+    # passing, so build.result == 'success' implies the gate passed (fork:
+    # rbe-approve was approved; same-repo: ungated rbe), the PR was not a draft,
+    # and format passed. !cancelled() keeps the explicit result check
+    # authoritative rather than the bare-needs short-circuit.
     if: >-
       ${{ !cancelled()
       && vars.PSMDB_RBE_ENABLED == 'true'
@@ -408,7 +411,8 @@ jobs:
     runs-on: ubuntu-24.04
     # Same unattended `rbe` environment as `build` — see `build.environment`
     # above. `needs: build` transitively pulls in `needs: gate`, so this job
-    # only runs after the maintainer approved `rbe-external` on the gate.
+    # only runs after the gate passed (fork: rbe-approve approved by a
+    # maintainer; same-repo: ungated rbe).
     environment: rbe
     # See `build.env` above for why this is at job level, not workflow level.
     env:
@@ -544,8 +548,8 @@ jobs:
   # its own needs, so the pipeline is build -> {binary_tests, unittests} -> jstests.
   # Each job gates on BUILD success, not on a sibling test job, so a failure in
   # one does not block the others: both test jobs run whenever build passed.
-  # `needs.gate.result == 'success'` preserves the rbe-external approval gate
-  # (it carries the same secrets via the `rbe` environment).
+  # `needs.gate.result == 'success'` preserves the gate (fork: rbe-approve
+  # approval; same-repo: ungated rbe — same secrets via the `rbe` environment).
   binary_tests:
     name: binary-tests
     needs: [gate, build]
@@ -807,8 +811,9 @@ jobs:
   #
   # The `if` uses !cancelled() + explicit result checks (not a bare `needs`) so
   # jstests still runs after a unittest failure. `needs.gate.result ==
-  # 'success'` keeps the security gate (jstests only runs after the rbe-external
-  # approval), and `needs.build.result == 'success'` means a failed build
+  # 'success'` keeps the security gate (jstests only runs after the gate passed:
+  # fork rbe-approve approval, or same-repo ungated rbe), and
+  # `needs.build.result == 'success'` means a failed build
   # (-> all test jobs skipped) still blocks jstests rather than slipping through
   # on a 'skipped' result, while a unittest failure (build still 'success')
   # does not.

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -33,9 +33,12 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/fast-forward')
     runs-on: ubuntu-latest
-    # Uses 'privileged-ops' environment for additional security controls
-    # on merge operations and AI token access
-    environment: privileged-ops
+    # 'push-approve' environment: required-reviewer approval before this job can
+    # push to a protected ref (fast-forward advances master). The /fast-forward
+    # comment can come from anyone, so the approval gate is the trust boundary
+    # (the in-job permission check below is the second layer). Carries no
+    # secrets beyond the repo-level App token.
+    environment: push-approve
 
     steps:
       # --- Authentication ---

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -41,8 +41,11 @@ on:
 
 jobs:
   trigger-merge:
-    # 'privileged-ops' environment controls access to merge operations and AI tokens
-    environment: privileged-ops
+    # 'ai' environment carries the AI-agent secrets. Ungated:
+    # workflow_dispatch is inherently trusted (only write-access actors can
+    # dispatch), so no approval is required. Repo settings restrict this
+    # environment's deployment branches to master + mergai/**.
+    environment: ai
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
@@ -105,7 +108,7 @@ jobs:
       #      one of three values:
       #        * "ai"   -> the agent chooses the boundary within the gate's
       #                    candidate window (uses AI tokens, hence in this
-      #                    privileged-ops job); honors the gate.
+      #                    `ai` job); honors the gate.
       #        * "next" -> raw `merge-pick --next`: the first prioritized strategy
       #                    match, with NO gate and NO window cap.
       #        * "gate" -> gate-respecting deterministic pick (windowed). This is
@@ -182,7 +185,7 @@ jobs:
       # branch (main/conflict/solution/semantic) for $MERGE_PICK means another
       # trigger-merge run already started it. Abort rather than race it. This
       # also covers the window the periodic-merge workflow can't see (a run
-      # dispatched but still awaiting privileged-ops approval, with no PR yet).
+      # dispatched but not yet far enough to have created a branch, no PR yet).
       - name: Fail if a merge for this commit is already in progress
         if: steps.pick.outputs.pick != ''
         run: |
@@ -254,7 +257,9 @@ jobs:
           fi
 
   solution-merged:
-    environment: privileged-ops
+    # No deployment environment: this job needs no AI/RBE secrets (only the
+    # repo-level App token) and the trigger is inherently trusted -- a
+    # pull_request with merged==true means a write-access actor merged it.
     # Solution PRs (textual conflict resolution) merge into the conflict
     # branch. Semantic PRs merge into main and are handled by `semantic-merged`.
     if: >-
@@ -300,7 +305,9 @@ jobs:
           mergai pr --repo "$GITHUB_REPOSITORY" create main --skip-commit-list-on-failure
 
   semantic-merged:
-    environment: privileged-ops
+    # No deployment environment: needs no AI/RBE secrets (only the repo-level
+    # App token) and the trigger is inherently trusted (pull_request
+    # merged==true => merged by a write-access actor).
     # Semantic PRs merge into the main branch.
     # Once merged, run finalize and then force-push main.
     # The main PR (main -> target) already exists and updates itself,
@@ -385,23 +392,32 @@ jobs:
   # is green or fire once per workflow; gating on the aggregate state makes
   # the loop converge.
   #
-  # The state machine is split into two jobs so the privileged half only runs
-  # when there is privileged work to do:
+  # The state machine is split into two jobs so the secret-bearing half only
+  # runs when there is work to do:
   #   * ci-gate   - read-only. Computes the aggregate state with the default
   #                 GITHUB_TOKEN; needs no AI tokens, no GitHub App token, and
-  #                 no `privileged-ops` environment. Runs on every completion.
-  #   * ci-handle - privileged. Gated on ci-gate's state == failure, so
-  #                 in-progress/none/success completions never spin it up (and
-  #                 never trip the privileged-ops approval/secrets path).
-  #                 success is a no-op now that folding into the merge commit
-  #                 is finalize-only.
+  #                 no deployment environment. Runs on every completion.
+  #   * ci-handle - carries the AI-agent secrets via the `ai` environment.
+  #                 Gated on ci-gate's state == failure, so in-progress/none/
+  #                 success completions never spin it up (and never touch the
+  #                 AI-secret path). success is a no-op now that folding into
+  #                 the merge commit is finalize-only.
   ci-gate:
     # Only react to watched-workflow completions. The workflow also fires on
     # workflow_dispatch and pull_request (for other jobs); without this guard
     # ci-gate would run on those too, since the mergai/* branch filter on the
     # workflow_run trigger only constrains workflow_run events. The branch
     # filter itself stays on the trigger.
-    if: github.event_name == 'workflow_run'
+    #
+    # Same-repo guard: the `mergai/**` branch filter alone is not a trust
+    # boundary -- a fork PR can name its head branch `mergai/...`, and when its
+    # format/clang-tidy run (pull_request) completes it emits a workflow_run
+    # whose head_branch matches. Requiring head_repository == this repo ensures
+    # the watched run came from a same-repo (write-access) branch, so an external
+    # fork cannot reach ci-gate/ci-handle (the secret-bearing `ai` path).
+    if: >-
+      github.event_name == 'workflow_run'
+      && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       actions: read # mergai ci status -> get_workflow_runs
@@ -480,7 +496,7 @@ jobs:
       # PR for the head branch to suppress the AI auto-fixer. We resolve the PR
       # from head_branch and read its labels live (the label is typically added
       # after the PR opens, so the workflow_run payload can't be trusted for it).
-      # When set, ci-handle is gated off below, so the privileged-ops job never
+      # When set, ci-handle is gated off below, so the `ai` job never
       # spins up. Removing the label lets the next watched-workflow completion
       # resume auto-fixing. Failures here fall through to skip_ci_fix=false so a
       # transient API error never silently disables fixing.
@@ -540,19 +556,24 @@ jobs:
     # (that is finalize-only, after a human merges the review PR), so it is a
     # no-op.
     # The `mergai-skip-ci-fix` label on the PR suppresses the auto-fixer
-    # entirely: with it set, even a failure is a no-op and this privileged-ops
-    # job never starts.
-    if: needs.ci-gate.outputs.state == 'failure' && needs.ci-gate.outputs.skip_ci_fix != 'true'
-    # Serialize approved handle jobs for the same branch. Each watched-workflow
-    # completion enqueues its own ci-handle, and each waits on the privileged-ops
-    # approval independently, so two can be approved close together and race on
-    # `git push` / `mergai notes push`. `cancel-in-progress: false` queues the
-    # later one instead of cancelling a fix mid-push; its handle-time re-check
-    # then sees the first one's pushed result and no-ops.
+    # entirely: with it set, even a failure is a no-op and this `ai` job never
+    # starts.
+    # The same-repo guard is repeated here (not just inherited via ci-gate) as
+    # defense in depth: it keeps the ungated `ai` environment unreachable by a
+    # fork-triggered workflow_run even if ci-gate's own guard regresses.
+    if: >-
+      needs.ci-gate.outputs.state == 'failure'
+      && needs.ci-gate.outputs.skip_ci_fix != 'true'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+    # Serialize handle jobs for the same branch. Each watched-workflow
+    # completion enqueues its own ci-handle, so two can start close together and
+    # race on `git push` / `mergai notes push`. `cancel-in-progress: false`
+    # queues the later one instead of cancelling a fix mid-push; its handle-time
+    # re-check then sees the first one's pushed result and no-ops.
     concurrency:
       group: ci-handle-exec-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: false
-    environment: privileged-ops
+    environment: ai
     runs-on: ubuntu-latest
     # The default GITHUB_TOKEN is used only to publish the ci-handle commit
     # status (below); all real work uses the scoped GitHub App tokens. Restrict
@@ -683,14 +704,15 @@ jobs:
           mergai context init
 
       # Re-evaluate the gate at handle time. ci-gate froze its verdict into
-      # needs.ci-gate.outputs.state *before* the privileged-ops approval; the
-      # branch can recover in between (e.g. a cancelled watched run is re-run
-      # and passes), so that verdict may be stale by the time this job actually
-      # runs. Recompute the live state with the same check ci-gate uses and
-      # route the steps below off it, so an approval granted late (or a
-      # superseded failure) becomes a clean no-op instead of a fix against a
-      # now-green branch. The job-level `if:` still gates the privileged-ops
-      # request on the original failure; this only suppresses acting on it.
+      # needs.ci-gate.outputs.state *before* this job runs; the branch can
+      # recover in between (e.g. a cancelled watched run is re-run and passes),
+      # so that verdict may be stale by the time this job actually runs (it can
+      # sit in the concurrency queue behind an earlier handle). Recompute the
+      # live state with the same check ci-gate uses and route the steps below
+      # off it, so a late run (or a superseded failure) becomes a clean no-op
+      # instead of a fix against a now-green branch. The job-level `if:` still
+      # gates this job on the original failure; this only suppresses acting on
+      # it.
       - name: Re-check gate
         id: recheck
         env:
@@ -855,7 +877,11 @@ jobs:
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
         && contains(github.event.comment.body, '/mergai review fix'))
-    environment: privileged-ops
+    # 'ai-approve' = AI-agent secrets + required-reviewer approval. The comment/
+    # review trigger fires for any user, so this stays gated: an untrusted
+    # commenter cannot start the secret-bearing job without a maintainer's
+    # approval. The CLI process_external filter is the second layer.
+    environment: ai-approve
     runs-on: ubuntu-latest
     # Serialize per-PR branch-mutation runs so two near-simultaneous triggers
     # don't race on the head branch. The group key (mergai-pr-<number>) is
@@ -905,8 +931,8 @@ jobs:
           # CUTOFF pins the run to the comment set as it stood when it was
           # triggered: the review's submission time, or the comment's creation
           # time. `mergai review fix --since` ignores anything posted (or
-          # edited) after it, so a comment added while this run waits for the
-          # privileged-ops approval cannot be pulled into the set.
+          # edited) after it, so a comment added while this run waits for
+          # approval cannot be pulled into the set.
           if [ "${{ github.event_name }}" = "pull_request_review" ]; then
             PR_NUMBER='${{ github.event.pull_request.number }}'
             HEAD_REF='${{ github.event.pull_request.head.ref }}'
@@ -1030,14 +1056,14 @@ jobs:
   # tip restores it. The rebase preserves merge commits and mergai notes and
   # reuses previously recorded conflict solutions, then force-pushes the branch.
   # As with review-handle, who may actually run this is gated by the
-  # privileged-ops environment (a required reviewer approves the deployment);
+  # 'push-approve' environment (a required reviewer approves the deployment);
   # the command filter and the mergai-branch check below scope *what* it acts on.
   rebase-handle:
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request != null
       && contains(github.event.comment.body, '/mergai rebase')
-    environment: privileged-ops
+    environment: push-approve
     runs-on: ubuntu-latest
     # Serialize per-PR branch-mutation runs. Uses the shared group key
     # (mergai-pr-<number>, see review-handle) so a `/mergai rebase` and a review

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -96,8 +96,9 @@ jobs:
       # any expensive work (the upstream fetch in 'fork init', status, pick).
       # This only needs the mergai CLI, the checked-out .mergai/config.yml, and a
       # token - no upstream remote - so it precedes 'fork init'. The pre-PR window
-      # (a trigger-merge run dispatched but still awaiting privileged-ops approval)
-      # is covered by the early-fail guard in mergai.yml's trigger-merge job.
+      # (a trigger-merge run dispatched but not yet far enough to have created a
+      # branch) is covered by the early-fail guard in mergai.yml's trigger-merge
+      # job.
       - name: Stop if a merge is already in progress
         id: guard
         env:
@@ -152,7 +153,7 @@ jobs:
       # Phase 2: dispatch trigger-merge to do the actual pick + merge. No sha is
       # passed - trigger-merge picks the commit itself (deterministic or AI per
       # the MERGAI_MERGE_PICK_MODE variable), keeping any AI-token use inside the
-      # privileged-ops job.
+      # trigger-merge job (which carries the AI secrets via the `ai` environment).
       - name: Trigger merge
         if: steps.guard.outputs.proceed == 'true' && steps.gate.outputs.merge == 'true'
         env:


### PR DESCRIPTION
Replaces the overloaded `privileged-ops` environment with environments split by **purpose**
(which secrets) and **approval** (whether a human must click), so the trusted automation loop
(periodic/team merges, CI auto-fixes on bot branches) runs with **zero** approvals while
comment/review commands and fork PRs stay gated.

**Environments:** `ai` / `ai-approve` (Claude creds), `push-approve` (no secrets), `rbe`
(unchanged), `rbe-approve` (renamed from `rbe-external`); `privileged-ops` removed.

**Routing:** trigger-merge & ci-handle → `ai`; the `*-merged` finalize jobs → no environment;
review/rebase/fast-forward → `*-approve`; build-and-test gate → ungated `rbe` for same-repo,
`rbe-approve` for forks. Trust is decided by the trigger (write-access-only dispatch,
`merged==true`, `mergai/**` push, same-repo), never by a spoofable field.

See the new **"Deployment Environments & Security Model"** section in `.github/MERGAI.md` for the
per-job rationale and why it's safe.

