### PR TITLE
PSMDB-2253 Fix FCBIS crash with KMIP/Vault encryption and no explicit…

### DIFF
--- a/jstests/replsets/fcbis_backup_cursor_storage_metadata.js
+++ b/jstests/replsets/fcbis_backup_cursor_storage_metadata.js
@@ -1,0 +1,48 @@
+/**
+ * Regression test for PSMDB-2253: the $backupCursor aggregation stage must include the
+ * top-level storage engine metadata file ('storage.bson') alongside the WiredTiger-managed
+ * files (and, when encryption is enabled, the encrypted keystore 'key.db') it already returns.
+ * 'storage.bson' is the only record of which KMIP/Vault master key identifier decrypts
+ * 'key.db'; without it, a consumer that clones a node's files onto an empty destination (e.g.
+ * File Copy Based Initial Sync) has no way to learn which key identifier to use, and can end up
+ * crashing instead of syncing.
+ *
+ * This does not require KMIP/Vault infrastructure: the fix is unconditional, so plain
+ * $backupCursor output is asserted directly against a single-node replica set. Because this
+ * test lives under jstests/replsets/, it also automatically runs under the keyfile-encrypted
+ * 'replica_sets_tde_cbc'/'replica_sets_tde_gcm' passthrough suites.
+ *
+ * @tags: [requires_wiredtiger, requires_persistence]
+ */
+(function() {
+'use strict';
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const backupCursor = primary.getDB('admin').aggregate([{$backupCursor: {}}]);
+
+// The first document returned by $backupCursor is always cursor metadata, not a file entry.
+assert(backupCursor.hasNext(), 'expected a metadata document from $backupCursor');
+backupCursor.next();
+
+let sawStorageBson = false;
+while (backupCursor.hasNext()) {
+    const doc = backupCursor.next();
+    assert(doc.hasOwnProperty('filename'), () => 'unexpected non-file document: ' + tojson(doc));
+    if (doc.filename.endsWith('storage.bson')) {
+        sawStorageBson = true;
+        assert.gt(doc.fileSize,
+                  0,
+                  () => 'storage.bson entry should report a non-zero size: ' + tojson(doc));
+    }
+}
+backupCursor.close();
+
+assert(sawStorageBson,
+       '$backupCursor did not include the storage engine metadata file (storage.bson)');
+
+rst.stopSet();
+})();

--- a/src/mongo/db/repl/initial_syncer_fcb.cpp
+++ b/src/mongo/db/repl/initial_syncer_fcb.cpp
@@ -1599,6 +1599,19 @@ Status InitialSyncerFCB::_switchStorageLocation(
                 "newLocation"_attr = newLocation,
                 "error"_attr = e);
     return e.toStatus();
+} catch (...) {
+    // Catches non-DBException failures, notably mongo::encryption::Error thrown while
+    // reinitializing the storage engine against just-downloaded data (e.g. a KMIP/Vault
+    // master-key mismatch). This function is invoked from noexcept callbacks; previously
+    // such an exception escaped every catch clause here and caused an uncontrolled
+    // std::terminate() instead of a clean initial sync failure. PSMDB-2253.
+    auto status = exceptionToStatus();
+    LOGV2_DEBUG(128499,
+                1,
+                "Failed to switch storage location",
+                "newLocation"_attr = newLocation,
+                "error"_attr = status);
+    return status;
 }
 
 void InitialSyncerFCB::_restoreStorageLocation(stdx::unique_lock<Latch>& lock,
@@ -2177,6 +2190,17 @@ void InitialSyncerFCB::_switchToDownloadedCallback(
         // _restoreStorageLocation will not be called in this case
         _inStorageChange = false;
         _inStorageChangeCondition.notify_all();
+        // Failing to switch storage to the downloaded data means the just-cloned files are
+        // unusable with this node's configuration (e.g. a KMIP/Vault master-key mismatch,
+        // PSMDB-2253). Denylist this sync source so a retry picks a different one instead of
+        // deterministically repeating the same failure against it.
+        status = _invalidSyncSource_inlock(
+            _syncSource,
+            kDenylistPersistent,
+            str::stream() << "Failed to switch storage location to downloaded initial sync "
+                             "data; sync source may have provided incompatible or "
+                             "improperly-encrypted data: "
+                          << status.toString());
         onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
         return;
     }
@@ -2246,8 +2270,10 @@ void InitialSyncerFCB::_switchToDownloadedCallback(
     }
 
     storageGuard.dismiss();
-} catch (const DBException&) {
-    // Report exception as an initial syncer failure.
+} catch (...) {
+    // Report exception as an initial syncer failure. Also catches non-DBException failures
+    // (notably mongo::encryption::Error) that could otherwise escape this noexcept callback
+    // and crash the process. PSMDB-2253.
     stdx::unique_lock<Latch> lock(_mutex);
     onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, exceptionToStatus());
 }
