### PR TITLE
PSMDB-2113: add `/mergai fast-forward` and surface approval gates as PR checks

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -15,6 +15,20 @@
 #   - Maintains clean, linear git history
 #   - Avoids unnecessary merge commits
 #   - Makes git log and bisect easier to work with
+#
+# The work is split into two jobs so the approval gate is visible on the PR:
+#   * fast-forward-check (ungated) validates the request and publishes a pending
+#     "Fast-Forward Merge" commit status on the PR head, so the checks section
+#     shows the job waiting while a required reviewer approves the deployment.
+#     (An issue_comment run is attributed to the default branch, so without this
+#     the environment approval gate would be invisible on the PR.)
+#   * fast-forward (push-approve environment) performs the merge after approval
+#     and resolves that status to success/failure.
+#
+# Commit statuses are published with the default GITHUB_TOKEN (github-actions[bot])
+# so the "Fast-Forward Merge" check shares the same icon as the mergai bot checks.
+# The App token is used only where it is actually needed: reading the PR /
+# commenter permission, posting comments, and pushing to the protected base ref.
 # =============================================================================
 name: Fast-Forward Merge
 
@@ -24,26 +38,31 @@ on:
     types: [created]
 
 jobs:
-  fast-forward:
-    name: Fast-Forward Merge
-    # Only run if:
-    # 1. Comment is on a pull request (not an issue)
-    # 2. Comment body contains '/fast-forward'
+  # ---------------------------------------------------------------------------
+  # Gate: validate the request and surface it on the PR *before* approval.
+  # ---------------------------------------------------------------------------
+  # Runs immediately (ungated) when the comment arrives. It validates the request
+  # (open / same-repo / commenter permission) and publishes a pending
+  # "Fast-Forward Merge" status on the PR head SHA so the PR shows the job waiting
+  # for approval. An invalid request gets a failure status + explanatory comment
+  # here and leaves proceed unset, so the merge job is skipped.
+  fast-forward-check:
+    name: Fast-Forward Merge (gate)
     if: |
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/fast-forward')
     runs-on: ubuntu-latest
-    # 'push-approve' environment: required-reviewer approval before this job can
-    # push to a protected ref (fast-forward advances master). The /fast-forward
-    # comment can come from anyone, so the approval gate is the trust boundary
-    # (the in-job permission check below is the second layer). Carries no
-    # secrets beyond the repo-level App token.
-    environment: push-approve
-
+    permissions:
+      statuses: write # publish the "Fast-Forward Merge" status with the default token
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+      head_ref: ${{ steps.gate.outputs.head_ref }}
+      base_ref: ${{ steps.gate.outputs.base_ref }}
     steps:
-      # --- Authentication ---
-      # Generate a GitHub App token for elevated permissions.
-      # App tokens allow pushing to protected branches and bypass branch protection rules.
+      # App token: getCollaboratorPermissionLevel needs push access, and the
+      # rejection comment is posted as the bot. The commit statuses below use the
+      # default GITHUB_TOKEN instead, so their icon matches the mergai checks.
       - name: Create GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -51,11 +70,13 @@ jobs:
           app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
 
-      # --- Gather PR Information ---
-      # Fetch PR details since issue_comment events don't include full PR data.
-      # We need: head SHA (for merge), head/base refs (branch names), and state.
-      - name: Get PR details
-        id: pr
+      # Fetch PR details (issue_comment events don't include full PR data) and
+      # validate state / fork / commenter permission. On an invalid request it
+      # posts an explanatory comment and records proceed=false; the status itself
+      # is published by the steps below (default token). head_sha is emitted even
+      # on rejection so the failure status can be attached to the PR head.
+      - name: Validate request
+        id: gate
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -66,67 +87,120 @@ jobs:
               pull_number: context.issue.number
             });
             core.setOutput('head_sha', pr.data.head.sha);
