### PR TITLE
PSMDB-2211: rename mergai workflow from "mergai bot" to "mergai"

### DIFF
--- a/.github/MERGAI.md
+++ b/.github/MERGAI.md
@@ -14,7 +14,7 @@ by hand. Both workflows are tuned through GitHub Actions
 
 1. **Check available commits**: Visit the
    [Fork Status page](https://percona.github.io/percona-server-mongodb/)
-2. **Trigger merge**: Go to Actions → "mergai bot" → "Run workflow", or use CLI:
+2. **Trigger merge**: Go to Actions → "mergai" → "Run workflow", or use CLI:
 
    ```bash
    gh workflow run .github/workflows/mergai.yml -f merge-pick=<SHA>
@@ -29,7 +29,7 @@ by hand. Both workflows are tuned through GitHub Actions
 
 ## Workflows
 
-### `mergai.yml` ("mergai bot")
+### `mergai.yml` ("mergai")
 
 | Job               | Trigger                          | Purpose                                                                  |
 | ----------------- | -------------------------------- | ------------------------------------------------------------------------ |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -191,7 +191,7 @@ env:
 # Trust model: same-repo PRs (head repo == base repo) route to the ungated
 # `rbe` environment; forks/external PRs route to `rbe-approve` and pay the
 # approval cost. A branch can only exist in this repo if someone with write
-# access pushed it, so same-repo is the trust signal -- mergai bot PRs
+# access pushed it, so same-repo is the trust signal -- mergai PRs
 # (mergai/** on this repo) and maintainers' own branches skip the approval,
 # forks do not. author_association is intentionally NOT used (spoofable in some
 # contexts); same-repo is the reliable signal. Non-PR events

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -26,7 +26,7 @@
 #     and resolves that status to success/failure.
 #
 # Commit statuses are published with the default GITHUB_TOKEN (github-actions[bot])
-# so the "Fast-Forward Merge" check shares the same icon as the mergai bot checks.
+# so the "Fast-Forward Merge" check shares the same icon as the mergai checks.
 # The App token is used only where it is actually needed: reading the PR /
 # commenter permission, posting comments, and pushing to the protected base ref.
 # =============================================================================

--- a/.github/workflows/mergai.yml
+++ b/.github/workflows/mergai.yml
@@ -1,4 +1,4 @@
-name: mergai bot
+name: mergai
 
 on:
   # Manual entry point: start a new merge of an upstream commit.

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -1,7 +1,7 @@
 name: mergai periodic merge
 
 # Drive the merge-from-upstream loop: pick the next upstream commit to merge and,
-# unless a merge is already in progress, dispatch the `mergai bot` `trigger-merge`
+# unless a merge is already in progress, dispatch the `mergai` `trigger-merge`
 # job for it. This replaces a human watching the Fork Status page and dispatching
 # mergai.yml by hand.
 #


### PR DESCRIPTION
Actions job names were rendered as "mergai bot / <job>" while commit-status contexts hardcoded "mergai / ..." prefixes, producing two different prefixes in the PR Checks list for the same bot. Renaming the workflow to "mergai" makes all checks share a single consistent prefix.

Updated all "mergai bot" references in comments and documentation.

