### PR TITLE
 PSMDB-2183 Add PSMDB dependency on MongoDB

### DIFF
--- a/percona-packaging/scripts/psmdb_builder.sh
+++ b/percona-packaging/scripts/psmdb_builder.sh
@@ -155,10 +155,14 @@ generate_release_sbom() {
     jq --indent 2 \
         --arg uuid "$uuid" \
         --arg timestamp "$timestamp" \
+        --arg version "$PSM_VER" \
         --arg release_version "$release_version" \
-        --arg purl_branch "pkg:github/percona/percona-server-mongodb@v$branch_version" \
-        --arg purl_release "pkg:github/percona/percona-server-mongodb@$release_version" \
-        --arg license_url "https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/tags/psmdb-$release_version/LICENSE-Community.txt" \
+        --arg mdb_purl_branch "pkg:github/mongodb/mongo@v$branch_version" \
+        --arg mdb_purl_release "pkg:github/mongodb/mongo@$PSM_VER" \
+        --arg psmdb_purl_branch "pkg:github/percona/percona-server-mongodb@v$branch_version" \
+        --arg psmdb_purl_release "pkg:github/percona/percona-server-mongodb@$release_version" \
+        --arg mdb_license_url "https://raw.githubusercontent.com/mongodb/mongo/refs/tags/r$PSM_VER/LICENSE-Community.txt" \
+        --arg psmdb_license_url "https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/tags/psmdb-$release_version/LICENSE-Community.txt" \
         --arg doc_url "https://docs.percona.com/percona-server-for-mongodb/$branch_version/index.html" \
         --arg rn_url "https://docs.percona.com/percona-server-for-mongodb/$release_version/release_notes/index.html" \
         --arg vcs_url "https://github.com/percona/percona-server-mongodb/tree/psmdb-$release_version" \
@@ -167,29 +171,48 @@ generate_release_sbom() {
             "lifecycles": [{"phase": "pre-build"}],
             "component": {
                 "type": "application",
-                "bom-ref": $purl_release,
+                "bom-ref": $psmdb_purl_release,
                 "supplier": {"name": "Percona LLC", "url": ["https://percona.com"]},
                 "author": "Percona LLC",
                 "publisher": "Percona LLC",
                 "group": "percona",
                 "name": "percona-server-mongodb",
                 "version": $release_version,
+                "licenses": [{"license": {"id": "SSPL-1.0"}}],
                 "cpe": "cpe:2.3:a:percona:percona-server-mongodb:\($release_version):*:*:*:*:*:*:*",
-                "purl": $purl_release,
+                "purl": $psmdb_purl_release,
                 "externalReferences": [
-                    {"type": "license", "url": $license_url, "comment": "Server Side Public License 1.0"},
+                    {"type": "license", "url": $psmdb_license_url, "comment": "Server Side Public License 1.0"},
                     {"type": "website", "url": $doc_url, "comment": "documentation"},
                     {"type": "release-notes", "url": $rn_url},
                     {"type": "vcs", "url": $vcs_url}
                 ]
             },
             "supplier": {"name": "Percona LLC", "url": ["https://percona.com"]}
-        } | if (.dependencies | any(.ref == $purl_branch)) then
-                (.dependencies[] | select(.ref == $purl_branch)).ref |= $purl_release
+        } | if (.components | any(.purl == $mdb_purl_branch)) then
+                (.components[] | select(.purl == $mdb_purl_branch) | .externalReferences[]
+                    | select(.type == "license")).url = $mdb_license_url
+                | (.components[] | select(.purl == $mdb_purl_branch)) += {
+                    "purl": $mdb_purl_release,
+                    "bom-ref": $mdb_purl_release,
+                    "version": $version,
+                    "cpe": "cpe:2.3:a:mongodb:mongodb:\($version):*:*:*:*:*:*:*"
+                }
             else
-                error("no dependency entry found matching \($purl_branch)")
+                error("no component entry found matching \($mdb_purl_branch)")
             end
