### PR TITLE
PSMDB-2212 Fix mongod abort on LDAP operation timeout

### DIFF
--- a/src/mongo/db/ldap/ldap_manager_impl.cpp
+++ b/src/mongo/db/ldap/ldap_manager_impl.cpp
@@ -702,10 +702,15 @@ Status LDAPManagerImpl::execQuery(const std::string& ldapurl,
     bool destroyOnReturn = false;
     int res = ldap_url_parse(ldapurl.c_str(), &ludp);
     // 'ldap' and 'destroyOnReturn' are captured by reference because their values
-    // can be changed as part of retry logic below
+    // can be changed as part of retry logic below. 'ldap' can end up null if the
+    // retry logic fails to borrow a replacement connection; in that case there is
+    // no connection left to return (the original was already destroyed by the
+    // retry logic, and borrow_or_create() destroys its own failed connection).
     ON_BLOCK_EXIT([&, ludp] {
         ldap_free_urldesc(ludp);
-        return_search_connection(ldap, destroyOnReturn);
+        if (ldap) {
+            return_search_connection(ldap, destroyOnReturn);
+        }
     });
     if (res != LDAP_SUCCESS) {
         return Status(ErrorCodes::LDAPLibraryError,


### PR DESCRIPTION
execQuery() registers a scope guard that returns its borrowed LDAP connection via a by-reference capture, so a successful retry can hand back the replacement connection instead of the original. If the retry itself fails to borrow a replacement, the local 'ldap' variable is left null and the function returns early. The guard then fires with ldap == nullptr and calls return_search_connection(nullptr, ...), which falls through to ldap_unbind_ext(nullptr, ...) since no pooled entry matches a null connection. libldap asserts ld != NULL on entry to ldap_unbind_ext(), so this aborts the process (SIGABRT).

Skip the cleanup call when the connection is null; both the original and the failed replacement connection have already been destroyed by that point; there is nothing left to return.