-            core.setOutput('head_ref', pr.data.head.ref);
-            core.setOutput('base_ref', pr.data.base.ref);
-            core.setOutput('state', pr.data.state);
-            core.setOutput('head_repo', pr.data.head.repo.full_name);
-            core.setOutput('base_repo', pr.data.base.repo.full_name);
-
-      # --- Validation: PR State ---
-      # Prevent merging closed or already-merged PRs
-      - name: Check PR state
-        if: steps.pr.outputs.state != 'open'
-        run: |
-          echo "::error::Pull request is not open (state: ${{ steps.pr.outputs.state }})"
-          exit 1
-
-      # --- Validation: Fork PR ---
-      # Fast-forward merge is not supported for PRs from forks because the head
-      # branch ref doesn't exist in the origin repository
-      - name: Check fork PR
-        if: steps.pr.outputs.head_repo != steps.pr.outputs.base_repo
-        run: |
-          echo "::error::Fast-forward merge is not supported for PRs from forks. The head branch must be in the same repository."
-          echo "Head repo: ${{ steps.pr.outputs.head_repo }}"
-          echo "Base repo: ${{ steps.pr.outputs.base_repo }}"
-          exit 1
-
-      # --- Validation: User Permissions ---
-      # Verify the commenter has sufficient repository permissions.
-      # Only users with write, maintain, or admin access can trigger merges.
-      - name: Check merge permission
-        id: check-permission
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const permission = await github.rest.repos.getCollaboratorPermissionLevel({
+            const reject = async (msg) => {
+              core.setOutput('proceed', 'false');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Fast-forward merge cannot proceed.\n\n${msg}`
+              });
+            };
+            // Prevent merging closed or already-merged PRs.
+            if (pr.data.state !== 'open') {
+              return reject(`Pull request is not open (state: ${pr.data.state}).`);
+            }
+            // Fork PRs: the head branch ref doesn't exist in the origin repo.
+            if (pr.data.head.repo.full_name !== pr.data.base.repo.full_name) {
+              return reject('Fast-forward merge is not supported for PRs from forks. The head branch must be in the same repository.');
+            }
+            // Only write/maintain/admin collaborators may advance the base ref.
+            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               username: context.actor
             });
-            const level = permission.data.permission;
-            const canMerge = ['admin', 'maintain', 'write'].includes(level);
-            core.setOutput('can_merge', canMerge);
-            if (!canMerge) {
-              core.setFailed(`User ${context.actor} does not have permission to merge (permission: ${level})`);
+            if (!['admin', 'maintain', 'write'].includes(perm.data.permission)) {
+              return reject(`User ${context.actor} does not have permission to merge (permission: ${perm.data.permission}).`);
             }
+            // Valid request: let the merge job run.
+            core.setOutput('proceed', 'true');
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('base_ref', pr.data.base.ref);
 
-      # --- Status Update: Pending ---
-      # Set commit status to 'pending' to indicate merge is in progress.
-      # This provides visual feedback in the PR UI.
-      - name: Set status pending
+      # Valid request: publish the pending "Fast-Forward Merge" check with the
+      # default token (github-actions[bot]) so its icon matches the mergai checks.
+      # Resolved by the merge job.
+      - name: Publish pending status (awaiting approval)
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ steps.pr.outputs.head_sha }}',
+              sha: '${{ steps.gate.outputs.head_sha }}',
               state: 'pending',
               context: 'Fast-Forward Merge',
-              description: 'Attempting fast-forward merge...',
+              description: 'Waiting for required-reviewer approval...',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+      # Invalid request: publish a failure status (default token) to match the
+      # explanatory comment the validate step already posted.
+      - name: Publish rejection status
+        if: steps.gate.outputs.proceed == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.gate.outputs.head_sha }}',
+              state: 'failure',
+              context: 'Fast-Forward Merge',
+              description: 'Request rejected; see comment',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+  # ---------------------------------------------------------------------------
+  # Merge: perform the fast-forward *after* approval.
+  # ---------------------------------------------------------------------------
+  fast-forward:
+    name: Fast-Forward Merge
+    # Runs only when the gate validated the request and published the pending
+    # check. The push-approve environment then holds this job at "waiting for
+    # approval" -- visible on the PR via that pending status -- until a required
+    # reviewer approves. This job resolves the status to success/failure.
+    needs: fast-forward-check
+    if: needs.fast-forward-check.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    # 'push-approve' environment: required-reviewer approval before this job can
+    # push to a protected ref (fast-forward advances master). The /fast-forward
+    # comment can come from anyone, so the approval gate is the trust boundary
+    # (the gate's permission check is the second layer). Carries no secrets
+    # beyond the repo-level App token.
+    environment: push-approve
+    permissions:
+      statuses: write # resolve the "Fast-Forward Merge" status with the default token
+
+    steps:
+      # App token for pushing to the protected base ref (bypasses branch
+      # protection). The commit statuses use the default GITHUB_TOKEN instead, so
+      # their icon matches the mergai checks.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+
+      # Approval was granted: flip the pending "Fast-Forward Merge" check from
+      # "waiting for approval" to "running".
+      - name: Set status running
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.fast-forward-check.outputs.head_sha }}',
+              state: 'pending',
+              context: 'Fast-Forward Merge',
+              description: 'Approved; performing fast-forward merge...',
               target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
 
@@ -151,12 +225,12 @@ jobs:
       # 3. Pushes the updated base branch
       - name: Fast-forward merge
         id: merge
+        env:
+          BASE_REF: ${{ needs.fast-forward-check.outputs.base_ref }}
+          HEAD_REF: ${{ needs.fast-forward-check.outputs.head_ref }}
+          HEAD_SHA: ${{ needs.fast-forward-check.outputs.head_sha }}
         run: |
           set -e
-
-          BASE_REF="${{ steps.pr.outputs.base_ref }}"
-          HEAD_REF="${{ steps.pr.outputs.head_ref }}"
-          HEAD_SHA="${{ steps.pr.outputs.head_sha }}"
 
           echo "Base branch: $BASE_REF"
           echo "Head branch: $HEAD_REF"
@@ -197,7 +271,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `Fast-forward merge completed successfully.\n\nMerged \`${{ steps.pr.outputs.head_ref }}\` into \`${{ steps.pr.outputs.base_ref }}\` at commit ${{ steps.pr.outputs.head_sha }}.`
+              body: `Fast-forward merge completed successfully.\n\nMerged \`${{ needs.fast-forward-check.outputs.head_ref }}\` into \`${{ needs.fast-forward-check.outputs.base_ref }}\` at commit ${{ needs.fast-forward-check.outputs.head_sha }}.`
             });
 
       # Update commit status to 'success'
@@ -205,12 +279,12 @@ jobs:
         if: success()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ steps.pr.outputs.head_sha }}',
+              sha: '${{ needs.fast-forward-check.outputs.head_sha }}',
               state: 'success',
               context: 'Fast-Forward Merge',
               description: 'Fast-forward merge completed successfully',
@@ -238,14 +312,34 @@ jobs:
         if: failure()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ steps.pr.outputs.head_sha }}',
+              sha: '${{ needs.fast-forward-check.outputs.head_sha }}',
               state: 'failure',
               context: 'Fast-Forward Merge',
               description: 'Fast-forward merge failed',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+      # --- Cancellation Handling ---
+      # On cancellation (manual cancel / timeout) neither the success nor failure
+      # step runs, which would leave the pending status stuck on the PR head.
+      # Resolve it to 'error' so the check doesn't hang.
+      - name: Set status cancelled
+        if: cancelled()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.fast-forward-check.outputs.head_sha }}',
+              state: 'error',
+              context: 'Fast-Forward Merge',
+              description: 'Fast-forward merge was cancelled',
               target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -859,19 +859,22 @@ jobs:
             -f description="handle: ${HANDLE_STATE:-n/a}" \
             || echo "::warning::could not publish ci-handle status"
 