-        | (.dependencies[].dependsOn[] | select(. == $purl_branch)) |= $purl_release' \
+        | if (.dependencies | any(.ref == $mdb_purl_branch)) then
+              (.dependencies[] | select(.ref == $mdb_purl_branch)).ref |= $mdb_purl_release
+          else
+              error("no dependency entry found matching \($mdb_purl_branch)")
+          end
+        | if (.dependencies | any(.ref == $psmdb_purl_branch)) then
+              (.dependencies[] | select(.ref == $psmdb_purl_branch)).ref |= $psmdb_purl_release
+          else
+              error("no dependency entry found matching \($psmdb_purl_branch)")
+          end
+        | (.dependencies[].dependsOn[] | select(. == $mdb_purl_branch)) |= $mdb_purl_release
+        | (.dependencies[].dependsOn[] | select(. == $psmdb_purl_branch)) |= $psmdb_purl_release' \
         "$src" > "$dst" || abort '`generate_release_sbom`: `jq` failed'
 }
 

--- a/sbom.json
+++ b/sbom.json
@@ -1863,6 +1863,48 @@
       ]
     },
     {
+      "type": "application",
+      "bom-ref": "pkg:github/mongodb/mongo@v8.3",
+      "supplier": {
+        "name": "MongoDB, Inc.",
+        "url": [
+          "https://mongodb.com"
+        ]
+      },
+      "author": "MongoDB, Inc.",
+      "publisher": "MongoDB, Inc.",
+      "group": "mongodb",
+      "name": "mongodb/mongo",
+      "version": "v8.3",
+      "cpe": "cpe:2.3:a:mongodb:mongodb:8.3.*:*:*:*:*:*:*:*",
+      "purl": "pkg:github/mongodb/mongo@v8.3",
+      "externalReferences": [
+        {
+          "url": "https://raw.githubusercontent.com/mongodb/mongo/refs/heads/master/LICENSE-Community.txt",
+          "comment": "Server Side Public License 1.0",
+          "type": "license"
+        },
+        {
+          "url": "https://www.mongodb.com/products/self-managed/community-edition",
+          "comment": "MongoDB Community Edition is self-managed and can be hosted locally or in the cloud.",
+          "type": "website"
+        },
+        {
+          "url": "https://www.mongodb.com/products/self-managed/enterprise-advanced",
+          "comment": "MongoDB Enterprise Advanced has powerful tools for automation, operations, and security in self-managed environments.",
+          "type": "website"
+        },
+        {
+          "url": "https://www.mongodb.com/docs/manual/release-notes/",
+          "type": "release-notes"
+        },
+        {
+          "url": "https://github.com/mongodb/mongo",
+          "type": "vcs"
+        }
+      ]
+    },
+    {
       "type": "library",
       "bom-ref": "pkg:github/nlohmann/json@v3.11.3",
       "author": "Niels Lohmann",
@@ -2706,7 +2748,7 @@
       ]
     },
     {
-      "ref": "pkg:github/percona/percona-server-mongodb@v8.3",
+      "ref": "pkg:github/mongodb/mongo@v8.3",
       "dependsOn": [
         "pkg:deb/debian/firefox-esr@140.9.0esr-1?arch=source",
         "pkg:generic/intel/IntelRDFPMathLib@2.0.1",
@@ -2755,10 +2797,7 @@
         "pkg:github/veorq/siphash@32d067603b93b47828700880649198e0bfbbcffa",
         "pkg:github/wiredtiger/wiredtiger@12.0.0",
         "pkg:pypi/ocspbuilder@0.10.2",
-        "pkg:pypi/ocspresponder@0.5.0",
-        "pkg:github/libarchive/libarchive@v3.8.4",
-        "pkg:github/aws/aws-sdk-cpp@1.11.471",
-        "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d"
+        "pkg:pypi/ocspresponder@0.5.0"
       ]
     },
     {
@@ -2784,6 +2823,15 @@
     {
       "ref": "pkg:github/pcre2project/pcre2@pcre2-10.40",
       "dependsOn": []
+    },
+    {
+      "ref": "pkg:github/percona/percona-server-mongodb@v8.3",
+      "dependsOn": [
+        "pkg:github/aws/aws-sdk-cpp@1.11.471",
+        "pkg:github/libarchive/libarchive@v3.8.4",
+        "pkg:github/mongodb/mongo@v8.3",
+        "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d"
+      ]
     },
     {
       "ref": "pkg:github/protocolbuffers/protobuf@v6.31.1",

--- a/sbom.json
+++ b/sbom.json
@@ -1876,6 +1876,16 @@
       "group": "mongodb",
       "name": "mongodb/mongo",
       "version": "v8.3",
+      "description": "A source-available NoSQL document-oriented database",
+      "scope": "required",
+      "licenses": [
+        {
+          "license": {
+            "id": "SSPL-1.0"
+          }
+        }
+      ],
+      "copyright": "MongoDB, Inc.",
       "cpe": "cpe:2.3:a:mongodb:mongodb:8.3.*:*:*:*:*:*:*:*",
       "purl": "pkg:github/mongodb/mongo@v8.3",
       "externalReferences": [
@@ -1901,6 +1911,27 @@
         {
           "url": "https://github.com/mongodb/mongo",
           "type": "vcs"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "src/mongo"
+          }
+        ]
+      },
+      "properties": [
+        {
+          "name": "emits_persisted_data",
+          "value": "true"
+        },
+        {
+          "name": "internal:team_responsible",
+          "value": "MongoDB Team"
+        },
+        {
+          "name": "mdb_first_party",
+          "value": "true"
         }
       ]
     },

