### PR TITLE
PSMDB-2112: fix build-and-test after the 'ff54e20bb15' merge (uv migration + flaky span test)

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,29 +18,28 @@ runs:
       with:
         python-version: "3.13"
         cache: "pip"
-        cache-dependency-path: poetry.lock
+        cache-dependency-path: uv.lock
 
     - name: Configure Python
       shell: bash
       run: |
-        python -m pip install -U pip "virtualenv>=20.35,<21" poetry==2.0.0
-        poetry config virtualenvs.create true
-        poetry config virtualenvs.in-project true
+        python -m pip install -U pip "uv==$(cat buildscripts/uv_version.txt)"
 
-    - name: Poetry virtualenv cache
+    - name: Python virtualenv cache
       uses: actions/cache@v4
       id: venv
       with:
         path: .venv
-        key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
+        key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('uv.lock') }}
 
     - name: Install Python deps
       shell: bash
       if: steps.venv.outputs.cache-hit != 'true'
       run: |
-        poetry install --no-root --without export
+        uv sync --locked --all-groups --no-group export --no-install-project \
+          --python "${{ steps.setup-python.outputs.python-path }}"
 
     - name: Install Bazel
       shell: bash
       run: |
-        poetry run python buildscripts/install_bazel.py
+        uv run --no-sync python buildscripts/install_bazel.py

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -618,7 +618,7 @@ jobs:
             //:install-dbtest
 
       # Run the resmoke dbtest suite locally against the freshly built binary.
-      # resmoke runs via the poetry venv set up by setup-env. The suite selector
+      # resmoke runs via the uv venv set up by setup-env. The suite selector
       # is empty; resmoke enumerates sub-suites from `dbtest --list`. One resmoke
       # job per CPU. Tee the console to a file (pipefail so resmoke's exit, not
       # tee's, decides the step result) for the failure-artifact upload.
@@ -647,7 +647,7 @@ jobs:
             echo "ERROR: dbtest binary not found under the Bazel output base after build" >&2
             exit 1
           fi
-          poetry run python buildscripts/resmoke.py run \
+          uv run --no-sync python buildscripts/resmoke.py run \
             --suites=dbtest \
             --dbtest="$DBTEST" \
             --jobs="$(nproc)" \

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -193,7 +193,7 @@ jobs:
             ls -la bazel-bin/src/mongo/tools/mongo_tidy_checks || true
             exit 1
           fi
-          CLANG_TIDY="$(poetry run python buildscripts/mongo_toolchain.py clang-tidy)"
+          CLANG_TIDY="$(uv run --no-sync python buildscripts/mongo_toolchain.py clang-tidy)"
           echo "Using clang-tidy: $CLANG_TIDY"
           echo "Using clang-tidy plugin: $TIDY_CHECKS_LIB"
           "$CLANG_TIDY" \

--- a/jstests/ldapauthz/BUILD.bazel
+++ b/jstests/ldapauthz/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@poetry//:dependencies.bzl", "dependency")
+load("//bazel/uv:defs.bzl", "dependency")
 load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
 load("//bazel/resmoke:resmoke.bzl", "resmoke_suite_test")
 

--- a/src/mongo/otel/traces/span/span_telemetry_context_impl_test.cpp
+++ b/src/mongo/otel/traces/span/span_telemetry_context_impl_test.cpp
@@ -3,13 +3,13 @@
 
 #include "mongo/otel/traces/span/span_telemetry_context_impl.h"
 
-#include "mongo/platform/atomic_word.h"
 #include "mongo/platform/random.h"
 #include "mongo/stdx/thread.h"
 #include "mongo/unittest/unittest.h"
 
 #include <memory>
 #include <span>
+#include <thread>
 
 #include <opentelemetry/trace/noop.h>
 #include <opentelemetry/trace/span_context.h>