-  # Handle code-review feedback on a mergai PR. Triggered by:
-  #   * a `/mergai review fix` comment on the PR (issue_comment), or
-  #   * a review submitted as "Changes requested" (pull_request_review).
-  # Runs the agent over the PR's unresolved review threads, commits + pushes
-  # the fixes inline on the PR branch, and posts a reply per thread. Mirrors
-  # the ci-handle routing for a review branch: the fix rides as another commit
-  # in the existing PR; nothing is folded here (that is finalize-only).
-  review-handle:
-    # The issue_comment trigger fires on every PR/issue comment in the repo, so
-    # the command filter lives here; the head-branch (mergai-only) check can't
-    # be expressed for issue_comment in `if:` (no head ref in the payload) and
-    # is enforced in the "Resolve PR" step below. pull_request_review carries
-    # the head ref, so we scope it to mergai/* and "Changes requested" up front.
+  # Gate + surface the `/mergai review fix` request on the PR. review-handle is
+  # gated by the ai-approve environment; for the issue_comment trigger the run is
+  # attributed to the default branch, so the approval gate would be invisible on
+  # the PR (the pull_request_review trigger is already PR-associated). This
+  # ungated gate publishes a pending "mergai / review-fix" commit status on the
+  # PR head SHA so the checks section shows the job waiting for approval (the
+  # ci-gate/ci-handle idiom). It resolves the PR from whichever event fired and
+  # confirms it is a mergai PR; review-handle runs only when this gate sets
+  # proceed=true and resolves the pending check to success/failure.
+  #
+  # The issue_comment trigger fires on every PR/issue comment in the repo, so the
+  # command filter lives in `if:`; the head-branch (mergai-only) check can't be
+  # expressed for issue_comment there (no head ref in the payload) and is done in
+  # the resolve step below. pull_request_review carries the head ref, so it is
+  # scoped to mergai/* and "Changes requested" up front.
+  review-gate:
     if: >-
       (github.event_name == 'pull_request_review'
         && github.event.review.state == 'changes_requested'
@@ -879,12 +882,112 @@ jobs:
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
         && contains(github.event.comment.body, '/mergai review fix'))
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write # publish the "mergai / review-fix" commit status
+    outputs:
+      proceed: ${{ steps.pr.outputs.proceed }}
+      number: ${{ steps.pr.outputs.number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      cutoff: ${{ steps.pr.outputs.cutoff }}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+
+      # Resolve the PR from whichever event fired and confirm it is a same-repo
+      # mergai PR. The issue_comment payload has no head ref, so we look it up; a
+      # fork PR (with an explanatory comment) or a non-mergai PR leaves proceed
+      # unset, so review-handle is skipped and no pending check is published.
+      # CUTOFF pins the run to the comment set as it stood when it was triggered
+      # (the review's submission time, or the comment's creation time), so a
+      # comment added while the run waits for approval can't be pulled in.
+      - name: Resolve and validate PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            PR_NUMBER='${{ github.event.pull_request.number }}'
+            HEAD_REF='${{ github.event.pull_request.head.ref }}'
+            HEAD_SHA='${{ github.event.pull_request.head.sha }}'
+            CROSS_REPO='${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}'
+            CUTOFF='${{ github.event.review.submitted_at }}'
+          else
+            PR_NUMBER='${{ github.event.issue.number }}'
+            read -r HEAD_REF HEAD_SHA CROSS_REPO < <(gh pr view "$PR_NUMBER" \
+              --json headRefName,headRefOid,isCrossRepository \
+              --jq '"\(.headRefName) \(.headRefOid) \(.isCrossRepository)"')
+            CUTOFF='${{ github.event.comment.created_at }}'
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR_NUMBER (head: $HEAD_REF, head_sha: $HEAD_SHA, cross_repo: $CROSS_REPO, cutoff: $CUTOFF)"
+          # Fork PRs: the head branch does not exist in this repo, so a later
+          # checkout/push would fail. Reject before publishing a pending check or
+          # queuing the secret-bearing review-handle job for approval -- a fork
+          # can name its head branch mergai/*, so the mergai check below is not a
+          # sufficient guard on its own.
+          if [ "$CROSS_REPO" = "true" ]; then
+            echo "PR #$PR_NUMBER is a fork (cross-repository) PR; /mergai review fix is not supported."
+            gh pr comment "$PR_NUMBER" --body \
+              "\`/mergai review fix\` is not supported for pull requests from forks: the head branch must live in this repository."
+            exit 0
+          fi
+          case "$HEAD_REF" in
+            mergai/*) ;;
+            *)
+              echo "PR #$PR_NUMBER is not a mergai PR; skipping."
+              exit 0 ;;
+          esac
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      # Surface the request as a pending "mergai / review-fix" check so the PR
+      # shows the job waiting while approval is pending. Resolved by review-handle.
+      - name: Publish pending status (awaiting approval)
+        if: steps.pr.outputs.proceed == 'true'
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          gh api "repos/$GH_REPO/statuses/$HEAD_SHA" \
+            -f state="pending" \
+            -f context="mergai / review-fix" \
+            -f target_url="$RUN_URL" \
+            -f description="waiting for required-reviewer approval" \
+            || echo "::warning::could not publish pending review-fix status"
+
+  # Handle code-review feedback on a mergai PR. Triggered by:
+  #   * a `/mergai review fix` comment on the PR (issue_comment), or
+  #   * a review submitted as "Changes requested" (pull_request_review).
+  # Runs the agent over the PR's unresolved review threads, commits + pushes
+  # the fixes inline on the PR branch, and posts a reply per thread. Mirrors
+  # the ci-handle routing for a review branch: the fix rides as another commit
+  # in the existing PR; nothing is folded here (that is finalize-only). Runs only
+  # after review-gate validated the request (proceed=true) and published the
+  # pending PR check; this job resolves that check to success/failure.
+  review-handle:
+    needs: review-gate
+    if: needs.review-gate.outputs.proceed == 'true'
     # 'ai-approve' = AI-agent secrets + required-reviewer approval. The comment/
     # review trigger fires for any user, so this stays gated: an untrusted
     # commenter cannot start the secret-bearing job without a maintainer's
     # approval. The CLI process_external filter is the second layer.
     environment: ai-approve
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write # resolve the "mergai / review-fix" commit status
     # Serialize per-PR branch-mutation runs so two near-simultaneous triggers
     # don't race on the head branch. The group key (mergai-pr-<number>) is
     # shared with rebase-handle so a `/mergai review fix` and a `/mergai rebase`
@@ -920,46 +1023,27 @@ jobs:
           permission-pull-requests: read
           permission-issues: read
 
-      # Resolve the PR number and head branch from whichever event fired, and
-      # confirm it is a mergai PR (head branch under mergai/). The issue_comment
-      # payload has no head ref, so we look it up; a non-mergai PR sets
-      # is_mergai=false and every later step is skipped (the job ends green).
-      - name: Resolve PR
-        id: pr
+      # Approval was granted (this job is past the ai-approve gate): flip the
+      # pending "mergai / review-fix" check from "waiting for approval" to
+      # "running".
+      - name: Mark review-fix running
         env:
-          GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.review-gate.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
-          # CUTOFF pins the run to the comment set as it stood when it was
-          # triggered: the review's submission time, or the comment's creation
-          # time. `mergai review fix --since` ignores anything posted (or
-          # edited) after it, so a comment added while this run waits for
-          # approval cannot be pulled into the set.
-          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            PR_NUMBER='${{ github.event.pull_request.number }}'
-            HEAD_REF='${{ github.event.pull_request.head.ref }}'
-            CUTOFF='${{ github.event.review.submitted_at }}'
-          else
-            PR_NUMBER='${{ github.event.issue.number }}'
-            HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName)
-            CUTOFF='${{ github.event.comment.created_at }}'
-          fi
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
-          echo "cutoff=$CUTOFF" >> "$GITHUB_OUTPUT"
-          echo "Resolved PR #$PR_NUMBER (head: $HEAD_REF, cutoff: $CUTOFF)"
-          case "$HEAD_REF" in
-            mergai/*) echo "is_mergai=true" >> "$GITHUB_OUTPUT" ;;
-            *)
-              echo "is_mergai=false" >> "$GITHUB_OUTPUT"
-              echo "PR #$PR_NUMBER is not a mergai PR; skipping." ;;
-          esac
+          gh api "repos/$GH_REPO/statuses/$HEAD_SHA" \
+            -f state="pending" \
+            -f context="mergai / review-fix" \
+            -f target_url="$RUN_URL" \
+            -f description="approved; running" \
+            || echo "::warning::could not update review-fix status"
 
       - name: Checkout PR branch
-        if: steps.pr.outputs.is_mergai == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.pr.outputs.head_ref }}
+          ref: ${{ needs.review-gate.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           # The AI agent runs in this checkout; do not leave the write token in
@@ -968,7 +1052,6 @@ jobs:
           persist-credentials: false
 
       - name: Setup workflow environment
-        if: steps.pr.outputs.is_mergai == 'true'
         uses: ./.github/actions/setup-mergai-workflow
         with:
           setup-gcp: "true"
@@ -987,7 +1070,6 @@ jobs:
           export-github-token: "false"
 
       - name: Fetch and load mergai notes
-        if: steps.pr.outputs.is_mergai == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
         run: |
@@ -1000,15 +1082,14 @@ jobs:
       # landed so the push step is conditional.
       - name: Generate review fixes
         id: review
-        if: steps.pr.outputs.is_mergai == 'true'
         env:
           # Read-only: the agent runs here. `mergai review fix` reads the PR's
           # review threads and commits the fix locally; --ack only *records* the
           # acknowledgement on the note (posted later by `mergai review post`).
           GH_TOKEN: ${{ steps.app-token-ro.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          CUTOFF: ${{ steps.pr.outputs.cutoff }}
+          PR_NUMBER: ${{ needs.review-gate.outputs.number }}
+          CUTOFF: ${{ needs.review-gate.outputs.cutoff }}
         run: |
           before=$(git rev-parse HEAD)
           # --ack records a short acknowledgement (how many comments were found /
@@ -1019,6 +1100,9 @@ jobs:
           if [ "$before" != "$after" ]; then
             echo "Review fix commit produced ($after)."
             echo "fix_produced=true" >> "$GITHUB_OUTPUT"
+            # The fix is pushed below, moving the PR head; expose the new tip so
+            # the status step resolves the check on the current PR head SHA.
+            echo "final_sha=$after" >> "$GITHUB_OUTPUT"
           else
             echo "No review fix commit produced."
             echo "fix_produced=false" >> "$GITHUB_OUTPUT"
@@ -1027,17 +1111,16 @@ jobs:
       # Push the inline fix to the PR branch before posting replies, so the
       # "Addressed in <sha>" reply points at a commit that exists on the PR.
       - name: Push review-fix commit
-        if: steps.pr.outputs.is_mergai == 'true' && steps.review.outputs.fix_produced == 'true'
+        if: steps.review.outputs.fix_produced == 'true'
         env:
           # Write token (scoped to this push): the setup credential helper reads
           # GH_TOKEN, and the job environment no longer carries a token.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          HEAD_REF: ${{ needs.review-gate.outputs.head_ref }}
         run: git push origin "HEAD:$HEAD_REF"
 
       # Publish the recorded replies (fixed / unfixable) to their threads.
       - name: Post review replies
-        if: steps.pr.outputs.is_mergai == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
@@ -1045,11 +1128,47 @@ jobs:
 
       # Persist the review_fix solution's git note (attached to the new commit).
       - name: Push mergai notes
-        if: steps.pr.outputs.is_mergai == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
         run: mergai notes push
+
+      # Resolve the pending "mergai / review-fix" check: green when the job
+      # finished cleanly (fixes pushed, or nothing to fix), red on error.
+      # Publishes on the SHA the gate posted the pending status to; when a fix was
+      # pushed the head moved, so also publish on the new tip so the PR reflects
+      # the outcome on its current head.
+      - name: Report review-fix status on the PR
+        if: always()
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GATE_SHA: ${{ needs.review-gate.outputs.head_sha }}
+          FINAL_SHA: ${{ steps.review.outputs.final_sha }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          case "$JOB_STATUS" in
+            success)   STATE=success; DESC="review feedback addressed" ;;
+            cancelled) STATE=error;   DESC="cancelled" ;;
+            *)         STATE=failure; DESC="review-fix failed" ;;
+          esac
+          gh api "repos/$GH_REPO/statuses/$GATE_SHA" \
+            -f state="$STATE" \
+            -f context="mergai / review-fix" \
+            -f target_url="$RUN_URL" \
+            -f description="$DESC" \
+            || echo "::warning::could not publish review-fix status"
+          if [ -n "$FINAL_SHA" ] && [ "$FINAL_SHA" != "$GATE_SHA" ]; then
+            gh api "repos/$GH_REPO/statuses/$FINAL_SHA" \
+              -f state="$STATE" \
+              -f context="mergai / review-fix" \
+              -f target_url="$RUN_URL" \
+              -f description="$DESC" \
+              || echo "::warning::could not publish review-fix status on new head"
+          fi
 
   # Gate + surface the `/mergai rebase` request on the PR. rebase-handle is gated
   # by the push-approve environment, but issue_comment runs are attributed to the

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -31,8 +31,10 @@ on:
     branches:
       - "mergai/**"
   # Comment entry points on a mergai PR:
-  #   * `/mergai review fix` -> review-handle, address review threads.
-  #   * `/mergai rebase`     -> rebase-handle, rebase the branch onto its base.
+  #   * `/mergai review fix`   -> review-handle, address review threads.
+  #   * `/mergai rebase`       -> rebase-handle, rebase the branch onto its base.
+  #   * `/mergai fast-forward` -> fast-forward-handle, rebase if needed then
+  #                               fast-forward the base branch onto the head.
   issue_comment:
     types: [created]
   # Review-handling entry point: a review submitted as "Changes requested".
@@ -1190,3 +1192,357 @@ jobs:
             "Rebased \`$HEAD_REF\` onto \`$BASE_REF\` and force-pushed the branch." \
             || echo "::warning::could not post rebase-success comment"
           echo "Rebase of $HEAD_REF onto $BASE_REF completed successfully"
+
+  # Gate + surface the `/mergai fast-forward` request on the PR. fast-forward-handle
+  # (below) is gated by the push-approve environment, but because this workflow is
+  # triggered by issue_comment its run is attributed to the *default branch*, so the
+  # environment approval gate would be invisible in the PR's checks section (unlike
+  # review-handle's pull_request_review path, where the run is tied to the PR head).
+  # This ungated gate job runs immediately and publishes a *pending* commit status on
+  # the PR head SHA, so the PR shows a "mergai / fast-forward" check waiting while a
+  # required reviewer approves the deployment -- the same idiom ci-gate/ci-handle use
+  # to make workflow_run jobs visible on a PR. It also does the cheap validation
+  # (open / same-repo / mergai / commenter permission) so an invalid or unauthorized
+  # request never creates an approval prompt: fast-forward-handle only runs when this
+  # gate sets proceed=true, and it resolves the pending check to success/failure.
+  fast-forward-gate:
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request != null
+      && contains(github.event.comment.body, '/mergai fast-forward')
+    runs-on: ubuntu-latest
+    # The status is published with the default GITHUB_TOKEN (see the status step)
+    # so it is attributed to github-actions[bot] -- matching the icon of the other
+    # mergai commit statuses (ci-gate/ci-handle). Restrict the token accordingly;
+    # all other calls in this job use the GitHub App token.
+    permissions:
+      statuses: write # publish the "mergai / fast-forward" commit status
+    outputs:
+      proceed: ${{ steps.pr.outputs.proceed }}
+      number: ${{ steps.pr.outputs.number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+
+      # Resolve the PR (the issue_comment payload carries none of its refs) and
+      # confirm it is an open, same-repo mergai PR whose commenter may merge. Any
+      # failing check leaves proceed unset (fast-forward-handle is skipped) with an
+      # explanatory comment, and no pending approval check is published.
+      - name: Resolve and validate PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          PR_NUMBER='${{ github.event.issue.number }}'
+          read -r HEAD_REF BASE_REF STATE CROSS_REPO HEAD_SHA < <(gh pr view "$PR_NUMBER" \
+            --json headRefName,baseRefName,state,isCrossRepository,headRefOid \
+            --jq '"\(.headRefName) \(.baseRefName) \(.state) \(.isCrossRepository) \(.headRefOid)"')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR_NUMBER (head: $HEAD_REF, base: $BASE_REF, state: $STATE, cross_repo: $CROSS_REPO, head_sha: $HEAD_SHA)"
+          # Only open PRs can be fast-forwarded.
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR #$PR_NUMBER is not open (state: $STATE); skipping."
+            gh pr comment "$PR_NUMBER" --body \
+              "\`/mergai fast-forward\` skipped: the pull request is not open (state: $STATE)."
+            exit 0
+          fi
+          # Fork PRs: the head branch does not exist in this repo, so we can
+          # neither rebase it nor push it back.
+          if [ "$CROSS_REPO" = "true" ]; then
+            echo "PR #$PR_NUMBER is a fork (cross-repository) PR; not supported."
+            gh pr comment "$PR_NUMBER" --body \
+              "\`/mergai fast-forward\` is not supported for pull requests from forks: the head branch must live in this repository."
+            exit 0
+          fi
+          # Only mergai branches carry the note context the rebase step needs.
+          case "$HEAD_REF" in
+            mergai/*) ;;
+            *)
+              echo "PR #$PR_NUMBER is not a mergai PR; skipping."
+              gh pr comment "$PR_NUMBER" --body \
+                "\`/mergai fast-forward\` only handles mergai PRs (it can rebase the mergai branch before fast-forwarding). For a regular branch, use \`/fast-forward\`."
+              exit 0 ;;
+          esac
+          # Defense-in-depth permission check (the push-approve environment on
+          # fast-forward-handle is the primary trust boundary). Only write/maintain/
+          # admin collaborators may advance the protected base ref, so an
+          # unauthorized comment never even creates an approval prompt.
+          LEVEL=$(gh api "repos/$GH_REPO/collaborators/$ACTOR/permission" --jq '.permission')
+          echo "Commenter $ACTOR permission: $LEVEL"
+          case "$LEVEL" in
+            admin|maintain|write) ;;
+            *)
+              echo "::error::User $ACTOR does not have permission to merge (permission: $LEVEL)"
+              gh pr comment "$PR_NUMBER" --body \
+                "\`/mergai fast-forward\` requires write access: @$ACTOR does not have permission to merge."
+              exit 0 ;;
+          esac
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      # Surface the request on the PR as a pending "mergai / fast-forward" check so
+      # its checks section shows the job waiting while approval is pending. Resolved
+      # by fast-forward-handle once it runs.
+      - name: Publish pending status (awaiting approval)
+        if: steps.pr.outputs.proceed == 'true'
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          gh api "repos/$GH_REPO/statuses/$HEAD_SHA" \
+            -f state="pending" \
+            -f context="mergai / fast-forward" \
+            -f target_url="$RUN_URL" \
+            -f description="waiting for required-reviewer approval" \
+            || echo "::warning::could not publish pending fast-forward status"
+
+  # Fast-forward a mergai PR's base branch to the PR head, rebasing first when
+  # the base has advanced. Runs only after fast-forward-gate validated the request
+  # (proceed=true) and published the pending PR check. The mergai-aware counterpart
+  # to the standalone `/fast-forward` (see fast-forward.yml): a plain fast-forward
+  # fails once the base branch moves past the point the mergai branch was cut from,
+  # because the head is no longer a descendant of the base. Rather than make a
+  # maintainer run `/mergai rebase` and then `/fast-forward` as two round-trips, this
+  # handler does both in one shot -- it rebases the mergai branch onto the current
+  # base tip (deterministically, reusing recorded conflict solutions, exactly like
+  # rebase-handle) and then fast-forwards the base onto the rebased head.
+  #
+  # Trust model mirrors the standalone fast-forward: advancing the protected base
+  # ref is gated by the 'push-approve' environment (a required reviewer approves the
+  # deployment) -- visible on the PR via the gate's pending check -- and the gate's
+  # permission check is the second layer. This job resolves the pending check to
+  # success/failure.
+  fast-forward-handle:
+    needs: fast-forward-gate
+    if: needs.fast-forward-gate.outputs.proceed == 'true'
+    environment: push-approve
+    runs-on: ubuntu-latest
+    # Commit statuses are published with the default GITHUB_TOKEN (github-actions[bot])
+    # to match the other mergai statuses' icon; all real work uses the App token.
+    permissions:
+      statuses: write # publish the "mergai / fast-forward" commit status
+    # Share the per-PR branch-mutation lock with rebase-handle / review-handle:
+    # this job rebases and force-pushes the head branch just like rebase-handle,
+    # so it must not run concurrently with a `/mergai rebase` or `/mergai review
+    # fix` on the same PR. (The standalone Fast-Forward Merge workflow stays out
+    # of this group -- it never mutates the head branch -- so a maintainer must
+    # still avoid running `/fast-forward` while a rebase is in flight.)
+    concurrency:
+      group: mergai-pr-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+
+      # Approval was granted (this job is past the push-approve gate): flip the
+      # pending "mergai / fast-forward" PR check from "waiting for approval" to
+      # "running" so the PR reflects that the work has started.
+      - name: Mark fast-forward running
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.fast-forward-gate.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          gh api "repos/$GH_REPO/statuses/$HEAD_SHA" \
+            -f state="pending" \
+            -f context="mergai / fast-forward" \
+            -f target_url="$RUN_URL" \
+            -f description="approved; running" \
+            || echo "::warning::could not update fast-forward status"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.fast-forward-gate.outputs.head_ref }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # No AI tokens needed: the rebase (when required) auto-resolves only from
+      # previously recorded solutions (deterministic), like rebase-handle.
+      - name: Setup workflow environment
+        uses: ./.github/actions/setup-mergai-workflow
+        with:
+          setup-gcp: "false"
+          setup-gemini: "false"
+          setup-claude: "false"
+          setup-mergai: "true"
+          github-app-token: ${{ steps.app-token.outputs.token }}
+          github-app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          mergai-ref: ${{ vars.MERGAI_REF || 'master' }}
+
+      # Fast-forward the base branch onto the PR head, rebasing first when the
+      # base has moved past the mergai branch.
+      #   1. fetch the current base and head tips;
+      #   2. load notes/context (needed for the rebase, and so the
+      #      `mergai pr comment` calls can resolve the PR from the note);
+      #   3. if origin/<base> is already an ancestor of origin/<head>, no rebase
+      #      is needed -- fast-forward straight away;
+      #   4. otherwise rebase the mergai branch onto origin/<base> (reusing
+      #      recorded solutions, preserving merge commits + notes), push the notes
+      #      and force-push the branch, then refresh the PR body;
+      #   5. fast-forward the base branch to the (possibly rebased) head tip with
+      #      --ff-only and push it.
+      - name: Fast-forward (rebase if needed)
+        id: ff
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.fast-forward-gate.outputs.number }}
+          HEAD_REF: ${{ needs.fast-forward-gate.outputs.head_ref }}
+          BASE_REF: ${{ needs.fast-forward-gate.outputs.base_ref }}
+        run: |
+          set -e
+          echo "Fast-forwarding $BASE_REF to $HEAD_REF (rebasing first if needed)"
+          git fetch origin "$BASE_REF"
+          git fetch origin "$HEAD_REF"
+
+          # Needed for the rebase below, and so the `mergai pr comment` calls in
+          # the success/failure steps can resolve the PR from the note context.
+          mergai notes update
+          mergai context init
+
+          if git merge-base --is-ancestor "origin/$BASE_REF" "origin/$HEAD_REF"; then
+            echo "Base ($BASE_REF) is already an ancestor of head ($HEAD_REF); no rebase needed."
+            FF_SHA=$(git rev-parse "origin/$HEAD_REF")
+          else
+            echo "Base ($BASE_REF) has advanced beyond head ($HEAD_REF); rebasing onto it first."
+            git checkout "$HEAD_REF"
+            if ! mergai rebase "origin/$BASE_REF"; then
+              mergai rebase --abort || true
+              # Record the reason so the failure step posts rebase-specific
+              # guidance (outputs written before a failing exit are still captured).
+              echo "reason=rebase" >> "$GITHUB_OUTPUT"
+              echo "::error::mergai rebase onto '$BASE_REF' could not complete automatically (unresolved conflicts)."
+              exit 1
+            fi
+            TYPE="${HEAD_REF##*/}"
+            mergai notes push --context
+            mergai branch push -f "$TYPE"
+            # The rebase advanced merge_info.target_branch_sha; refresh the PR body.
+            mergai pr --repo "$GITHUB_REPOSITORY" update \
+              || echo "::warning::'mergai pr update' failed"
+            FF_SHA=$(git rev-parse HEAD)
+            # Let the success comment report that a rebase was needed.
+            echo "rebased=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Fast-forward the base branch to the head tip by pushing the head SHA
+          # straight to the base ref. A non-force push is accepted by the remote
+          # only when it is a genuine fast-forward (origin/<base> is an ancestor
+          # of the head tip -- guaranteed above by the ancestor check or by the
+          # rebase), so this enforces --ff-only semantics AND avoids a local
+          # `git checkout <base>`: `mergai fork init` adds an `upstream` remote,
+          # so a bare `git checkout master` matches multiple remote-tracking
+          # branches (origin/master + upstream/master) and fails with exit 128.
+          git push origin "$FF_SHA:refs/heads/$BASE_REF"
+          # Expose the tip we fast-forwarded to so the status step can also
+          # resolve the check on the rebased head when the head SHA changed.
+          echo "final_sha=$FF_SHA" >> "$GITHUB_OUTPUT"
+          echo "Fast-forwarded $BASE_REF to $FF_SHA ($HEAD_REF)."
+
+      # Confirm the fast-forward on the PR. A successful fast-forward merges (and
+      # closes) the PR, so the comment targets it via `mergai pr comment
+      # --pr-number` (which resolves a PR regardless of state, unlike the default
+      # open-PR lookup) -- keeping mergai's run-link footer. The wording reflects
+      # whether a rebase was needed first.
+      - name: Post success comment
+        if: success()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.fast-forward-gate.outputs.number }}
+          BASE_REF: ${{ needs.fast-forward-gate.outputs.base_ref }}
+          HEAD_REF: ${{ needs.fast-forward-gate.outputs.head_ref }}
+          REBASED: ${{ steps.ff.outputs.rebased }}
+        run: |
+          if [ "$REBASED" = "true" ]; then
+            BODY="Fast-forwarded \`$HEAD_REF\` into \`$BASE_REF\` (rebased onto \`$BASE_REF\` first)."
+          else
+            BODY="Fast-forwarded \`$HEAD_REF\` into \`$BASE_REF\`."
+          fi
+          mergai pr --repo "$GITHUB_REPOSITORY" comment --pr-number "$PR_NUMBER" \
+            --allow-missing --body "$BODY" \
+            || echo "::warning::could not post fast-forward success comment"
+
+      # Explain the failure. A rebase-conflict failure (reason=rebase) gets
+      # actionable recovery instructions; any other failure (e.g. the base raced
+      # ahead so the --ff-only push was rejected) gets a generic pointer. A failed
+      # fast-forward leaves the PR open, but we still target it by --pr-number for
+      # consistency with the success path (both carry mergai's run-link footer).
+      - name: Post failure comment
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.fast-forward-gate.outputs.number }}
+          BASE_REF: ${{ needs.fast-forward-gate.outputs.base_ref }}
+          HEAD_REF: ${{ needs.fast-forward-gate.outputs.head_ref }}
+          REASON: ${{ steps.ff.outputs.reason }}
+        run: |
+          if [ "$REASON" = "rebase" ]; then
+            BODY="\`/mergai fast-forward\` could not rebase \`$HEAD_REF\` onto \`$BASE_REF\` automatically. Rebase locally with \`mergai notes update && mergai context init && mergai rebase origin/$BASE_REF\`, then push the branch and notes and re-run \`/mergai fast-forward\`."
+          else
+            BODY="\`/mergai fast-forward\` of \`$BASE_REF\` onto \`$HEAD_REF\` failed. See the workflow run for details."
+          fi
+          mergai pr --repo "$GITHUB_REPOSITORY" comment --pr-number "$PR_NUMBER" \
+            --allow-missing --body "$BODY" \
+            || echo "::warning::could not post fast-forward failure comment"
+
+      # Resolve the pending "mergai / fast-forward" check on the PR: green when the
+      # fast-forward succeeded, red otherwise. Publishes on the SHA the gate posted
+      # the pending status to; if a rebase moved the head, also publishes on the new
+      # tip so a still-open PR reflects the outcome on its current head.
+      - name: Report fast-forward status on the PR
+        if: always()
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GATE_SHA: ${{ needs.fast-forward-gate.outputs.head_sha }}
+          FINAL_SHA: ${{ steps.ff.outputs.final_sha }}
+          BASE_REF: ${{ needs.fast-forward-gate.outputs.base_ref }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          case "$JOB_STATUS" in
+            success)   STATE=success; DESC="fast-forwarded $BASE_REF" ;;
+            cancelled) STATE=error;   DESC="cancelled" ;;
+            *)         STATE=failure; DESC="fast-forward failed" ;;
+          esac
+          gh api "repos/$GH_REPO/statuses/$GATE_SHA" \
+            -f state="$STATE" \
+            -f context="mergai / fast-forward" \
+            -f target_url="$RUN_URL" \
+            -f description="$DESC" \
+            || echo "::warning::could not publish fast-forward status"
+          if [ -n "$FINAL_SHA" ] && [ "$FINAL_SHA" != "$GATE_SHA" ]; then
+            gh api "repos/$GH_REPO/statuses/$FINAL_SHA" \
+              -f state="$STATE" \
+              -f context="mergai / fast-forward" \
+              -f target_url="$RUN_URL" \
+              -f description="$DESC" \
+              || echo "::warning::could not publish fast-forward status on rebased head"
+          fi

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -1051,22 +1051,107 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: mergai notes push
 