--- a/sbom.json
+++ b/sbom.json
@@ -406,6 +406,55 @@
     },
     {
       "type": "library",
+      "name": "AWS SDK for C++",
+      "version": "1.11.471",
+      "bom-ref": "pkg:github/aws/aws-sdk-cpp@1.11.471",
+      "purl": "pkg:github/aws/aws-sdk-cpp@1.11.471",
+      "supplier": {
+        "name": "AWS",
+        "url": [
+          "https://aws.amazon.com/sdk-for-cpp/"
+        ]
+      },
+      "author": "Amazon.com, Inc.",
+      "group": "amazon.opensource",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "copyright": "Amazon.com, Inc. or its affiliates",
+      "properties": [
+        {
+          "name": "internal:team_responsible",
+          "value": "Percona Server for MongoDB Team"
+        },
+        {
+          "name": "emits_persisted_data",
+          "value": "false"
+        },
+        {
+          "name": "info_link",
+          "value": "https://aws.amazon.com/sdk-for-cpp/"
+        },
+        {
+          "name": "import_script_path",
+          "value": "src/third_party/aws-sdk-cpp/scripts/import.sh"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "src/third_party/aws-sdk-cpp"
+          }
+        ]
+      },
+      "scope": "required"
+    },
+    {
+      "type": "library",
       "bom-ref": "pkg:github/boostorg/boost@boost-1.88.0",
       "supplier": {
         "name": "The Boost Foundation",
@@ -1504,6 +1553,57 @@
     },
     {
       "type": "library",
+      "name": "libarchive",
+      "version": "3.8.4",
+      "bom-ref": "pkg:github/libarchive/libarchive@v3.8.4",
+      "purl": "pkg:github/libarchive/libarchive@v3.8.4",
+      "supplier": {
+        "name": "libarchive",
+        "url": [
+          "https://www.libarchive.org"
+        ]
+      },
+      "author": "Tim Kientzle and contributors",
+      "group": "libarchive",
+      "description": "Multi-format archive and compression library",
+      "licenses": [
+        {
+          "license": {
+            "name": "A mix of BSD-2-Clause and others",
+            "url": "https://raw.githubusercontent.com/libarchive/libarchive/refs/tags/v3.8.4/COPYING"
+          }
+        }
+      ],
+      "copyright": "Copyright (C) Tim Kientzle",
+      "properties": [
+        {
+          "name": "internal:team_responsible",
+          "value": "Percona Server for MongoDB Team"
+        },
+        {
+          "name": "emits_persisted_data",
+          "value": "true"
+        },
+        {
+          "name": "info_link",
+          "value": "https://www.libarchive.org"
+        },
+        {
+          "name": "import_script_path",
+          "value": "src/third_party/libarchive/scripts/import.sh"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "src/third_party/libarchive"
+          }
+        ]
+      },
+      "scope": "required"
+    },
+    {
+      "type": "library",
       "bom-ref": "pkg:github/libtom/libtomcrypt@v1.18.2",
       "supplier": {
         "name": "LibTom Projects",
@@ -1835,6 +1935,53 @@
         ]
       },
       "properties": []
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d",
+      "supplier": {
+        "name": "OpenKMIP"
+      },
+      "author": "Peter Hamilton",
+      "group": "OpenKMIP",
+      "name": "libkmip",
+      "version": "66119416e2c89ab182343900418cecafe02b6e8d",
+      "description": "A C implementation of the KMIP specification",
+      "licenses": [
+        {
+          "expression": "Apache-2.0 OR BSD-3-Clause"
+        }
+      ],
+      "copyright": "Copyright (C) Peter Hamilton",
+      "purl": "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d",
+      "externalReferences": [
+        {
+          "url": "https://github.com/OpenKMIP/libkmip.git",
+          "type": "distribution"
+        }
+      ],
+      "properties": [
+        {
+          "name": "internal:team_responsible",
+          "value": "Percona Server for MongoDB Team"
+        },
+        {
+          "name": "emits_persisted_data",
+          "value": "false"
+        },
+        {
+          "name": "import_script_path",
+          "value": "src/third_party/libkmip/scripts/import.sh"
+        }
+      ],
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "src/third_party/libkmip"
+          }
+        ]
+      },
+      "scope": "required"
     },
     {
       "type": "library",
@@ -2392,153 +2539,6 @@
           "value": "false"
         }
       ]
