### PR TITLE
PSMDB-2113: stop mergai comment gates from looping on bot comments

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -48,8 +48,14 @@ jobs:
   # here and leaves proceed unset, so the merge job is skipped.
   fast-forward-check:
     name: Fast-Forward Merge (gate)
+    # Ignore comments authored by a bot / GitHub App. This gate posts rejection /
+    # result comments with the App token (which, unlike the default GITHUB_TOKEN,
+    # dispatches new workflow runs); guarding on the author type keeps a bot
+    # comment that happens to quote '/fast-forward' from re-triggering the gate
+    # in a loop (defense-in-depth, matching mergai.yml's comment gates).
     if: |
       github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
       contains(github.event.comment.body, '/fast-forward')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -881,6 +881,7 @@ jobs:
         && startsWith(github.event.pull_request.head.ref, 'mergai/'))
       || (github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
+        && github.event.comment.user.type != 'Bot'
         && contains(github.event.comment.body, '/mergai review fix'))
     runs-on: ubuntu-latest
     permissions:
@@ -1179,9 +1180,14 @@ jobs:
   # validates the request (same-repo mergai PR); rebase-handle runs only when this
   # gate sets proceed=true and resolves the pending check to success/failure.
   rebase-gate:
+    # Ignore bot / GitHub App comments: rebase-handle's "could not rebase ...
+    # re-run `/mergai rebase`" comment quotes the trigger and is posted with the
+    # App token (which dispatches workflows), so without this guard it would
+    # re-trigger the gate in the same infinite loop as fast-forward-gate.
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request != null
+      && github.event.comment.user.type != 'Bot'
       && contains(github.event.comment.body, '/mergai rebase')
     runs-on: ubuntu-latest
     permissions:
@@ -1427,9 +1433,17 @@ jobs:
   # request never creates an approval prompt: fast-forward-handle only runs when this
   # gate sets proceed=true, and it resolves the pending check to success/failure.
   fast-forward-gate:
+    # Ignore comments authored by a bot / GitHub App. The gate's own rejection
+    # ("requires write access") and fast-forward-handle's failure comment both
+    # quote the `/mergai fast-forward` trigger verbatim, and are posted with the
+    # App token -- which, unlike the default GITHUB_TOKEN, *does* dispatch new
+    # workflow runs. Without this guard each such comment re-triggers the gate,
+    # whose commenter is now the bot (no write access), so it posts the same
+    # rejection again -> an infinite loop (see PR #2095).
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request != null
+      && github.event.comment.user.type != 'Bot'
       && contains(github.event.comment.body, '/mergai fast-forward')
     runs-on: ubuntu-latest
     # The status is published with the default GITHUB_TOKEN (see the status step)


### PR DESCRIPTION
The comment-triggered gates fired on any comment containing their command phrase (`/mergai fast-forward`, `/mergai rebase`, `/mergai review fix`, `/fast-forward`). Their own rejection/status comments -- and the handlers' failure comments -- quote those phrases verbatim and are posted with the GitHub App token, which (unlike the default GITHUB_TOKEN) dispatches new workflow runs. So a bot comment re-triggered the gate, whose commenter was now the bot (no write access), which posted the same rejection again -- an infinite loop (see PR #2095).

Guard every comment gate with `github.event.comment.user.type != 'Bot'` so bot/App-authored comments no longer trigger them. Human commenters still get their rejection/result comments and cannot loop; no automation issues these commands as a bot. Applied to fast-forward-gate, rebase-gate and review-gate in mergai.yml and to fast-forward-check in fast-forward.yml.

Anything in this description will be included in the commit message. Replace or delete this text
before merging. Add links to testing in the comments of the PR.