+  # Gate + surface the `/mergai rebase` request on the PR. rebase-handle is gated
+  # by the push-approve environment, but issue_comment runs are attributed to the
+  # default branch, so the approval gate would be invisible in the PR's checks
+  # section. This ungated gate runs immediately and publishes a pending
+  # "mergai / rebase" commit status on the PR head SHA, so the checks section
+  # shows the job waiting for approval (the ci-gate/ci-handle idiom). It also
+  # validates the request (same-repo mergai PR); rebase-handle runs only when this
+  # gate sets proceed=true and resolves the pending check to success/failure.
+  rebase-gate:
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request != null
+      && contains(github.event.comment.body, '/mergai rebase')
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write # publish the "mergai / rebase" commit status
+    outputs:
+      proceed: ${{ steps.pr.outputs.proceed }}
+      number: ${{ steps.pr.outputs.number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
+          private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
+
+      # Resolve the PR (issue_comment carries no refs) and confirm it is a
+      # same-repo mergai PR. A fork PR (with an explanatory comment) or a
+      # non-mergai PR leaves proceed unset, so rebase-handle is skipped and no
+      # pending approval check is published.
+      - name: Resolve and validate PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER='${{ github.event.issue.number }}'
+          read -r HEAD_REF BASE_REF CROSS_REPO HEAD_SHA < <(gh pr view "$PR_NUMBER" \
+            --json headRefName,baseRefName,isCrossRepository,headRefOid \
+            --jq '"\(.headRefName) \(.baseRefName) \(.isCrossRepository) \(.headRefOid)"')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR_NUMBER (head: $HEAD_REF, base: $BASE_REF, cross_repo: $CROSS_REPO, head_sha: $HEAD_SHA)"
+          # Fork PRs: the head branch does not exist in this repo, so we can
+          # neither rebase it nor push it back.
+          if [ "$CROSS_REPO" = "true" ]; then
+            echo "PR #$PR_NUMBER is a fork (cross-repository) PR; /mergai rebase is not supported."
+            gh pr comment "$PR_NUMBER" --body \
+              "\`/mergai rebase\` is not supported for pull requests from forks: the head branch must live in this repository."
+            exit 0
+          fi
+          case "$HEAD_REF" in
+            mergai/*) ;;
+            *)
+              echo "PR #$PR_NUMBER is not a mergai PR; skipping."
+              exit 0 ;;
+          esac
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      # Surface the request as a pending "mergai / rebase" check so the PR shows
+      # the job waiting while approval is pending. Resolved by rebase-handle.
+      - name: Publish pending status (awaiting approval)
+        if: steps.pr.outputs.proceed == 'true'
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          gh api "repos/$GH_REPO/statuses/$HEAD_SHA" \
+            -f state="pending" \
+            -f context="mergai / rebase" \
+            -f target_url="$RUN_URL" \
+            -f description="waiting for required-reviewer approval" \
+            || echo "::warning::could not publish pending rebase status"
+
   # Rebase a mergai PR branch onto its base branch. Triggered by a
   # `/mergai rebase` comment on the PR. When the base branch (e.g. `master`)
   # advances after the PR opened, the head branch is no longer fast-forwardable
   # and `/fast-forward` fails; rebasing the mergai branch onto the current base
   # tip restores it. The rebase preserves merge commits and mergai notes and
   # reuses previously recorded conflict solutions, then force-pushes the branch.
-  # As with review-handle, who may actually run this is gated by the
-  # 'push-approve' environment (a required reviewer approves the deployment);
-  # the command filter and the mergai-branch check below scope *what* it acts on.
+  # Runs only after rebase-gate validated the request (proceed=true) and
+  # published the pending PR check; the push-approve environment then holds this
+  # job at "waiting for approval" until a required reviewer approves, and this
+  # job resolves the pending check to success/failure.
   rebase-handle:
-    if: >-
-      github.event_name == 'issue_comment'
-      && github.event.issue.pull_request != null
-      && contains(github.event.comment.body, '/mergai rebase')
+    needs: rebase-gate
+    if: needs.rebase-gate.outputs.proceed == 'true'
     environment: push-approve
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write # resolve the "mergai / rebase" commit status
     # Serialize per-PR branch-mutation runs. Uses the shared group key
     # (mergai-pr-<number>, see review-handle) so a `/mergai rebase` and a review
     # fix on the same PR can't run concurrently: both check out and push the
@@ -1086,47 +1171,26 @@ jobs:
           app-id: ${{ secrets.PSMDB_BOT_GH_APP_ID }}
           private-key: ${{ secrets.PSMDB_BOT_GH_APP_PRIVATE_KEY }}
 
-      # Resolve the PR number, head branch and base branch (the issue_comment
-      # payload carries none of them), and confirm this is a same-repo mergai
-      # PR. Anything else sets is_mergai=false and every later step is skipped
-      # (the job ends green).
-      - name: Resolve PR
-        id: pr
+      # Approval was granted (this job is past the push-approve gate): flip the
+      # pending "mergai / rebase" check from "waiting for approval" to "running".
+      - name: Mark rebase running
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.rebase-gate.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
-          PR_NUMBER='${{ github.event.issue.number }}'
-          read -r HEAD_REF BASE_REF CROSS_REPO < <(gh pr view "$PR_NUMBER" \
-            --json headRefName,baseRefName,isCrossRepository \
-            --jq '"\(.headRefName) \(.baseRefName) \(.isCrossRepository)"')
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
-          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
-          echo "Resolved PR #$PR_NUMBER (head: $HEAD_REF, base: $BASE_REF, cross_repo: $CROSS_REPO)"
-          # Fork PRs: the head branch does not exist in this repo, so the
-          # checkout below would fail and there is nothing we could push back.
-          # Bail out early with a clear comment rather than a cryptic checkout
-          # error. mergai's own branches are always same-repo.
-          if [ "$CROSS_REPO" = "true" ]; then
-            echo "is_mergai=false" >> "$GITHUB_OUTPUT"
-            echo "PR #$PR_NUMBER is a fork (cross-repository) PR; /mergai rebase is not supported."
-            gh pr comment "$PR_NUMBER" --body \
-              "\`/mergai rebase\` is not supported for pull requests from forks: the head branch must live in this repository."
-            exit 0
-          fi
-          case "$HEAD_REF" in
-            mergai/*) echo "is_mergai=true" >> "$GITHUB_OUTPUT" ;;
-            *)
-              echo "is_mergai=false" >> "$GITHUB_OUTPUT"
-              echo "PR #$PR_NUMBER is not a mergai PR; skipping." ;;
-          esac
+          gh api "repos/$GH_REPO/statuses/$HEAD_SHA" \
+            -f state="pending" \
+            -f context="mergai / rebase" \
+            -f target_url="$RUN_URL" \
+            -f description="approved; running" \
+            || echo "::warning::could not update rebase status"
 
       - name: Checkout PR branch
-        if: steps.pr.outputs.is_mergai == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.pr.outputs.head_ref }}
+          ref: ${{ needs.rebase-gate.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -1134,7 +1198,6 @@ jobs:
       # recorded solutions (deterministic), so this sets up the mergai CLI alone,
       # like solution-merged / semantic-merged.
       - name: Setup workflow environment
-        if: steps.pr.outputs.is_mergai == 'true'
         uses: ./.github/actions/setup-mergai-workflow
         with:
           setup-gcp: "false"
@@ -1155,13 +1218,12 @@ jobs:
       #      branch name: mergai/<target>-<sha>/<type>).
       - name: Rebase onto base branch
         id: rebase
-        if: steps.pr.outputs.is_mergai == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_NUMBER: ${{ needs.rebase-gate.outputs.number }}
+          HEAD_REF: ${{ needs.rebase-gate.outputs.head_ref }}
+          BASE_REF: ${{ needs.rebase-gate.outputs.base_ref }}
         run: |
           set -e
           echo "Rebasing $HEAD_REF onto $BASE_REF"
@@ -1182,6 +1244,9 @@ jobs:
           TYPE="${HEAD_REF##*/}"
           mergai notes push --context
           mergai branch push -f "$TYPE"
+          # The rebase rewrote the branch; expose the new tip so the status step
+          # can also resolve the check on the (now current) PR head SHA.
+          echo "final_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           # The rebase advanced merge_info.target_branch_sha, so refresh the PR
           # body (rebuilt from the current note data) to reflect the new base.
           mergai pr --repo "$GITHUB_REPOSITORY" update \
@@ -1192,6 +1257,43 @@ jobs:
             "Rebased \`$HEAD_REF\` onto \`$BASE_REF\` and force-pushed the branch." \
             || echo "::warning::could not post rebase-success comment"
           echo "Rebase of $HEAD_REF onto $BASE_REF completed successfully"
+
+      # Resolve the pending "mergai / rebase" check: green when the rebase pushed,
+      # red otherwise. Publishes on the SHA the gate posted the pending status to;
+      # the rebase force-pushes a new head, so also publish on the new tip so the
+      # PR reflects the outcome on its current head.
+      - name: Report rebase status on the PR
+        if: always()
+        env:
+          # Default token so the status is attributed to github-actions[bot],
+          # matching the icon of the other mergai commit statuses.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GATE_SHA: ${{ needs.rebase-gate.outputs.head_sha }}
+          FINAL_SHA: ${{ steps.rebase.outputs.final_sha }}
+          BASE_REF: ${{ needs.rebase-gate.outputs.base_ref }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          case "$JOB_STATUS" in
+            success)   STATE=success; DESC="rebased onto $BASE_REF" ;;
+            cancelled) STATE=error;   DESC="cancelled" ;;
+            *)         STATE=failure; DESC="rebase failed" ;;
+          esac
+          gh api "repos/$GH_REPO/statuses/$GATE_SHA" \
+            -f state="$STATE" \
+            -f context="mergai / rebase" \
+            -f target_url="$RUN_URL" \
+            -f description="$DESC" \
+            || echo "::warning::could not publish rebase status"
+          if [ -n "$FINAL_SHA" ] && [ "$FINAL_SHA" != "$GATE_SHA" ]; then
+            gh api "repos/$GH_REPO/statuses/$FINAL_SHA" \
+              -f state="$STATE" \
+              -f context="mergai / rebase" \
+              -f target_url="$RUN_URL" \
+              -f description="$DESC" \
+              || echo "::warning::could not publish rebase status on rebased head"
+          fi
 
   # Gate + surface the `/mergai fast-forward` request on the PR. fast-forward-handle
   # (below) is gated by the push-approve environment, but because this workflow is