-    },
-    {
-      "type": "library",
-      "name": "libarchive",
-      "version": "3.8.4",
-      "bom-ref": "pkg:github/libarchive/libarchive@v3.8.4",
-      "purl": "pkg:github/libarchive/libarchive@v3.8.4",
-      "supplier": {
-        "name": "libarchive",
-        "url": [
-          "https://www.libarchive.org"
-        ]
-      },
-      "author": "Tim Kientzle and contributors",
-      "group": "libarchive",
-      "description": "Multi-format archive and compression library",
-      "licenses": [
-        {
-          "license": {
-            "name": "A mix of BSD-2-Clause and others",
-            "url": "https://raw.githubusercontent.com/libarchive/libarchive/refs/tags/v3.8.4/COPYING"
-          }
-        }
-      ],
-      "copyright": "Copyright (C) Tim Kientzle",
-      "properties": [
-        {
-          "name": "internal:team_responsible",
-          "value": "Percona Server for MongoDB Team"
-        },
-        {
-          "name": "emits_persisted_data",
-          "value": "true"
-        },
-        {
-          "name": "info_link",
-          "value": "https://www.libarchive.org"
-        },
-        {
-          "name": "import_script_path",
-          "value": "src/third_party/libarchive/scripts/import.sh"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "src/third_party/libarchive"
-          }
-        ]
-      },
-      "scope": "required"
-    },
-    {
-      "type": "library",
-      "name": "AWS SDK for C++",
-      "version": "1.11.471",
-      "bom-ref": "pkg:github/aws/aws-sdk-cpp@1.11.471",
-      "purl": "pkg:github/aws/aws-sdk-cpp@1.11.471",
-      "supplier": {
-        "name": "AWS",
-        "url": [
-          "https://aws.amazon.com/sdk-for-cpp/"
-        ]
-      },
-      "author": "Amazon.com, Inc.",
-      "group": "amazon.opensource",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "copyright": "Amazon.com, Inc. or its affiliates",
-      "properties": [
-        {
-          "name": "internal:team_responsible",
-          "value": "Percona Server for MongoDB Team"
-        },
-        {
-          "name": "emits_persisted_data",
-          "value": "false"
-        },
-        {
-          "name": "info_link",
-          "value": "https://aws.amazon.com/sdk-for-cpp/"
-        },
-        {
-          "name": "import_script_path",
-          "value": "src/third_party/aws-sdk-cpp/scripts/import.sh"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "src/third_party/aws-sdk-cpp"
-          }
-        ]
-      },
-      "scope": "required"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d",
-      "supplier": {
-        "name": "OpenKMIP"
-      },
-      "author": "Peter Hamilton",
-      "group": "OpenKMIP",
-      "name": "libkmip",
-      "version": "66119416e2c89ab182343900418cecafe02b6e8d",
-      "description": "A C implementation of the KMIP specification",
-      "licenses": [
-        {
-          "expression": "Apache-2.0 OR BSD-3-Clause"
-        }
-      ],
-      "copyright": "Copyright (C) Peter Hamilton",
-      "purl": "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d",
-      "externalReferences": [
-        {
-          "url": "https://github.com/OpenKMIP/libkmip.git",
-          "type": "distribution"
-        }
-      ],
-      "properties": [
-        {
-          "name": "internal:team_responsible",
-          "value": "Percona Server for MongoDB Team"
-        },
-        {
-          "name": "emits_persisted_data",
-          "value": "false"
-        },
-        {
-          "name": "import_script_path",
-          "value": "src/third_party/libkmip/scripts/import.sh"
-        }
-      ],
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "src/third_party/libkmip"
-          }
-        ]
-      },
-      "scope": "required"
     }
   ],
   "dependencies": [
@@ -2573,6 +2573,12 @@
     {
       "ref": "pkg:github/arximboldi/immer@v0.9.1",
       "dependsOn": []
+    },
+    {
+      "ref": "pkg:github/aws/aws-sdk-cpp@1.11.471",
+      "dependsOn": [
+        "pkg:github/madler/zlib@v1.3.1"
+      ]
     },
     {
       "ref": "pkg:github/boostorg/boost@boost-1.88.0",
@@ -2667,6 +2673,10 @@
       "dependsOn": []
     },
     {
+      "ref": "pkg:github/libarchive/libarchive@v3.8.4",
+      "dependsOn": []
+    },
+    {
       "ref": "pkg:github/libtom/libtomcrypt@v1.18.2",
       "dependsOn": []
     },
@@ -2753,6 +2763,10 @@
       "dependsOn": []
     },
     {
+      "ref": "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d",
+      "dependsOn": []
+    },
+    {
       "ref": "pkg:github/open-telemetry/opentelemetry-cpp@v1.24.0",
       "dependsOn": []
     },