@@ -2308,8 +2334,10 @@ void InitialSyncerFCB::_executeRecovery(
     }
 
     storageGuard.dismiss();
-} catch (const DBException&) {
-    // Report exception as an initial syncer failure.
+} catch (...) {
+    // Report exception as an initial syncer failure. Also catches non-DBException failures
+    // (notably mongo::encryption::Error) that could otherwise escape this noexcept callback
+    // and crash the process. PSMDB-2253.
     stdx::unique_lock<Latch> lock(_mutex);
     onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, exceptionToStatus());
 }
@@ -2386,8 +2414,14 @@ void InitialSyncerFCB::_switchToDummyToDBPathCallback(
         onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, status);
         return;
     }
-} catch (const DBException&) {
-    // Report exception as an initial syncer failure.
+} catch (...) {
+    // Report exception as an initial syncer failure. Also catches non-DBException failures
+    // (notably mongo::encryption::Error) that could otherwise escape this noexcept callback
+    // and crash the process. PSMDB-2253.
+    //
+    // Only callbacks that call directly into storage-engine open/reinit (this one and the
+    // two preceding it) need this wide a catch; _finalizeAndCompleteCallback below runs
+    // after the engine is already up and only needs the narrower DBException handling.
     stdx::unique_lock<Latch> lock(_mutex);
     onCompletionGuard->setResultAndCancelRemainingWork_inlock(lock, exceptionToStatus());
 }

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.cpp
@@ -32,6 +32,8 @@ Copyright (C) 2021-present Percona and/or its affiliates. All rights reserved.
 
 #include "mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.h"
 
+#include <boost/filesystem.hpp>
+
 #include "mongo/db/concurrency/lock_manager_defs.h"
 #include "mongo/db/concurrency/replication_state_transition_lock_guard.h"
 #include "mongo/db/dbhelpers.h"
@@ -183,6 +185,33 @@ BackupCursorState WiredTigerBackupCursorHooks::openBackupCursor(
     if (encHooks->enabled()) {
         eseBackupBlocks =
             uassertStatusOK(encHooks->beginNonBlockingBackup(opCtx, checkpointTimestamp, options));
+    }
+
+    // The storage engine metadata file ('storage.bson') records which KMIP/Vault key
+    // identifier encrypts 'key.db'. It is a plain file that no WiredTiger backup cursor
+    // (neither the main data cursor above nor key.db's own cursor inside
+    // EncryptionHooks::beginNonBlockingBackup) has any knowledge of, so it must be added
+    // explicitly here. Without it, a consumer of $backupCursor that clones a node's files
+    // onto an empty destination (e.g. File Copy Based Initial Sync) has no way to learn
+    // which key identifier decrypts the cloned key.db. Included unconditionally (not gated
+    // on encHooks->enabled()) so the local pre-clean file list and the remote fetch list
+    // built from this same function stay symmetric regardless of either side's encryption
+    // state. Mirrors WiredTigerKVEngine::_hotBackupPopulateLists()'s handling of the same
+    // file for the unrelated 'createBackup' hot-backup command. PSMDB-2253.
+    {
+        boost::filesystem::path storageMetadataPath =
+            boost::filesystem::path(storageGlobalParams.dbpath) / "storage.bson";
+        boost::system::error_code ec;
+        auto fsize = boost::filesystem::file_size(storageMetadataPath, ec);
+        if (!ec) {
+            eseBackupBlocks.emplace_back(
+                opCtx, boost::none, boost::none, storageMetadataPath.string(), 0, fsize, fsize);
+        } else {
+            LOGV2_WARNING(29104,
+                          "Storage engine metadata file is missing; backup cursor will not "
+                          "include it",
+                          "path"_attr = storageMetadataPath.string());
+        }
     }
 
     BSONObjBuilder builder;


### PR DESCRIPTION
… key identifier

File Copy Based Initial Sync (FCBIS) clones a node's data via the $backupCursor aggregation stage, which already knew to transfer WiredTiger's data files and the encrypted keystore key.db, but never transferred storage.bson - the plain metadata file that records which KMIP/Vault key identifier decrypts key.db. A node starting with an empty dbpath and no --kmipKeyIdentifier auto-generates its own master key; if it then FCBIS's from a source encrypted with a different key, it ends up with a cloned key.db and no way to learn which identifier unlocks it, and crashes.

Root cause fix: WiredTigerBackupCursorHooks::openBackupCursor() now includes storage.bson in the backup cursor's file list unconditionally, mirroring how the existing hot-backup path already handles this file. No client-side changes are needed since FCBIS already transfers arbitrary files generically.

Defensive hardening: mongo::encryption::Error does not derive from DBException, so it previously escaped the DBException-only catch clauses in FCBIS's noexcept storage-switch callbacks and crashed the process via std::terminate() instead of failing the sync attempt cleanly. Widen those catches, and denylist the sync source when switching to the downloaded data fails so a retry can pick a different source instead of looping against the same one.

Adds a regression test asserting $backupCursor includes storage.bson.