### PR DESCRIPTION
## Summary

Adds a `/mergai fast-forward` PR command and makes the required-reviewer
approval visible as a PR check for every comment-triggered command.

## `/mergai fast-forward`

The mergai-aware counterpart to `/fast-forward`. When the base branch has moved
past the point the mergai branch was cut from, a plain fast-forward fails (the
head is no longer a descendant of the base). This command rebases the mergai
branch onto the current base tip first (deterministically, reusing recorded
conflict solutions) and then fast-forwards the base onto the rebased head — both
in one comment.

## Approval visible as a PR check

These commands run behind a deployment-environment approval, but because they
are triggered by `issue_comment` their runs are attributed to the default
branch, so the approval gate was invisible on the PR. Each command is now split
into an ungated **gate** job that publishes a pending commit status on the PR
head (so the checks section shows the job *waiting for approval*) and the gated
**handle** job that resolves it to success/failure:

| Command | Check |
| --- | --- |
| `/mergai fast-forward` | `mergai / fast-forward` |
| `/mergai rebase` | `mergai / rebase` |
| `/mergai review fix` | `mergai / review-fix` |
| `/fast-forward` | `Fast-Forward Merge` |

All statuses are published with the default `GITHUB_TOKEN` so the checks share a
consistent icon.

## Dependency

Depends on Percona-Lab/mergai#40 (`pr comment --pr-number`), which lets the
fast-forward success comment post to the PR after the fast-forward has merged
(and closed) it. Requires a mergai build that includes it (`MERGAI_REF`).