@@ -2798,20 +2812,6 @@
     },
     {
       "ref": "pkg:pypi/ocspresponder@0.5.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:github/libarchive/libarchive@v3.8.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:github/aws/aws-sdk-cpp@1.11.471",
-      "dependsOn": [
-        "pkg:github/madler/zlib@v1.3.1"
-      ]
-    },
-    {
-      "ref": "pkg:github/OpenKMIP/libkmip@66119416e2c89ab182343900418cecafe02b6e8d",
       "dependsOn": []
     }
   ]

--- a/sbom.json
+++ b/sbom.json
@@ -25,6 +25,13 @@
       "group": "percona",
       "name": "percona-server-mongodb",
       "version": "v8.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "SSPL-1.0"
+          }
+        }
+      ],
       "cpe": "cpe:2.3:a:percona:percona-server-mongodb:8.3.*:*:*:*:*:*:*:*",
       "purl": "pkg:github/percona/percona-server-mongodb@v8.3",
       "externalReferences": [

--- a/sbom.json
+++ b/sbom.json
@@ -2657,7 +2657,7 @@
     {
       "ref": "pkg:github/aws/aws-sdk-cpp@1.11.471",
       "dependsOn": [
-        "pkg:github/madler/zlib@v1.3.1"
+        "pkg:github/madler/zlib@1.3.2"
       ]
     },
     {


### PR DESCRIPTION
The PR:
- restores the alphabetical sorting of components and dependencies
- adds a SPDX licesne id to PSMDB
- adds PSMDB dependency on MongoDB
- fixes `zlib` dependency reference for `aws-sdk-cpp`

It can be easier to review the PR commit-by-commit.