@@ -72,23 +72,31 @@ TEST_F(SpanTelemetryContextImplTest, HasActiveTraceReturnsTrueWhenSpanIsSet) {
 
 // TSAN regression for concurrent setSpan writes vs getSpan/hasActiveTrace reads of _ctx.
 // No ASSERT/EXPECT by design: correctness is enforced by ThreadSanitizer detecting a data race.
+//
+// The writer is bounded to a fixed iteration count rather than looping until a stop flag. Each
+// setSpan prepends a node to the underlying OpenTelemetry Context's persistent list (it is never
+// pruned), so an unbounded writer accumulates a chain whose recursive destruction at teardown
+// overflows the stack -- a non-deterministic crash whose likelihood scales with how many
+// iterations the writer wins. A fixed, modest count keeps the chain small enough to tear down
+// safely while still exercising concurrent access; both loops yield each iteration so the writes
+// and reads interleave rather than one loop draining before the other starts.
 TEST_F(SpanTelemetryContextImplTest, ConcurrentSetSpanAndGetSpan) {
-    constexpr int kReadIterations = 10000;
+    constexpr int kIterations = 10000;
     SpanTelemetryContextImpl impl(getSpanContext());
-    AtomicWord<bool> stop{false};
 
     stdx::thread writer([&] {
-        while (!stop.load()) {
+        for (int i = 0; i < kIterations; ++i) {
             impl.setSpan(makeValidSpan());
+            std::this_thread::yield();
         }
     });
 
-    for (int i = 0; i < kReadIterations; ++i) {
+    for (int i = 0; i < kIterations; ++i) {
         (void)impl.getSpan();
         (void)impl.hasActiveTrace();
+        std::this_thread::yield();
     }
 
-    stop.store(true);
     writer.join();
 }
 


### PR DESCRIPTION
Both changes are needed to get `build-and-test` green again after the upstream
merge in percona/percona-server-mongodb#2065

## 1. Migrate Percona CI from Poetry to uv

Upstream SERVER-126500 (in that merge) replaced Poetry/rules_poetry with
uv/rules_pycross, deleting `poetry.lock` and moving dependency groups to PEP 735.
Two Percona-owned spots still referenced the now-removed `@poetry`:

- CI ran `poetry install --no-root --without export`, which aborted with
  `Group(s) not found: export` and broke the build.
- `jstests/ldapauthz/BUILD.bazel` still did
  `load("@poetry//:dependencies.bzl", "dependency")` to pull in `ldaptor`. With
  `@poetry` gone, target-pattern loading failed (`The repository '@poetry' could
  not be resolved`) and the `jstests` job errored out before any test ran
  ([failing run](https://github.com/plebioda/percona-server-mongodb/actions/runs/30451360280/job/90582990400)).

Fixes:
- Migrated the three Percona-owned CI files to
  `uv sync --locked --all-groups --no-install-project` (mirroring upstream):
  `.github/actions/setup-env/action.yml`, `.github/workflows/build-and-test.yml`,
  `.github/workflows/clang-tidy.yml`.
- Switched `jstests/ldapauthz/BUILD.bazel` to
  `load("//bazel/uv:defs.bzl", "dependency")` — same `dependency(name, group=...)`
  API, resolves `ldaptor` via the `@pypi` hub (already locked in `uv.lock`).

## 2. Fix flaky segfault in the span telemetry context test

With the build fixed, the `unittests` job then failed intermittently in
`//src/mongo/otel/traces/span:span_telemetry_context_impl_test`, e.g.:

- https://github.com/plebioda/percona-server-mongodb/actions/runs/30383513142/job/90371811302
- https://github.com/plebioda/percona-server-mongodb/actions/runs/30432846282/job/90517915312

`ConcurrentSetSpanAndGetSpan` ran its writer thread in an unbounded `while (!stop)`
loop. Each `setSpan` prepends a node to the OpenTelemetry `Context`'s persistent list
(never pruned), so the writer built a chain of hundreds of thousands of nodes whose
recursive destruction at teardown overflowed the stack — a `SIGSEGV` in tcmalloc,
confirmed by a captured core with a >200k-frame teardown stack. The crash rate scaled
with the writer's head start, so it surfaced as a low-rate flake on the busy RBE
workers.

Fix: bound the writer to a fixed iteration count instead of looping until a stop flag,
and yield each iteration in both loops so the reads and writes still interleave for
TSAN. The chain stays small enough to tear down safely. Verified 2000/2000 passing on
the buildfarm.

## Notes

- The unbounded loop was introduced upstream by SERVER-131480 (mongodb/mongo#58672,
  GitOrigin-RevId `1f0353437d78a490c239218d1e4756fbeb18e623`)
- Latent smell: `setSpan` grows the `Context` unboundedly; no current caller hits it in
  a loop, so this only fixes the test. A separate ticket could harden the class itself.
